### PR TITLE
redirect about.sourcegraph.com to sourcegraph.com

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -8,3 +8,5 @@
 /docs/datacenter/prometheus-metrics	https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/prom-metrics.md	301
 /docs/datacenter/scaling	https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/scale.md	301
 /docs/datacenter/update	https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/update.md	301
+
+/   https://sourcegraph.com	301


### PR DESCRIPTION
Once the new website has been tested, redirect about.sourcegraph.com to sourcegraph.com