### PR TITLE
Add link to branding in docs

### DIFF
--- a/website/src/components/PricingTable.tsx
+++ b/website/src/components/PricingTable.tsx
@@ -199,6 +199,7 @@ const DATA: PricingItemCategory[] = [
             },
             {
                 name: 'Custom branding',
+                url: 'https://docs.sourcegraph.com/admin/config/site_config#reference',
                 plans: ENTERPRISE_PLAN,
             },
             {


### PR DESCRIPTION
We don't have a dedicated page, but it's discoverable here