### PR TITLE
link to friendlier new-subscription page instead of "Contact us"

### DIFF
--- a/website/src/EventLogger.tsx
+++ b/website/src/EventLogger.tsx
@@ -169,6 +169,12 @@ class EventLogger {
     public trackContactUsFormSubmitted(): void {
         this.trackEvent('Pages', 'Submit', null, 'ContactUsFormSubmitted', {})
     }
+    public trackBuyEnterpriseStarterButtonClicked(): void {
+        this.trackEvent('Pages', 'Click', null, 'BuyEnterpriseStarterButtonClicked', {})
+    }
+    public trackBuyEnterpriseButtonClicked(): void {
+        this.trackEvent('Pages', 'Click', null, 'BuyEnterpriseButtonClicked', {})
+    }
 
     public trackEvent(category: string, action: string, feature: any, label: string, eventProps: object): void {
         if (!(window as any).telligent) {

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -140,10 +140,10 @@ export default class Pricing extends React.Component<any, any> {
                                                         <a
                                                             className="btn btn-pricing btn-lg justify-content-center text-center"
                                                             role="button"
-                                                            href="/contact/sales"
-                                                            onClick={this.trackContactUsClickedButton}
+                                                            href="https://sourcegraph.com/user/subscriptions/new"
+                                                            onClick={this.trackBuyClickedButton}
                                                         >
-                                                            Contact us
+                                                            Buy
                                                         </a>
                                                     </div>
                                                 </div>
@@ -190,10 +190,10 @@ export default class Pricing extends React.Component<any, any> {
                                                         <a
                                                             className="btn btn-pricing btn-lg justify-content-center text-center"
                                                             role="button"
-                                                            href="/contact/sales"
-                                                            onClick={this.trackContactUsClickedButton}
+                                                            href="https://sourcegraph.com/user/subscriptions/new"
+                                                            onClick={this.trackBuyClickedButton}
                                                         >
-                                                            Contact us
+                                                            Buy
                                                         </a>
                                                     </div>
                                                 </div>
@@ -781,6 +781,9 @@ export default class Pricing extends React.Component<any, any> {
 
     private trackInstallSourcegraphServerClicked = () => {
         eventLogger.trackContactUsCTAClicked('ContactUs')
+    }
+    private trackBuyClickedButton = () => {
+        eventLogger.trackContactUsCTAClicked('BuyButton')
     }
     private trackContactUsClickedButton = () => {
         eventLogger.trackContactUsCTAClicked('ContactUsButton')

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -141,7 +141,7 @@ export default class Pricing extends React.Component<any, any> {
                                                             className="btn btn-pricing btn-lg justify-content-center text-center"
                                                             role="button"
                                                             href="https://sourcegraph.com/user/subscriptions/new"
-                                                            onClick={this.trackBuyClickedButton}
+                                                            onClick={this.trackBuyEnterpriseStarterButtonClicked}
                                                         >
                                                             Buy
                                                         </a>
@@ -191,7 +191,7 @@ export default class Pricing extends React.Component<any, any> {
                                                             className="btn btn-pricing btn-lg justify-content-center text-center"
                                                             role="button"
                                                             href="https://sourcegraph.com/user/subscriptions/new"
-                                                            onClick={this.trackBuyClickedButton}
+                                                            onClick={this.trackBuyEnterpriseButtonClicked}
                                                         >
                                                             Buy
                                                         </a>
@@ -765,7 +765,7 @@ export default class Pricing extends React.Component<any, any> {
                                             className="btn btn-secondary"
                                             role="button"
                                             href="/contact/sales"
-                                            onClick={this.trackContactUsClickedButton}
+                                            onClick={this.trackContactUsButtonClicked}
                                         >
                                             Contact us
                                         </a>
@@ -780,12 +780,15 @@ export default class Pricing extends React.Component<any, any> {
     }
 
     private trackInstallSourcegraphServerClicked = () => {
-        eventLogger.trackContactUsCTAClicked('ContactUs')
+        eventLogger.trackContactUsCTAClicked('PricingPage')
     }
-    private trackBuyClickedButton = () => {
-        eventLogger.trackContactUsCTAClicked('BuyButton')
+    private trackBuyEnterpriseStarterButtonClicked = () => {
+        eventLogger.trackBuyEnterpriseStarterButtonClicked()
     }
-    private trackContactUsClickedButton = () => {
-        eventLogger.trackContactUsCTAClicked('ContactUsButton')
+    private trackBuyEnterpriseButtonClicked = () => {
+        eventLogger.trackBuyEnterpriseButtonClicked()
+    }
+    private trackContactUsButtonClicked = () => {
+        eventLogger.trackContactUsCTAClicked('PricingPage')
     }
 }


### PR DESCRIPTION
After https://github.com/sourcegraph/enterprise/pull/13708 is merged, the new-subscription page on Sourcegraph.com will be friendlier: you can price out a subscription even if you're not signed in. Previously it would dump you on a sign-in page, so we didn't feel comfortable linking directly to it from this pricing page.

![screenshot from 2018-10-24 01-54-57](https://user-images.githubusercontent.com/1976/47418856-d7dfc000-d72f-11e8-80d2-e4d9d511cc74.png)
