### PR TITLE
fix: update enterprise cta to free trial

### DIFF
--- a/website/src/css/pages/_sales.scss
+++ b/website/src/css/pages/_sales.scss
@@ -79,9 +79,9 @@
     }
 
     .panel-area {
-        max-width: 32rem;
         @media (min-width: $media-lg) {
             margin: 3rem 0 3rem 0;
+            max-width: 32rem;
         }
     }
 

--- a/website/src/pages/contact/sales.tsx
+++ b/website/src/pages/contact/sales.tsx
@@ -35,7 +35,7 @@ export default class Trial extends React.Component<any, any> {
                         </div>
                     </div>
                     <section className="d-flex justify-content-around flex-column flex-lg-row sales">
-                        <div className="panel-area mr-lg-5 mt-0">
+                        <div className="panel-area mr-lg-5 mt-0 mb-2">
                             <div className="d-flex flex-column panel">
                                 <h3>Your team will love Sourcegraph Enterprise</h3>
                                 <p>The best way to search and browse all of your organization's code, with:</p>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -1,3 +1,4 @@
+import { Link } from 'gatsby'
 import * as React from 'react'
 import Helmet from 'react-helmet'
 import Layout from '../components/Layout'
@@ -121,7 +122,8 @@ export default class Pricing extends React.Component<any, any> {
                                                         <h2>$4</h2>
                                                         <h3>/user /month</h3>
                                                         <h4>
-                                                            Starts at $10 one-time for the first <nobr>10 users</nobr>
+                                                            Starts at $10 one-time for the first{' '}
+                                                            <span className="text-nowrap">10 users</span>
                                                         </h4>
                                                     </div>
                                                 </div>
@@ -192,14 +194,14 @@ export default class Pricing extends React.Component<any, any> {
                                                         </a>
                                                     </div>
                                                     <div className="col-12 contact">
-                                                        <a
+                                                        <Link
                                                             className="btn btn-pricing btn-lg justify-content-center text-center"
                                                             role="button"
-                                                            href="https://sourcegraph.com/user/subscriptions/new"
+                                                            to="/contact/sales/"
                                                             onClick={this.trackBuyEnterpriseButtonClicked}
                                                         >
-                                                            Buy
-                                                        </a>
+                                                            Free trial
+                                                        </Link>
                                                     </div>
                                                 </div>
                                             </div>


### PR DESCRIPTION
Updates the Enterprise plan CTA to go to the free trial form.

<img width="1792" alt="screenshot 2018-11-15 07 33 50" src="https://user-images.githubusercontent.com/4897310/48563268-cd38c680-e8a8-11e8-9d49-8613364c1b18.png">
