### PR TITLE
fix: update pricing page

### DIFF
--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -98,7 +98,7 @@ export default class Pricing extends React.Component<any, any> {
                                                             <p>Single sign-on (SSO) support</p>
                                                         </a>
                                                         <a href="#admin">
-                                                            <p>10-user limit</p>
+                                                            <p>20-user limit</p>
                                                         </a>
                                                         <a href="#search">
                                                             <p>Support on our public issue tracker</p>
@@ -206,11 +206,13 @@ export default class Pricing extends React.Component<any, any> {
                                                         <a href="#integrations">
                                                             <p>Custom integrations</p>
                                                         </a>
+                                                        <a href="#admin">
+                                                            <p>Unlimited guest users</p>
+                                                        </a>
                                                         <a href="#support">
                                                             <p>Dedicated support</p>
                                                             <br />
                                                         </a>
-                                                        <p>&nbsp;</p>
                                                         <p>&nbsp;</p>
                                                         <p>&nbsp;</p>
                                                     </div>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -97,6 +97,9 @@ export default class Pricing extends React.Component<any, any> {
                                                         <a href="#admin">
                                                             <p>Single sign-on (SSO) support</p>
                                                         </a>
+                                                        <a href="#admin">
+                                                            <p>10-user limit</p>
+                                                        </a>
                                                         <a href="#search">
                                                             <p>Support on our public issue tracker</p>
                                                             <br />
@@ -153,6 +156,9 @@ export default class Pricing extends React.Component<any, any> {
                                                                 registry
                                                             </p>
                                                         </a>
+                                                        <a href="#admin">
+                                                            <p>Unlimited users</p>
+                                                        </a>
                                                         <a href="#support">
                                                             <p>Premium support</p>
                                                         </a>
@@ -206,6 +212,7 @@ export default class Pricing extends React.Component<any, any> {
                                                             <p>Dedicated support</p>
                                                             <br />
                                                         </a>
+                                                        <p>&nbsp;</p>
                                                         <p>&nbsp;</p>
                                                         <p>&nbsp;</p>
                                                         <p>&nbsp;</p>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -105,8 +105,7 @@ export default class Pricing extends React.Component<any, any> {
                                                             <br />
                                                         </a>
                                                     </div>
-                                                    <p>&nbsp;</p>
-                                                    <p>&nbsp;</p>
+
                                                     <div className="col-12 contact">
                                                         <a
                                                             className="btn btn-pricing btn-lg justify-content-center text-center"
@@ -163,7 +162,6 @@ export default class Pricing extends React.Component<any, any> {
                                                             <p>Premium support</p>
                                                         </a>
                                                         <p>&nbsp;</p>
-                                                        <p>&nbsp;</p>
                                                     </div>
                                                     <div className="col-12 contact">
                                                         <Link
@@ -212,7 +210,6 @@ export default class Pricing extends React.Component<any, any> {
                                                             <p>Dedicated support</p>
                                                             <br />
                                                         </a>
-                                                        <p>&nbsp;</p>
                                                         <p>&nbsp;</p>
                                                         <p>&nbsp;</p>
                                                         <p>&nbsp;</p>


### PR DESCRIPTION
Explicitly state the max users allowed on a Core instance, instead of leaving it vague