### PR TITLE
Temporary fix for blogpost text overflow into black margin

### DIFF
--- a/blogposts/announcing-sourcegraph-3.4.md
+++ b/blogposts/announcing-sourcegraph-3.4.md
@@ -46,7 +46,7 @@ For site admins, instead of saving configuration to the database.
 <p style="text-align: center"><a href="https://vimeo.com/336923053" target="_blank">View on Vimeo</a></p>
 </p>
 
-If your code host's hostname is long, such as `githubenterprise.mycompany.internal`, then your Sourcegraph URLs will be long (e.g. `https://sourcegraph.mycompany.internal/githubenterprise.mycompany.internal/myteam/myproject`). To shorten these URLs, you can use the [`repositoryPathPattern`](https://www.google.com/search?ie=UTF-8&q=site%3Adocs.sourcegraph.com+%22repositoryPathPattern%22) external service configuration property.
+If your code host's hostname is long, such as `githubenterprise.mycompany.internal`, then your Sourcegraph URLs will be long (e.g. `https://sourcegraph.mycompany.internal` `/githubenterprise.mycompany.internal` `/myteam/myproject`). To shorten these URLs, you can use the [`repositoryPathPattern`](https://www.google.com/search?ie=UTF-8&q=site%3Adocs.sourcegraph.com+%22repositoryPathPattern%22) external service configuration property.
 
 Sourcegraph 3.4 fixes a problem where the browser extension didn't work if you used `repositoryPathPattern`. If you had been holding off on using the browser extension due to this problem, it will now work.
 

--- a/website/src/css/pages/_blog-post.scss
+++ b/website/src/css/pages/_blog-post.scss
@@ -1,7 +1,7 @@
 // stylelint-disable declaration-property-unit-whitelist
 .blog-post {
     margin: auto;
-    // FIXME: temporary solution to text running over.
+    // FIXME(#125): temporary solution to text running over.
     // width: 980px;
     padding: 45px 0;
 

--- a/website/src/css/pages/_blog-post.scss
+++ b/website/src/css/pages/_blog-post.scss
@@ -1,7 +1,8 @@
 // stylelint-disable declaration-property-unit-whitelist
 .blog-post {
     margin: auto;
-    width: 980px;
+    // FIXME: temporary solution to text running over.
+    // width: 980px;
     padding: 45px 0;
 
     &__wrapper {


### PR DESCRIPTION
Temporary but immediate fix for #125:

- Remove fixed widith so text stays in the white area.
- The long code line doesn't break lines, and causes a run over still. I'm manually breaking it up so that it stays within width. This will look reasonable on mobile devices:

<img width="477" alt="Screen Shot 2019-05-30 at 7 23 44 PM" src="https://user-images.githubusercontent.com/888624/58671417-968c4000-8310-11e9-8f22-6c35acfa07df.png">

There is a minor ugliness due to the space in the long codeline in the larger-width desktop view:

<img width="957" alt="Screen Shot 2019-05-30 at 7 23 54 PM" src="https://user-images.githubusercontent.com/888624/58671414-93914f80-8310-11e9-8928-8f93b9c6efa6.png">