### PR TITLE
fix format of redirects file

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,79 +1,66 @@
-/																						  https://sourcegraph.com/start																		301
+/ https://sourcegraph.com/start 301
 /changelog https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md 301
-
-/blog/sourecgraph-liveblogging-at-gophercon-2018                                          /blog/sourcegraph-liveblogging-at-gophercon-2018                                                  301
-/go/sourcegraph-liveblogging-at-gophercon-2018-go                                         /blog/sourcegraph-liveblogging-at-gophercon-2018                                                  301
-/go/go-in-debian                                                                          /go/gophercon-2018-go-in-debian/                                                                  301
-/go/grpc-in-production 	                                                                  /go/grpc-in-production-alan-shreve/				                                                301
-/docs/datacenter	                                                                      https://github.com/sourcegraph/deploy-sourcegraph	                                                301
-/docs/datacenter/admin-guide	                                                          https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/admin-guide.md	                301
-/docs/datacenter/prometheus-metrics	                                                      https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/prom-metrics.md	            301
-/docs/datacenter/scaling	                                                              https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/scale.md	                    301
-/docs/datacenter/update	                                                                  https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/update.md	                    301
-/docs/server/datacenter                                                                   https://github.com/sourcegraph/deploy-sourcegraph                                                 301
-
-
-/docs                                                                                     https://docs.sourcegraph.com/                                                                     301
-/docs/overview                                                                            https://docs.sourcegraph.com/user                                                                 301
-/docs/tour                                                                                https://docs.sourcegraph.com/tour                                                                 301
-
-/docs/code-intelligence                                                                   https://docs.sourcegraph.com/extensions/language_servers                                          301
-/docs/code-intelligence/install                                                           https://docs.sourcegraph.com/extensions/language_servers/install                                  301
-/docs/code-intelligence/go                                                                https://docs.sourcegraph.com/extensions/language_servers/go                                       301
-/docs/code-intelligence/typescript                                                        https://docs.sourcegraph.com/extensions/language_servers/typescript                               301
-/docs/code-intelligence/javascript                                                        https://docs.sourcegraph.com/extensions/language_servers/javascript                               301
-/docs/code-intelligence/python                                                            https://docs.sourcegraph.com/extensions/language_servers/python                                   301
-/docs/code-intelligence/java                                                              https://docs.sourcegraph.com/extensions/language_servers/java                                     301
-/docs/code-intelligence/php                                                               https://docs.sourcegraph.com/extensions/language_servers/php                                      301
-/docs/code-intelligence/swift                                                             https://docs.sourcegraph.com/extensions/language_servers/swift                                    301
-/docs/code-intelligence/experimental-language-servers                                     https://docs.sourcegraph.com/extensions/language_servers/experimental_language_servers            301
-
-/docs/search                                                                              https://docs.sourcegraph.com/user/search                                                          301
-/docs/search/query-syntax                                                                 https://docs.sourcegraph.com/user/search/queries                                                  301
-/docs/search/saved-searches                                                               https://docs.sourcegraph.com/user/search/saved_searches                                           301
-/docs/search/scopes                                                                       https://docs.sourcegraph.com/user/search/scopes                                                   301
-
-
-/docs/config                                                                              https://docs.sourcegraph.com/admin/site_config                                                    301
-/docs/config/site                                                                         https://docs.sourcegraph.com/admin/site_config/all                                                301
-/docs/config/external-database                                                            https://docs.sourcegraph.com/admin/external_database                                              301
-/docs/config/update-repo-webhook                                                          https://docs.sourcegraph.com/user/repo/webhooks                                                   301
-
-/docs/usage                                                                               https://docs.sourcegraph.com/user/usage_statistics                                                301
-/docs/usage#usage-analytics-for-admins                                                    https://docs.sourcegraph.com/user/usage_statistics/analytics                                      301
-/docs/usage#user-surveys                                                                  https://docs.sourcegraph.com/user/usage_statistics/user_surveys                                   301
-/docs/usage#server-pings                                                                  https://docs.sourcegraph.com/user/admin/pings                                                     301
-/docs/pricing                                                                             https://docs.sourcegraph.com/admin/subscriptions                                                  301
-
-/docs/deploy/aws                                                                          https://docs.sourcegraph.com/admin/install/docker/aws                                             301
-/docs/deploy/gcp                                                                          https://docs.sourcegraph.com/admin/install/docker/google_cloud                                    301
-/docs/deploy/digitalocean                                                                 https://docs.sourcegraph.com/admin/install/docker/digitalocean                                    301
-
-
-/docs/config/repositories                                                                 https://docs.sourcegraph.com/admin/repo/add                                                       301
-/docs/config/authentication                                                               https://docs.sourcegraph.com/admin/auth                                                           301
-/docs/config/custom-domain                                                                https://docs.sourcegraph.com/admin/url                                                            301
-/docs/config/tlsssl                                                                       https://docs.sourcegraph.com/admin/tls_ssl                                                        301
-/docs/server/update                                                                       https://docs.sourcegraph.com/admin/updates                                                        301
-/docs/config/monitoring-and-tracing                                                       https://docs.sourcegraph.com/admin/monitoring-and-tracing                                           301
-/docs/config/organizations                                                                https://docs.sourcegraph.com/user/organizations                                                   301
-/docs/config/federation                                                                   https://docs.sourcegraph.com/admin/federation                                                     301
-/docs/extensions                                                                          https://docs.sourcegraph.com/extensions                                                           301
-
-/docs/integrations                                                                        https://docs.sourcegraph.com/integration                                                          301
-/docs/integrations/editor-plugins                                                         https://docs.sourcegraph.com/integration/editor                                                   301
-/docs/features/browser-extension                                                          https://docs.sourcegraph.com/integration/browser_extension                                        301
-/docs/features/search-shortcuts                                                           https://docs.sourcegraph.com/integration/browser_search_engine                                    301
-/docs/extensions                                                                          https://docs.sourcegraph.com/extensions                                                           301
-/docs/features/api                                                                        https://docs.sourcegraph.com/api/graphql                                                          301
-/docs/features/browser-extension/g-suite-installation                                     https://docs.sourcegraph.com/integration/google_gsuite                                            301
-/docs/config/phabricator                                                                  https://docs.sourcegraph.com/integration/phabricator                                              301
-
-/docs/config/repositories#add-repositories-already-cloned-to-disk                         https://docs.sourcegraph.com/admin/repo/add_from_local_disk                                       301
-/docs/config/repositories#github-configuration                                            https://docs.sourcegraph.com/integration/github#syncing-github-repositories                       301
-/docs/config/repositories#bitbucket-server-configuration                                  https://docs.sourcegraph.com/bitbucket_server#syncing-bitbucket-server-repositories               301
-/docs/config/repositories#aws-codecommit-configuration                                    https://docs.sourcegraph.com/integration/aws_codecommit#aws-codecommit-configuration              301
-/docs/config/repositories#github-configuration                                            https://docs.sourcegraph.com/integration/github#syncing-github-repositories                       301
-/docs/migration/oracle-opengrok-to-sourcegraph                                            https://docs.sourcegraph.com/admin/migration/opengrok                                             301
+/blog/sourecgraph-liveblogging-at-gophercon-2018 /blog/sourcegraph-liveblogging-at-gophercon-2018 301
+/go/sourcegraph-liveblogging-at-gophercon-2018-go /blog/sourcegraph-liveblogging-at-gophercon-2018 301
+/go/go-in-debian /go/gophercon-2018-go-in-debian/ 301
+/go/grpc-in-production  /go/grpc-in-production-alan-shreve/ 301
+/docs/datacenter https://github.com/sourcegraph/deploy-sourcegraph 301
+/docs/datacenter/admin-guide https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/admin-guide.md 301
+/docs/datacenter/prometheus-metrics https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/prom-metrics.md 301
+/docs/datacenter/scaling https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/scale.md 301
+/docs/datacenter/update https://github.com/sourcegraph/deploy-sourcegraph/blob/master/docs/update.md 301
+/docs/server/datacenter https://github.com/sourcegraph/deploy-sourcegraph 301
+/docs https://docs.sourcegraph.com/ 301
+/docs/overview https://docs.sourcegraph.com/user 301
+/docs/tour https://docs.sourcegraph.com/tour 301
+/docs/code-intelligence https://docs.sourcegraph.com/extensions/language_servers 301
+/docs/code-intelligence/install https://docs.sourcegraph.com/extensions/language_servers/install 301
+/docs/code-intelligence/go https://docs.sourcegraph.com/extensions/language_servers/go 301
+/docs/code-intelligence/typescript https://docs.sourcegraph.com/extensions/language_servers/typescript 301
+/docs/code-intelligence/javascript https://docs.sourcegraph.com/extensions/language_servers/javascript 301
+/docs/code-intelligence/python https://docs.sourcegraph.com/extensions/language_servers/python 301
+/docs/code-intelligence/java https://docs.sourcegraph.com/extensions/language_servers/java 301
+/docs/code-intelligence/php https://docs.sourcegraph.com/extensions/language_servers/php 301
+/docs/code-intelligence/swift https://docs.sourcegraph.com/extensions/language_servers/swift 301
+/docs/code-intelligence/experimental-language-servers https://docs.sourcegraph.com/extensions/language_servers/experimental_language_servers 301
+/docs/search https://docs.sourcegraph.com/user/search 301
+/docs/search/query-syntax https://docs.sourcegraph.com/user/search/queries 301
+/docs/search/saved-searches https://docs.sourcegraph.com/user/search/saved_searches 301
+/docs/search/scopes https://docs.sourcegraph.com/user/search/scopes 301
+/docs/config https://docs.sourcegraph.com/admin/site_config 301
+/docs/config/site https://docs.sourcegraph.com/admin/site_config/all 301
+/docs/config/external-database https://docs.sourcegraph.com/admin/external_database 301
+/docs/config/update-repo-webhook https://docs.sourcegraph.com/user/repo/webhooks 301
+/docs/usage https://docs.sourcegraph.com/user/usage_statistics 301
+/docs/usage#usage-analytics-for-admins https://docs.sourcegraph.com/user/usage_statistics/analytics 301
+/docs/usage#user-surveys https://docs.sourcegraph.com/user/usage_statistics/user_surveys 301
+/docs/usage#server-pings https://docs.sourcegraph.com/user/admin/pings 301
+/docs/pricing https://docs.sourcegraph.com/admin/subscriptions 301
+/docs/deploy/aws https://docs.sourcegraph.com/admin/install/docker/aws 301
+/docs/deploy/gcp https://docs.sourcegraph.com/admin/install/docker/google_cloud 301
+/docs/deploy/digitalocean https://docs.sourcegraph.com/admin/install/docker/digitalocean 301
+/docs/config/repositories https://docs.sourcegraph.com/admin/repo/add 301
+/docs/config/authentication https://docs.sourcegraph.com/admin/auth 301
+/docs/config/custom-domain https://docs.sourcegraph.com/admin/url 301
+/docs/config/tlsssl https://docs.sourcegraph.com/admin/tls_ssl 301
+/docs/server/update https://docs.sourcegraph.com/admin/updates 301
+/docs/config/monitoring-and-tracing https://docs.sourcegraph.com/admin/monitoring-and-tracing 301
+/docs/config/organizations https://docs.sourcegraph.com/user/organizations 301
+/docs/config/federation https://docs.sourcegraph.com/admin/federation 301
+/docs/extensions https://docs.sourcegraph.com/extensions 301
+/docs/integrations https://docs.sourcegraph.com/integration 301
+/docs/integrations/editor-plugins https://docs.sourcegraph.com/integration/editor 301
+/docs/features/browser-extension https://docs.sourcegraph.com/integration/browser_extension 301
+/docs/features/search-shortcuts https://docs.sourcegraph.com/integration/browser_search_engine 301
+/docs/extensions https://docs.sourcegraph.com/extensions 301
+/docs/features/api https://docs.sourcegraph.com/api/graphql 301
+/docs/features/browser-extension/g-suite-installation https://docs.sourcegraph.com/integration/google_gsuite 301
+/docs/config/phabricator https://docs.sourcegraph.com/integration/phabricator 301
+/docs/config/repositories#add-repositories-already-cloned-to-disk https://docs.sourcegraph.com/admin/repo/add_from_local_disk 301
+/docs/config/repositories#github-configuration https://docs.sourcegraph.com/integration/github#syncing-github-repositories 301
+/docs/config/repositories#bitbucket-server-configuration https://docs.sourcegraph.com/bitbucket_server#syncing-bitbucket-server-repositories 301
+/docs/config/repositories#aws-codecommit-configuration https://docs.sourcegraph.com/integration/aws_codecommit#aws-codecommit-configuration 301
+/docs/config/repositories#github-configuration https://docs.sourcegraph.com/integration/github#syncing-github-repositories 301
+/docs/migration/oracle-opengrok-to-sourcegraph https://docs.sourcegraph.com/admin/migration/opengrok 301
 /product/server https://docs.sourcegraph.com 301
 /product/browser-extension https://docs.sourcegraph.com/integration/browser_extension 301

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -1,5 +1,5 @@
 /																						  https://sourcegraph.com/start																		301
