### PR TITLE
Add landing page for setting Sourcegraph up at hackathons

### DIFF
--- a/website/src/EventLogger.tsx
+++ b/website/src/EventLogger.tsx
@@ -164,6 +164,10 @@ class EventLogger {
     public trackContactUsFormSubmitted(): void {
         this.trackEvent('Pages', 'Submit', null, 'ContactUsFormSubmitted', {})
     }
+
+    public trackHackathonFormSubmitted(): void {
+        this.trackEvent('Pages', 'Submit', null, 'HackathonFormSubmitted', {})
+    }
     public trackBuyUnlimitedButtonClicked(): void {
         this.trackEvent('Pages', 'Click', null, 'BuyUnlimitedButtonClicked', {})
     }

--- a/website/src/pages/hackathons.tsx
+++ b/website/src/pages/hackathons.tsx
@@ -37,7 +37,8 @@ export default class Pricing extends React.Component<any, any> {
                                 <div>
                                     <h1 className="text-center">Set up Sourcegraph during a hackathon</h1>
                                     <p className="text-center measure">
-                                        We'll give you access to Sourcegraph Enterprise features so you can ship code search and intelligence to your team.
+                                        We'll give you access to Sourcegraph Enterprise features so you can ship code
+                                        search and intelligence to your team.
                                     </p>
                                 </div>
                             </div>
@@ -47,16 +48,27 @@ export default class Pricing extends React.Component<any, any> {
                         <div className="panel-area mr-lg-5 mt-0 mb-2">
                             <div className="d-flex flex-column panel">
                                 <p>
-                                    Want to win your hackathon? Set up Sourcegraph
-                                    and bring the power of code search and code intelligence to your engineering team!
+                                    Want to win your hackathon? Set up Sourcegraph and bring the power of code search
+                                    and code intelligence to your engineering team!
                                 </p>
                                 <ul>
-                                    <li>We'll give you access to all of our <a href="/pricing" target="_blank">Enterprise features</a></li>
+                                    <li>
+                                        We'll give you access to all of our{' '}
+                                        <a href="/pricing" target="_blank">
+                                            Enterprise features
+                                        </a>
+                                    </li>
                                     <li>We'll give you live tech support</li>
                                     <li>We'll ship you a bag of stickers, shirts, socks, and other great swag!</li>
                                 </ul>
 
-                                <p>Fill out the form or tweet us <a href="https://twitter.com/srcgraph" target="_blank">@srcgraph</a>, and we'll get back to you ASAP on how to get started!</p>
+                                <p>
+                                    Fill out the form or tweet us{' '}
+                                    <a href="https://twitter.com/srcgraph" target="_blank">
+                                        @srcgraph
+                                    </a>
+                                    , and we'll get back to you ASAP on how to get started!
+                                </p>
                                 <div className="panel__help">
                                     <p>
                                         Get started with the{' '}

--- a/website/src/pages/hackathons.tsx
+++ b/website/src/pages/hackathons.tsx
@@ -37,9 +37,7 @@ export default class Pricing extends React.Component<any, any> {
                                 <div>
                                     <h1 className="text-center">Set up Sourcegraph during a hackathon</h1>
                                     <p className="text-center measure">
-                                        Hackathons are the perfect time to set up code search and intelligence for your
-                                        team. We'll give you access to all of Sourcegraph's features to set you up for
-                                        the best possible demo.
+                                        We'll give you access to Sourcegraph Enterprise features so you can ship code search and intelligence to your team.
                                     </p>
                                 </div>
                             </div>
@@ -49,21 +47,16 @@ export default class Pricing extends React.Component<any, any> {
                         <div className="panel-area mr-lg-5 mt-0 mb-2">
                             <div className="d-flex flex-column panel">
                                 <p>
-                                    Want to bring lasting value to your company during a hackathon? Set up Sourcegraph
-                                    and bring the power of code search and code intelligence to your engineering team.
+                                    Want to win your hackathon? Set up Sourcegraph
+                                    and bring the power of code search and code intelligence to your engineering team!
                                 </p>
                                 <ul>
-                                    <li>
-                                        We'll give you <b>access to our Enterprise features</b> so you can ship
-                                        Sourcegraph's full feature set to your team and for your demo.
-                                    </li>
-                                    <li>
-                                        We'll <b>answer any questions and share tips</b> to make sure you can
-                                        successfully deploy and demo Sourcegraph
-                                    </li>
+                                    <li>We'll give you access to all of our <a href="/pricing" target="_blank">Enterprise features</a></li>
+                                    <li>We'll give you live tech support</li>
+                                    <li>We'll ship you a bag of stickers, shirts, socks, and other great swag!</li>
                                 </ul>
 
-                                <p>Fill out the form, and we'll get back to you ASAP on how to get started!</p>
+                                <p>Fill out the form or tweet us <a href="https://twitter.com/srcgraph" target="_blank">@srcgraph</a>, and we'll get back to you ASAP on how to get started!</p>
                                 <div className="panel__help">
                                     <p>
                                         Get started with the{' '}

--- a/website/src/pages/hackathons.tsx
+++ b/website/src/pages/hackathons.tsx
@@ -47,7 +47,7 @@ export default class Pricing extends React.Component<any, any> {
                                     <li>We'll <b>answer any questions and share tips</b> to make sure you can successfully deploy and demo Sourcegraph</li>
                                 </ul>
 
-                                <p>Fill out the form, and we'll get back to you  ASAP on how to get started!</p>
+                                <p>Fill out the form, and we'll get back to you ASAP on how to get started!</p>
                                 <div className="panel__help">
                                     <p>Get started with the <a target="blank" href="https://docs.sourcegraph.com/admin/install/docker">installation docs.</a></p>
                                     <p>When you're ready to present, check out the <a target="blank" href="https://docs.sourcegraph.com/user/tour">Sourcegraph tour</a> for example use-cases to show off.</p>

--- a/website/src/pages/hackathons.tsx
+++ b/website/src/pages/hackathons.tsx
@@ -4,6 +4,7 @@ import Helmet from 'react-helmet'
 import Layout from '../components/Layout'
 import { eventLogger } from '../EventLogger'
 
+
 export default class Pricing extends React.Component<any, any> {
     public componentDidMount(): void {
         const script = document.createElement('script')
@@ -13,7 +14,7 @@ export default class Pricing extends React.Component<any, any> {
         script.addEventListener('load', () => {
             ;(window as any).hbspt.forms.create({
                 portalId: '2762526',
-                formId: '6170d9b0-fa5b-4240-9f47-f3a3aa9557c9',
+                formId: '7d6c55af-3de3-4e57-a5df-a0de341a4814',
                 target: '#hubspotTrialForm',
                 onFormSubmit: (e: Event) => {
                     eventLogger.trackContactUsFormSubmitted()

--- a/website/src/pages/hackathons.tsx
+++ b/website/src/pages/hackathons.tsx
@@ -1,9 +1,7 @@
-import { Link } from 'gatsby'
 import * as React from 'react'
 import Helmet from 'react-helmet'
 import Layout from '../components/Layout'
 import { eventLogger } from '../EventLogger'
-
 
 export default class Pricing extends React.Component<any, any> {
     public componentDidMount(): void {
@@ -17,7 +15,7 @@ export default class Pricing extends React.Component<any, any> {
                 formId: '7d6c55af-3de3-4e57-a5df-a0de341a4814',
                 target: '#hubspotTrialForm',
                 onFormSubmit: (e: Event) => {
-                    eventLogger.trackContactUsFormSubmitted()
+                    eventLogger.trackHackathonFormSubmitted()
                 },
             })
         })
@@ -27,13 +25,22 @@ export default class Pricing extends React.Component<any, any> {
         return (
             <Layout location={this.props.location}>
                 <div>
-                    <div className="pricing-bg"/>
+                    <Helmet>
+                        <title>Sourcegraph - Set up Sourcegraph at a Hackathon</title>
+                        <meta name="twitter:title" content="Set up Sourcegraph at a Hackathon" />
+                        <meta property="og:title" content="Set up Sourcegraph at a Hackathon" />
+                    </Helmet>
+                    <div className="pricing-bg" />
                     <div className="jumbotron text-right dark-7">
                         <div className="row">
                             <div className="sales py-0 d-flex flex-grow flex-column flex-lg-row align-items-center justify-content-around">
                                 <div>
                                     <h1 className="text-center">Set up Sourcegraph during a hackathon</h1>
-                                    <p className="text-center measure">Hackathons are the perfect time to set up code search and intelligence for your team. We'll give you access to all of Sourcegraph's features to set you up for the best possible demo.</p>
+                                    <p className="text-center measure">
+                                        Hackathons are the perfect time to set up code search and intelligence for your
+                                        team. We'll give you access to all of Sourcegraph's features to set you up for
+                                        the best possible demo.
+                                    </p>
                                 </div>
                             </div>
                         </div>
@@ -41,16 +48,36 @@ export default class Pricing extends React.Component<any, any> {
                     <section className="d-flex justify-content-around flex-column flex-lg-row sales bg-white">
                         <div className="panel-area mr-lg-5 mt-0 mb-2">
                             <div className="d-flex flex-column panel">
-                                <p>Want to bring lasting value to your company during a hackathon? Set up Sourcegraph and bring the power of code search and code intelligence to your engineering team.</p>
+                                <p>
+                                    Want to bring lasting value to your company during a hackathon? Set up Sourcegraph
+                                    and bring the power of code search and code intelligence to your engineering team.
+                                </p>
                                 <ul>
-                                    <li>We'll give you <b>access to our Enterprise features</b> so you can ship Sourcegraph's full feature set to your team and for your demo.</li>
-                                    <li>We'll <b>answer any questions and share tips</b> to make sure you can successfully deploy and demo Sourcegraph</li>
+                                    <li>
+                                        We'll give you <b>access to our Enterprise features</b> so you can ship
+                                        Sourcegraph's full feature set to your team and for your demo.
+                                    </li>
+                                    <li>
+                                        We'll <b>answer any questions and share tips</b> to make sure you can
+                                        successfully deploy and demo Sourcegraph
+                                    </li>
                                 </ul>
 
                                 <p>Fill out the form, and we'll get back to you ASAP on how to get started!</p>
                                 <div className="panel__help">
-                                    <p>Get started with the <a target="blank" href="https://docs.sourcegraph.com/admin/install/docker">installation docs.</a></p>
-                                    <p>When you're ready to present, check out the <a target="blank" href="https://docs.sourcegraph.com/user/tour">Sourcegraph tour</a> for example use-cases to show off.</p>
+                                    <p>
+                                        Get started with the{' '}
+                                        <a target="blank" href="https://docs.sourcegraph.com/admin/install/docker">
+                                            installation docs.
+                                        </a>
+                                    </p>
+                                    <p>
+                                        When you're ready to present, check out the{' '}
+                                        <a target="blank" href="https://docs.sourcegraph.com/user/tour">
+                                            Sourcegraph tour
+                                        </a>{' '}
+                                        for example use-cases to show off.
+                                    </p>
                                 </div>
                             </div>
                         </div>
@@ -63,9 +90,5 @@ export default class Pricing extends React.Component<any, any> {
                 </div>
             </Layout>
         )
-    }
-
-    private trackInstallSourcegraphServerClicked = () => {
-        eventLogger.trackContactUsCTAClicked('PricingPage')
     }
 }

--- a/website/src/pages/hackathons.tsx
+++ b/website/src/pages/hackathons.tsx
@@ -1,0 +1,73 @@
+import { Link } from 'gatsby'
+import * as React from 'react'
+import Helmet from 'react-helmet'
+import Layout from '../components/Layout'
+import { eventLogger } from '../EventLogger'
+
+export default class Pricing extends React.Component<any, any> {
+    public componentDidMount(): void {
+        const script = document.createElement('script')
+        script.src = '//js.hsforms.net/forms/v2.js'
+        const hubspot = document.getElementById('hubspotTrialForm')
+        hubspot.appendChild(script)
+        script.addEventListener('load', () => {
+            ;(window as any).hbspt.forms.create({
+                portalId: '2762526',
+                formId: '6170d9b0-fa5b-4240-9f47-f3a3aa9557c9',
+                target: '#hubspotTrialForm',
+                onFormSubmit: (e: Event) => {
+                    eventLogger.trackContactUsFormSubmitted()
+                },
+            })
+        })
+    }
+
+    public render(): JSX.Element | null {
+        return (
+            <Layout location={this.props.location}>
+                <div>
+                    <div className="pricing-bg"/>
+                    <div className="jumbotron text-right dark-7">
+                        <div className="row">
+                            <div className="sales py-0 d-flex flex-grow flex-column flex-lg-row align-items-center justify-content-around">
+                                <div>
+                                    <h1 className="text-center">Set up Sourcegraph during a hackathon</h1>
+                                    <p className="text-center measure">Hackathons are the perfect time to set up code search and intelligence for your team. Get a <b>free Sourcegraph Enterprise trial key</b> to give your team Sourcegraph's full capabilities.</p>
+                                </div>
+                            </div>
+                        </div>
+                    </div>
+                    <section className="d-flex justify-content-around flex-column flex-lg-row sales bg-white">
+                        <div className="panel-area mr-lg-5 mt-0 mb-2">
+                            <div className="d-flex flex-column panel">
+                                <p>Want to bring lasting value to your company during a hackathon? Set up Sourcegraph and bring the power of code search and code intelligence to your engineering team.</p>
+                                <ul>
+                                    <li>We'll give you a <b>free trial key</b> for Sourcegraph Enterprise so your team can use all of Sourcegraph features for a month after the hackathon.</li>
+                                    <li>We'll <b>answer any questions</b> to make sure you can successfully deploy Sourcegraph.</li>
+                                </ul>
+
+                                <p>Fill out the form, and we'll get back to you with your trial key and answer your questions ASAP!</p>
+                                <div className="panel__help">
+                                    <p>Get started with the <a target="blank" href="https://docs.sourcegraph.com/admin/install/docker">installation docs.</a></p>
+                                    <p>When you're ready to present, check out the <a target="blank" href="https://docs.sourcegraph.com/user/tour">Sourcegraph tour</a> for example use-cases to show off.</p>
+                                </div>
+                            </div>
+                        </div>
+                        <div className="form-area">
+                            <div>
+                                <h1>Get a free trial key</h1>
+                            </div>
+                            <div className="form">
+                                <div id="hubspotTrialForm" className="d-flex justify-center" />
+                            </div>
+                        </div>
+                    </section>
+                </div>
+            </Layout>
+        )
+    }
+
+    private trackInstallSourcegraphServerClicked = () => {
+        eventLogger.trackContactUsCTAClicked('PricingPage')
+    }
+}

--- a/website/src/pages/hackathons.tsx
+++ b/website/src/pages/hackathons.tsx
@@ -44,10 +44,10 @@ export default class Pricing extends React.Component<any, any> {
                                 <p>Want to bring lasting value to your company during a hackathon? Set up Sourcegraph and bring the power of code search and code intelligence to your engineering team.</p>
                                 <ul>
                                     <li>We'll give you <b>access to our Enterprise features</b> so you can ship Sourcegraph's full feature set to your team and for your demo.</li>
-                                    <li>We'll <b>answer any questions</b> to make sure you can successfully deploy and demo Sourcegraph.</li>
+                                    <li>We'll <b>answer any questions and share tips</b> to make sure you can successfully deploy and demo Sourcegraph</li>
                                 </ul>
 
-                                <p>Fill out the form, and we'll get back to you ASAP!</p>
+                                <p>Fill out the form, and we'll get back to you  ASAP on how to get started!</p>
                                 <div className="panel__help">
                                     <p>Get started with the <a target="blank" href="https://docs.sourcegraph.com/admin/install/docker">installation docs.</a></p>
                                     <p>When you're ready to present, check out the <a target="blank" href="https://docs.sourcegraph.com/user/tour">Sourcegraph tour</a> for example use-cases to show off.</p>

--- a/website/src/pages/hackathons.tsx
+++ b/website/src/pages/hackathons.tsx
@@ -33,7 +33,7 @@ export default class Pricing extends React.Component<any, any> {
                             <div className="sales py-0 d-flex flex-grow flex-column flex-lg-row align-items-center justify-content-around">
                                 <div>
                                     <h1 className="text-center">Set up Sourcegraph during a hackathon</h1>
-                                    <p className="text-center measure">Hackathons are the perfect time to set up code search and intelligence for your team. Get a <b>free Sourcegraph Enterprise trial key</b> to give your team Sourcegraph's full capabilities.</p>
+                                    <p className="text-center measure">Hackathons are the perfect time to set up code search and intelligence for your team. We'll give you access to all of Sourcegraph's features to set you up for the best possible demo.</p>
                                 </div>
                             </div>
                         </div>
@@ -43,11 +43,11 @@ export default class Pricing extends React.Component<any, any> {
                             <div className="d-flex flex-column panel">
                                 <p>Want to bring lasting value to your company during a hackathon? Set up Sourcegraph and bring the power of code search and code intelligence to your engineering team.</p>
                                 <ul>
-                                    <li>We'll give you a <b>free trial key</b> for Sourcegraph Enterprise so your team can use all of Sourcegraph features for a month after the hackathon.</li>
-                                    <li>We'll <b>answer any questions</b> to make sure you can successfully deploy Sourcegraph.</li>
+                                    <li>We'll give you <b>access to our Enterprise features</b> so you can ship Sourcegraph's full feature set to your team and for your demo.</li>
+                                    <li>We'll <b>answer any questions</b> to make sure you can successfully deploy and demo Sourcegraph.</li>
                                 </ul>
 
-                                <p>Fill out the form, and we'll get back to you with your trial key and answer your questions ASAP!</p>
+                                <p>Fill out the form, and we'll get back to you ASAP!</p>
                                 <div className="panel__help">
                                     <p>Get started with the <a target="blank" href="https://docs.sourcegraph.com/admin/install/docker">installation docs.</a></p>
                                     <p>When you're ready to present, check out the <a target="blank" href="https://docs.sourcegraph.com/user/tour">Sourcegraph tour</a> for example use-cases to show off.</p>
@@ -55,9 +55,6 @@ export default class Pricing extends React.Component<any, any> {
                             </div>
                         </div>
                         <div className="form-area">
-                            <div>
-                                <h1>Get a free trial key</h1>
-                            </div>
                             <div className="form">
                                 <div id="hubspotTrialForm" className="d-flex justify-center" />
                             </div>


### PR DESCRIPTION
A page we can send people to if they want to set Sourcegraph up during a hackathon. We'll provide access to Enterprise features to set them up for a successful demo.

![image](https://user-images.githubusercontent.com/16265452/53455592-e5f46480-39df-11e9-905c-29dd38ccd3fd.png)
