### PR TITLE
Update pricing page with $10 starting price callout

### DIFF
--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -71,6 +71,7 @@ export default class Pricing extends React.Component<any, any> {
                                                     <div className="col-12 user-pricing">
                                                         <h2>Free</h2>
                                                         <h3>&nbsp;</h3>
+                                                        <h4>Made for developers, priced for everyone</h4>
                                                     </div>
                                                 </div>
                                                 <div className="row">
@@ -119,6 +120,9 @@ export default class Pricing extends React.Component<any, any> {
                                                     <div className="col-12 user-pricing">
                                                         <h2>$4</h2>
                                                         <h3>/user /month</h3>
+                                                        <h4>
+                                                            Starts at $10 one-time for the first <nobr>10 users</nobr>
+                                                        </h4>
                                                     </div>
                                                 </div>
                                                 <div className="row">
@@ -160,6 +164,7 @@ export default class Pricing extends React.Component<any, any> {
                                                     <div className="col-12 user-pricing">
                                                         <h2>$19</h2>
                                                         <h3>/user /month</h3>
+                                                        <h4>Empowering developers company wide</h4>
                                                     </div>
                                                 </div>
                                                 <div className="row">


### PR DESCRIPTION
This adds a callout to the pricing cards. Specifically, it adds a callout that Enterprise Starter is a $10 license for the first 10 users.

<img width="1275" alt="screen shot 2018-11-07 at 10 32 26 am" src="https://user-images.githubusercontent.com/11583013/48152805-ad3a4f00-e279-11e8-970a-631c9f2a833e.png">

