### PR TITLE
fix: remove 3.0 from upgrade language

### DIFF
--- a/blogposts/announcing-sourcegraph-3.1.md
+++ b/blogposts/announcing-sourcegraph-3.1.md
@@ -133,7 +133,7 @@ Thank you to the many people who contributed to make Sourcegraph better since th
 
 Ready to install? [Install Sourcegraph 3.1](https://docs.sourcegraph.com/)
 
-Upgrading from 2.x or 3.0? [See the migration guide](https://docs.sourcegraph.com/admin/migration/3_0)
+Upgrading from 2.x? [See the migration guide](https://docs.sourcegraph.com/admin/migration/3_0)
 
 ---
 

--- a/blogposts/announcing-sourcegraph-3.1.md
+++ b/blogposts/announcing-sourcegraph-3.1.md
@@ -131,9 +131,9 @@ Thank you to the many people who contributed to make Sourcegraph better since th
 
 ## Install or upgrade
 
-Ready to install? [Install Sourcegraph 3.1](https://docs.sourcegraph.com/)
+Ready to install or upgrade? [Install Sourcegraph 3.1](https://docs.sourcegraph.com/)
 
-Upgrading from 2.x? [See the migration guide](https://docs.sourcegraph.com/admin/migration/3_0)
+Upgrading from 2.x or 3.0.0? [See the migration guide](https://docs.sourcegraph.com/admin/migration/3_0)
 
 ---
 


### PR DESCRIPTION
The current language here (just "or 3.0") makes it sound like all 3.0 patch releases need the docs. That's not true — it's ONLY `3.0.0` (and none of the -beta, etc. ones are included).

There are relatively few `3.0.0` instances left, so for clarity, I think we would be smart to just remove that part entirely.