### PR TITLE
Change remaining title case to sentence case, update docs links

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -82,7 +82,7 @@ export default class Header extends React.Component<HeaderProps, any> {
                             <a href="https://docs.sourcegraph.com/integration/browser_extension">
                                 <button className="btn btn-secondary" type="button">
                                     <OpenInAppIcon className="material-icons" />
-                                    Install Browser Extension
+                                    Install browser extension
                                 </button>
                             </a>
                         )}

--- a/website/src/pages/about.tsx
+++ b/website/src/pages/about.tsx
@@ -51,7 +51,7 @@ export default class About extends React.Component<any, any> {
                                 <div className="row">
                                     <div className="col-md-12">
                                         <h1 className="mb-0">
-                                            Master Plan
+                                            Master plan
                                             <br />
                                         </h1>
                                         <hr />
@@ -310,7 +310,7 @@ export default class About extends React.Component<any, any> {
                         <div className="about__founders">
                             <div className="container">
                                 <h1>
-                                    Advisors and Supporters
+                                    Advisors and supporters
                                     <br />
                                 </h1>
                                 <div className="about__founders-advisors">

--- a/website/src/pages/contact/sales.tsx
+++ b/website/src/pages/contact/sales.tsx
@@ -27,7 +27,7 @@ export default class Trial extends React.Component<any, any> {
                 <section className="d-flex flex-column flex-lg-row sales">
                     <div className="form-area">
                         <div>
-                            <h1>Contact Our Team</h1>
+                            <h1>Contact our team</h1>
                             <p>
                                 Let us know which <Link to="/pricing">paid product</Link> you're interested in and for
                                 how many users. Our team is happy to answer any questions. Fill out the form and we’ll
@@ -40,7 +40,7 @@ export default class Trial extends React.Component<any, any> {
                     </div>
                     <div className="panel-area ml-lg-5">
                         <div className="d-flex flex-column panel">
-                            <h3>Your Team will Love Sourcegraph</h3>
+                            <h3>Your team will love Sourcegraph</h3>
                             <ul className="list pl0">
                                 <li className="mb-2">
                                     <div className="d-flex">Code search and intelligence for all your repositories</div>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -15,7 +15,7 @@ export default class Index extends React.Component<any, any> {
                         <div className="container v-prop__container mt-4">
                             <div className="row d-flex justify-content-center">
                                 <div className="col-md-5">
-                                    <h1>Build Better Software</h1>
+                                    <h1>Build better software</h1>
                                     <p>
                                         Sourcegraph is a fast, solid, full-featured code navigation engine. Get
                                         cross-repository code intelligence, including:
@@ -27,7 +27,7 @@ export default class Index extends React.Component<any, any> {
                                         >
                                             <div className="d-flex align-items-center pb-2">
                                                 <MagnifyIcon className="material-icons" size={24} />
-                                                <span className="pl-1">Advanced Code Search</span>
+                                                <span className="pl-1">Advanced code search</span>
                                             </div>
                                         </a>
                                         <a
@@ -36,7 +36,7 @@ export default class Index extends React.Component<any, any> {
                                         >
                                             <div className="d-flex align-items-center pb-2">
                                                 <ChatIcon className="material-icons" size={24} />
-                                                <span className="pl-1">Hover Tooltips</span>
+                                                <span className="pl-1">Hover tooltips</span>
                                             </div>
                                         </a>
                                         <a
@@ -45,7 +45,7 @@ export default class Index extends React.Component<any, any> {
                                         >
                                             <div className="d-flex align-items-center pb-2">
                                                 <ReplyIcon className="material-icons" size={24} />
-                                                <span className="pl-1">Jump-To-Definition</span>
+                                                <span className="pl-1">Jump-to-definition</span>
                                             </div>
                                         </a>
                                         <a
@@ -54,7 +54,7 @@ export default class Index extends React.Component<any, any> {
                                         >
                                             <div className="d-flex align-items-center pb-2">
                                                 <MagnifyIcon className="material-icons" size={24} />
-                                                <span className="pl-1">Find References</span>
+                                                <span className="pl-1">Find references</span>
                                             </div>
                                         </a>
                                     </div>
@@ -75,7 +75,7 @@ export default class Index extends React.Component<any, any> {
                                             <div className="col-md-6 home__deploy-card">
                                                 <div className="d-flex">
                                                     <WebIcon className="material-icons" size={32} />
-                                                    <h2 className="ml-2">For Yourself</h2>
+                                                    <h2 className="ml-2">For yourself</h2>
                                                 </div>
                                                 <p>
                                                     Hover tooltips, go-to-definition, and find-references on GitHub,
@@ -105,7 +105,7 @@ export default class Index extends React.Component<any, any> {
                                             <div className="col-md-6 home__deploy-card">
                                                 <div className="d-flex align-items-center">
                                                     <ServerIcon className="material-icons" size={32} />
-                                                    <h2 className="ml-2">For Your Team</h2>
+                                                    <h2 className="ml-2">For your team</h2>
                                                 </div>
                                                 <p>
                                                     Advanced search and intelligence on a private instance for all your
@@ -143,7 +143,7 @@ export default class Index extends React.Component<any, any> {
                                             <figure className="search-icon" />
                                         </div>
                                         <div className="copy">
-                                            <h2>Powerful, Instant Code Search</h2>
+                                            <h2>Powerful, instant code search</h2>
                                             <p>
                                                 Search in files and diffs in your code using simple terms, regular
                                                 expressions, and other filters. Syncs repositories with your code host
@@ -156,11 +156,11 @@ export default class Index extends React.Component<any, any> {
                                             <figure className="dc-icon" />
                                         </div>
                                         <div className="copy">
-                                            <h2>Data Center</h2>
+                                            <h2>Enterprise</h2>
                                             <p>
                                                 As you grow to hundreds or thousands of users and repositories, graduate
                                                 from the single-server deployment to a highly scalable cluster with
-                                                Sourcegraph Data Center.
+                                                Sourcegraph Enterprise.
                                             </p>
                                         </div>
                                     </div>
@@ -171,7 +171,7 @@ export default class Index extends React.Component<any, any> {
                                             <figure className="ci-icon" />
                                         </div>
                                         <div className="copy">
-                                            <h2>Code Intelligence</h2>
+                                            <h2>Code intelligence</h2>
                                             <p>
                                                 Code intelligence makes browsing code easier, with IDE-like hovers,
                                                 go-to-definition, and find-references on your code, powered by language

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -33,7 +33,7 @@ export default class Pricing extends React.Component<any, any> {
                                 <div className="container">
                                     <div className="row">
                                         <div className="col-lg-12 col-md-12 col-sm-12 col-xs-12">
-                                            <h2>Sourcegraph Pricing</h2>
+                                            <h2>Sourcegraph pricing</h2>
                                             <h1>Open. For business.</h1>
                                             <p>
                                                 Sourcegraph is open source and ready to use for teams of all sizes. You
@@ -143,7 +143,7 @@ export default class Pricing extends React.Component<any, any> {
                                                             href="/contact/sales"
                                                             onClick={this.trackContactUsClickedButton}
                                                         >
-                                                            Contact Us
+                                                            Contact us
                                                         </a>
                                                     </div>
                                                 </div>
@@ -193,7 +193,7 @@ export default class Pricing extends React.Component<any, any> {
                                                             href="/contact/sales"
                                                             onClick={this.trackContactUsClickedButton}
                                                         >
-                                                            Contact Us
+                                                            Contact us
                                                         </a>
                                                     </div>
                                                 </div>
@@ -205,7 +205,7 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="col-xl-12 lg-12 pricing-true-up-notice">
                                         If you exceed your licensed users over the term of your subscription,
                                         Sourcegraph will true up your license at your next renewal. Learn more about{' '}
-                                        <a href="/docs/pricing">Sourcegraph's true-up pricing model</a>.
+                                        <a href="https://docs.sourcegraph.com/admin/subscriptions">Sourcegraph's true-up pricing model</a>.
                                     </div>
                                 </div>
                             </div>
@@ -329,7 +329,7 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
                                             Code intelligence for all languages (
-                                            <a href="/docs/code-intelligence" target="_blank">
+                                            <a href="https://docs.sourcegraph.com/extensions/language_servers" target="_blank">
                                                 learn more
                                             </a>
                                             )
@@ -440,7 +440,7 @@ export default class Pricing extends React.Component<any, any> {
                                 <div id="integrations" className="table-section">
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
-                                            <a href="/docs/integrations" target="_blank">
+                                            <a href="https://docs.sourcegraph.com/integration" target="_blank">
                                                 Browser, code host, and editor integrations
                                             </a>
                                         </div>
@@ -458,7 +458,7 @@ export default class Pricing extends React.Component<any, any> {
                                         <div className="col-6 feature-title">
                                             Instantly deploy company-wide via G Suite (
                                             <a
-                                                href="/docs/features/browser-extension/g-suite-installation"
+                                                href="https://docs.sourcegraph.com/integration/google_gsuite"
                                                 target="_blank"
                                             >
                                                 learn more
@@ -567,7 +567,7 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
                                             Single sign-on integration (
-                                            <a href="/docs/config/authentication" target="_blank">
+                                            <a href="https://docs.sourcegraph.com/admin/auth" target="_blank">
                                                 learn more
                                             </a>
                                             )
@@ -613,7 +613,7 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
                                             External database (
-                                            <a href="/docs/config/external-database" target="_blank">
+                                            <a href="https://docs.sourcegraph.com/admin/external_database" target="_blank">
                                                 learn more
                                             </a>
                                             )
@@ -643,7 +643,7 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
                                             Webhooks for repository updates (
-                                            <a href="/docs/config/update-repo-webhook" target="_blank">
+                                            <a href="https://docs.sourcegraph.com/user/repo/webhooks" target="_blank">
                                                 learn more
                                             </a>
                                             )
@@ -661,7 +661,7 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
                                             Logging and monitoring for your Sourcegraph instance (
-                                            <a href="/docs/config/monitoring-and-tracing" target="_blank">
+                                            <a href="https://docs.sourcegraph.com/admin/monitorg-and-tracing" target="_blank">
                                                 learn more
                                             </a>
                                             )
@@ -755,7 +755,7 @@ export default class Pricing extends React.Component<any, any> {
                                             href="/contact/sales"
                                             onClick={this.trackContactUsClickedButton}
                                         >
-                                            Contact Us
+                                            Contact us
                                         </a>
                                     </div>
                                 </div>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -205,7 +205,10 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="col-xl-12 lg-12 pricing-true-up-notice">
                                         If you exceed your licensed users over the term of your subscription,
                                         Sourcegraph will true up your license at your next renewal. Learn more about{' '}
-                                        <a href="https://docs.sourcegraph.com/admin/subscriptions">Sourcegraph's true-up pricing model</a>.
+                                        <a href="https://docs.sourcegraph.com/admin/subscriptions">
+                                            Sourcegraph's true-up pricing model
+                                        </a>
+                                        .
                                     </div>
                                 </div>
                             </div>
@@ -329,7 +332,10 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
                                             Code intelligence for all languages (
-                                            <a href="https://docs.sourcegraph.com/extensions/language_servers" target="_blank">
+                                            <a
+                                                href="https://docs.sourcegraph.com/extensions/language_servers"
+                                                target="_blank"
+                                            >
                                                 learn more
                                             </a>
                                             )
@@ -613,7 +619,10 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
                                             External database (
-                                            <a href="https://docs.sourcegraph.com/admin/external_database" target="_blank">
+                                            <a
+                                                href="https://docs.sourcegraph.com/admin/external_database"
+                                                target="_blank"
+                                            >
                                                 learn more
                                             </a>
                                             )
@@ -661,7 +670,10 @@ export default class Pricing extends React.Component<any, any> {
                                     <div className="row feature-table-row">
                                         <div className="col-6 feature-title">
                                             Logging and monitoring for your Sourcegraph instance (
-                                            <a href="https://docs.sourcegraph.com/admin/monitorg-and-tracing" target="_blank">
+                                            <a
+                                                href="https://docs.sourcegraph.com/admin/monitorg-and-tracing"
+                                                target="_blank"
+                                            >
                                                 learn more
                                             </a>
                                             )

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -52,7 +52,7 @@
 /docs/config/custom-domain                                                                https://docs.sourcegraph.com/admin/url                                                            301
 /docs/config/tlsssl                                                                       https://docs.sourcegraph.com/admin/tls_ssl                                                        301
 /docs/server/update                                                                       https://docs.sourcegraph.com/admin/updates                                                        301
-/docs/config/monitoring-and-tracing                                                       https://docs.sourcegraph.com/admin/monitorg-and-tracing                                           301
+/docs/config/monitoring-and-tracing                                                       https://docs.sourcegraph.com/admin/monitoring-and-tracing                                           301
 /docs/config/organizations                                                                https://docs.sourcegraph.com/user/organizations                                                   301
 /docs/config/federation                                                                   https://docs.sourcegraph.com/admin/federation                                                     301
 /docs/extensions                                                                          https://docs.sourcegraph.com/extensions                                                           301


### PR DESCRIPTION
* Changes any title case to sentence case
* Updates any /docs links to point to corresponding docs.sourcegraph.com link

Fixes https://github.com/sourcegraph/about/issues/21 
Fixes https://github.com/sourcegraph/about/issues/20