### PR TITLE
Set a max width of 740px for blog post content column

### DIFF
--- a/website/src/css/pages/_blog-post.scss
+++ b/website/src/css/pages/_blog-post.scss
@@ -8,6 +8,7 @@
     &__wrapper {
         width: 66.667%;
         margin: auto;
+        max-width: 740px; // Copied from medium.com
     }
 
     &__title {


### PR DESCRIPTION
Based on the max width of medium.com's content column.


![ScreenFlow](https://user-images.githubusercontent.com/133014/59942160-cb714b80-9413-11e9-999c-59e3fb7599b9.gif)
