### PR TITLE
Added optional meta field to LayoutProps

### DIFF
--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -5,6 +5,12 @@ import { Footer } from './Footer'
 import Header from './Header'
 
 interface LayoutProps {
+    meta?: {
+        title?: string
+        description?: string
+        image: string
+        icon?: string
+    }
     location: {
         pathname: string
     }
@@ -14,29 +20,36 @@ interface LayoutProps {
 
 export default class Layout extends React.PureComponent<LayoutProps> {
     public render(): JSX.Element | null {
+        const defaultMetaProps: LayoutProps['meta'] = {
+            title: 'Sourcegraph',
+            description:
+                'Sourcegraph is a free, self-hosted code search and intelligence server that helps developers find, review, understand, and debug code. Use it with any Git code host for teams from 1 to 10,000+.',
+            image: 'https://about.sourcegraph.com/sourcegraph-mark.png',
+            icon: 'https://about.sourcegraph.com/favicon.png',
+        }
         const pathname = this.props.location.pathname
         const isHome = pathname === '/'
         const isProductPage = pathname.startsWith('/product/')
-        const desc =
-            'Sourcegraph is a free, self-hosted code search and intelligence server that helps developers find, review, understand, and debug code. Use it with any Git code host for teams from 1 to 10,000+.'
+        const metaProps = this.props.meta || defaultMetaProps
+
         return (
             <div className="flex flex-column fill-height">
                 <Helmet>
                     <title>Sourcegraph - Code search and intelligence</title>
-                    <meta name="twitter:title" content="Sourcegraph" />
+                    <meta name="twitter:title" content={metaProps.title} />
                     <meta name="twitter:site" content="@srcgraph" />
-                    <meta name="twitter:image" content="https://about.sourcegraph.com/sourcegraph-mark.png" />
+                    <meta name="twitter:image" content={metaProps.image} />
                     <meta name="twitter:card" content="summary" />
-                    <meta name="twitter:description" content={desc} />
+                    <meta name="twitter:description" content={metaProps.description} />
 
                     <meta property="og:type" content="website" />
-                    <meta property="og:title" content="Sourcegraph" />
-                    <meta property="og:image" content="https://about.sourcegraph.com/sourcegraph-mark.png" />
-                    <meta property="og:description" content={desc} />
+                    <meta property="og:title" content={metaProps.title} />
+                    <meta property="og:image" content={metaProps.image} />
+                    <meta property="og:description" content={metaProps.description} />
 
-                    <meta name="description" content={desc} />
-                    <link rel="icon" type="image/png" href="https://about.sourcegraph.com/favicon.png" />
-                    <link rel="icon" type="image/png" href="https://about.sourcegraph.com/sourcegraph-mark.png" />
+                    <meta name="description" content={metaProps.description} />
+                    <link rel="icon" type="image/png" href={metaProps.icon} />
+                    <link rel="icon" type="image/png" href={metaProps.image} />
                     <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
 
                     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet" />

--- a/website/src/pages/case-studies/we-are-thorn.tsx
+++ b/website/src/pages/case-studies/we-are-thorn.tsx
@@ -9,42 +9,15 @@ import { RequestDemoAction } from '../../css/components/actions/RequestDemoActio
 import { ViewDeveloperDocumentationAction } from '../../css/components/actions/ViewDeveloperDocumentationAction'
 
 export default ((props: any) => (
-    <Layout location={props.location}>
-        <Helmet>
-            <title>Thorn sunsets legacy applications safely with Sourcegraph</title>
-            <meta name="twitter:title" content="How Thorn sunsets legacy applications safely with Sourcegraph" />
-            <meta property="og:title" content="How Thorn sunsets legacy applications safely with Sourcegraph" />
-            <meta
-                name="twitter:description"
-                content="Learn how Sourcegraph code search enabled Thorn to systematically sunset legacy systems safely, removing huge amounts of tech debt in the process."
-            />
-            <meta
-                name="twitter:image"
-                content="https://about.sourcegraph.com/case-studies/thorn-sourcegraph-case-study.png"
-            />
-            <meta
-                property="og:description"
-                content="Learn how Sourcegraph code search enabled Thorn to systematically sunset legacy systems safely, removing huge amounts of tech debt in the process."
-            />
-            <meta
-                name="og:image"
-                content="https://about.sourcegraph.com/case-studies/thorn-sourcegraph-case-study.png"
-            />
-            <meta
-                name="description"
-                content="Learn how Sourcegraph code search enabled Thorn to systematically sunset legacy systems safely, removing huge amounts of tech debt in the process."
-            />
-            <link
-                rel="icon"
-                type="image/png"
-                href="https://about.sourcegraph.com/case-studies/thorn-sourcegraph-case-study.png"
-            />
-            <link
-                rel="stylesheet"
-                href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.8.2/css/all.min.css"
-            ></link>
-        </Helmet>
-
+    <Layout
+        location={props.location}
+        meta={{
+            title: 'Thorn sunsets legacy applications safely with Sourcegraph',
+            description:
+                'Learn how Sourcegraph code search enabled Thorn to systematically sunset legacy systems safely, removing huge amounts of tech debt in the process.',
+            image: 'https://about.sourcegraph.com/case-studies/thorn-sourcegraph-case-study.png',
+        }}
+    >
         <CaseStudyPage
             title="Thorn sunsets legacy applications safely with Sourcegraph"
             logo="/case-studies/thorn-logo.png"


### PR DESCRIPTION
Required for the Thorn case study page to override the title, description, and image for social media previewing.

The Thorn case study page now has the meta overrides.

<img width="1393" alt="Screen Shot 2019-07-03 at 11 43 44 AM" src="https://user-images.githubusercontent.com/133014/60617159-023a5080-9d88-11e9-9198-976c5a04f17a.png">
