### PR TITLE
Remove extra pair of parenthesies from footer

### DIFF
--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -31,7 +31,6 @@ export const Footer: React.FunctionComponent<{ minimal?: boolean }> = ({ minimal
                                 </a>
                             </li>
                         </ul>
-                        )}
                     </div>
                     <div className="col-sm-6 col-md-3 col-lg-2 mb-3">
                         <h3 className="footer__nav-header">Why Sourcegraph?</h3>


### PR DESCRIPTION
Removes an extra pair of parenthesies `)}` I noticed in the footer just under the social buttons:

![Screen Shot 2019-05-02 at 19 23 17](https://user-images.githubusercontent.com/364725/57069561-eecf2280-6d0f-11e9-9a49-f59d641f8afb.png)

Looks like they snuck in with https://github.com/sourcegraph/about/pull/112/commits/20317c5aa42b23b694456e2970129d6d16200708 .