-/changelog 301 https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md
+/changelog https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md 301
 
 /blog/sourecgraph-liveblogging-at-gophercon-2018                                          /blog/sourcegraph-liveblogging-at-gophercon-2018                                                  301
 /go/sourcegraph-liveblogging-at-gophercon-2018-go                                         /blog/sourcegraph-liveblogging-at-gophercon-2018                                                  301
@@ -75,5 +75,5 @@
 /docs/config/repositories#aws-codecommit-configuration                                    https://docs.sourcegraph.com/integration/aws_codecommit#aws-codecommit-configuration              301
 /docs/config/repositories#github-configuration                                            https://docs.sourcegraph.com/integration/github#syncing-github-repositories                       301
 /docs/migration/oracle-opengrok-to-sourcegraph                                            https://docs.sourcegraph.com/admin/migration/opengrok                                             301
-/product/server 301 https://docs.sourcegraph.com
-/product/browser-extension 301 https://docs.sourcegraph.com/integration/browser_extension
+/product/server https://docs.sourcegraph.com 301
+/product/browser-extension https://docs.sourcegraph.com/integration/browser_extension 301


### PR DESCRIPTION
The correct format is `OLD-PATH WS NEW-URL WS HTTP-STATUS-CODE`. There were incorrect lines in this file that put the HTTP status code before the new URL.

fix https://github.com/sourcegraph/sourcegraph/issues/1969