### PR TITLE
Improving 3.5 blog post title

### DIFF
--- a/blogposts/announcing-sourcegraph-3.5.md
+++ b/blogposts/announcing-sourcegraph-3.5.md
@@ -1,5 +1,5 @@
 ---
-title: 'Sourcegraph 3.5: Improved searching, repository syncing, and Bitbucket Server repository permissions'
+title: 'Sourcegraph 3.5: Powerful new search filters, improved configuration, and Bitbucket Server repository permissions'
 author: Ryan Blunden and Christina Forney
 publishDate: 2019-06-20T10:00-07:00
 tags: [


### PR DESCRIPTION
When writing the release email I noticed that that title of the blog post didn't make sense with Improved at the front of the sentence. The middle item needs a better descriptor.