### PR TITLE
Add GopherCon 2019 posts

### DIFF
--- a/blogposts/gophercon-2019-better-x86-assembly-generation-from-go.md
+++ b/blogposts/gophercon-2019-better-x86-assembly-generation-from-go.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Better x86 Assembly Generation from Go"
+description: "This talk will equip you with the tools to safely write lightning fast assembly functions for Go. We will introduce Go assembly and the role it plays in the Go ecosystem, promote best practices for assembly development and demonstrate how code generation tools can manage complexity in large assembly projects."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-14:00
+tags: [
+  gophercon
+]
+slug: gophercon-2019-better-x86-assembly-generation-from-go
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Michael McLoughlin
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+This talk will equip you with the tools to safely write lightning fast assembly functions for Go. We will introduce Go assembly and the role it plays in the Go ecosystem, promote best practices for assembly development and demonstrate how code generation tools can manage complexity in large assembly projects.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-contributing-to-the-os-package-how-deep-do-you-go.md
+++ b/blogposts/gophercon-2019-contributing-to-the-os-package-how-deep-do-you-go.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Contributing to the os Package: How deep do you Go?"
+description: "When the core of a language fails you, and you can't remove a file, how can you fix it? Oliver will share his contribution journey from bug to merge in a crucial part of Golang: the os package. Discover how Golang manages platform independence and how even novices can contribute Unix system calls."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-16:25
+tags: [
+  gophercon
+]
+slug: gophercon-2019-contributing-to-the-os-package-how-deep-do-you-go
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Oliver Stenbom
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+When the core of a language fails you, and you can't remove a file, how can you fix it? Oliver will share his contribution journey from bug to merge in a crucial part of Golang: the os package. Discover how Golang manages platform independence and how even novices can contribute Unix system calls.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-controlling-the-go-runtime.md
+++ b/blogposts/gophercon-2019-controlling-the-go-runtime.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Controlling the go runtime"
+description: "Sometimes we need to tell the go runtime what to do. This talk explains how to control the runtime, why we should, and describes two new ways to control it better."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-11:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-controlling-the-go-runtime
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Patrick Hawley
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Sometimes we need to tell the go runtime what to do. This talk explains how to control the runtime, why we should, and describes two new ways to control it better.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-death-by-three-thousand-timers-streaming-video-on-demand-for-cable-tv.md
+++ b/blogposts/gophercon-2019-death-by-three-thousand-timers-streaming-video-on-demand-for-cable-tv.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Death by three thousand timers: Streaming video-on-demand for Cable TV"
+description: "Can Go handle soft real-time applications? Learn about the challenges my team overcame to deliver video-on-demand MPEG streams to millions of cable TV customers using pure Go. Along the way we'll dig deeper into how Go manages timers and goroutine scheduling."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-11:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-death-by-three-thousand-timers-streaming-video-on-demand-for-cable-tv
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Chris Hines
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Can Go handle soft real-time applications? Learn about the challenges my team overcame to deliver video-on-demand MPEG streams to millions of cable TV customers using pure Go. Along the way we'll dig deeper into how Go manages timers and goroutine scheduling.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-design-command-line-tools-people-love.md
+++ b/blogposts/gophercon-2019-design-command-line-tools-people-love.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Design Command-Line Tools People Love"
+description: "It is a joy to build command-line tools that are not only easy to learn, but that other developers are willing to maintain. Often a team's engineering efforts are spent on the backend, while the cli doesn't receive the same level of attention. This can result in hard-to-test tools and dumping maintenance of them to whoever most recently joined the team. Learn how to take full advantage of popular Go libraries, structure your Go code to improve reuse and testability, publish binaries, and of course design your commands to be user friendly."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-14:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-design-command-line-tools-people-love
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Carolyn Van Slyck
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+It is a joy to build command-line tools that are not only easy to learn, but that other developers are willing to maintain. Often a team's engineering efforts are spent on the backend, while the cli doesn't receive the same level of attention. This can result in hard-to-test tools and dumping maintenance of them to whoever most recently joined the team. Learn how to take full advantage of popular Go libraries, structure your Go code to improve reuse and testability, publish binaries, and of course design your commands to be user friendly.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-detecting-incompatible-api-changes.md
+++ b/blogposts/gophercon-2019-detecting-incompatible-api-changes.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Detecting incompatible API changes"
+description: "Detecting whether your package's API is backwards-compatible is an important problem. You want to know whether your change could break existing users, or whether you're just adding new features. In this tutorial, I'll begin by discussing what we mean by API compatibility. I'll talk about how computing it is harder than it might seem at first, and I'll describe the algorithm I used to write my apidiff tool. Along the way, I'll provide tips on how to future-proof your own code against API breakage. Listeners will emerge with a new appreciation for and a deeper understanding of the Go language, as well as a sense of how to build tools like this one."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-14:00
+tags: [
+  gophercon
+]
+slug: gophercon-2019-detecting-incompatible-api-changes
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Jonathan Amsterdam
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Detecting whether your package's API is backwards-compatible is an important problem. You want to know whether your change could break existing users, or whether you're just adding new features. In this tutorial, I'll begin by discussing what we mean by API compatibility. I'll talk about how computing it is harder than it might seem at first, and I'll describe the algorithm I used to write my apidiff tool. Along the way, I'll provide tips on how to future-proof your own code against API breakage. Listeners will emerge with a new appreciation for and a deeper understanding of the Go language, as well as a sense of how to build tools like this one.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-dynamically-instrumenting-go-programs.md
+++ b/blogposts/gophercon-2019-dynamically-instrumenting-go-programs.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Dynamically instrumenting Go programs"
+description: "Ever wanted to ask arbitrary questions about your program while it is running with minimal impact on performance? In this talk, we go beyond static instrumentation and look at specific techniques for gathering information about your programs so that you can understand what your gophers are up to!"
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-14:00
+tags: [
+  gophercon
+]
+slug: gophercon-2019-dynamically-instrumenting-go-programs
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Jason Keene
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Ever wanted to ask arbitrary questions about your program while it is running with minimal impact on performance? In this talk, we go beyond static instrumentation and look at specific techniques for gathering information about your programs so that you can understand what your gophers are up to!
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-generics-in-go.md
+++ b/blogposts/gophercon-2019-generics-in-go.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Generics in Go"
+description: "Advantages and requirements for generics in Go."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-09:40
+tags: [
+  gophercon
+]
+slug: gophercon-2019-generics-in-go
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Ian Lance Taylor
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Advantages and requirements for generics in Go.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-get-going-with-webassembly.md
+++ b/blogposts/gophercon-2019-get-going-with-webassembly.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Get going with WebAssembly"
+description: "Curious about WebAssembly and how we can use it with Go? This tutorial will introduce the technology, show how to get started with WebAssembly and Go, discuss what is possible today and what will be possible tomorrow."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-11:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-get-going-with-webassembly
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Johan Brandhorst
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Curious about WebAssembly and how we can use it with Go? This tutorial will introduce the technology, show how to get started with WebAssembly and Go, discuss what is possible today and what will be possible tomorrow.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-go-linters-myths-and-best-practices.md
+++ b/blogposts/gophercon-2019-go-linters-myths-and-best-practices.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Go Linters: Myths and best practices"
+description: "Go contains over 50 different linters. For linter adepts, I'll reveal how to use their full power, as well as little-known tips and tricks to get ahead. For linters beginners, this presentation explains what they are, the benefit of their use, and the best way to introduce them into a workflow."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-14:00
+tags: [
+  gophercon
+]
+slug: gophercon-2019-go-linters-myths-and-best-practices
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Denis Isaev
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Go contains over 50 different linters. For linter adepts, I'll reveal how to use their full power, as well as little-known tips and tricks to get ahead. For linters beginners, this presentation explains what they are, the benefit of their use, and the best way to introduce them into a workflow.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-go-module-proxy-life-of-a-query.md
+++ b/blogposts/gophercon-2019-go-module-proxy-life-of-a-query.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Go Module Proxy: Life of a query"
+description: "The Go team has built a module mirror and checksum database, which adds reliability and security to the Go ecosystem. This talk discusses the technical details of authenticated module proxies, following the journey of a request through the go command, proxy, and checksum database."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-14:00
+tags: [
+  gophercon
+]
+slug: gophercon-2019-go-module-proxy-life-of-a-query
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Katie Hockman
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+The Go team has built a module mirror and checksum database, which adds reliability and security to the Go ecosystem. This talk discusses the technical details of authenticated module proxies, following the journey of a request through the go command, proxy, and checksum database.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-go-pls-stop-breaking-my-editor.md
+++ b/blogposts/gophercon-2019-go-pls-stop-breaking-my-editor.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Go, pls stop breaking my editor"
+description: "The Go community has built many amazing tools to improve the Go developer experience. However, when a maintainer disappears or a new Go release wreaks havoc, the Go development experience becomes frustrating and complicated. This talk will cover the details behind a new tool to solve these issues: gopls (pronounced 'go please'). This tool is currently in development by the Go team and community, and it will ultimately serve as the backend for your Go editor."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-11:20
+tags: [
+  gophercon
+]
+slug: gophercon-2019-go-pls-stop-breaking-my-editor
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Rebecca Stambler
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+The Go community has built many amazing tools to improve the Go developer experience. However, when a maintainer disappears or a new Go release wreaks havoc, the Go development experience becomes frustrating and complicated. This talk will cover the details behind a new tool to solve these issues: gopls (pronounced 'go please'). This tool is currently in development by the Go team and community, and it will ultimately serve as the backend for your Go editor.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-handling-go-errors.md
+++ b/blogposts/gophercon-2019-handling-go-errors.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Handling Go errors"
+description: "Let's talk about programmable errors and how you can design your own architecture that allows you to legibly master your system failures."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-11:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-handling-go-errors
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Marwan Sulaiman
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Let's talk about programmable errors and how you can design your own architecture that allows you to legibly master your system failures.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-how-i-write-http-web-services-after-eight-years.md
+++ b/blogposts/gophercon-2019-how-i-write-http-web-services-after-eight-years.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - How I write HTTP web services after eight years"
+description: "A look at how Mat Ryer builds web services after doing so for the past eight years. Extremely practical, tried and tested patterns that everybody can start using today."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-14:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-how-i-write-http-web-services-after-eight-years
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Mat Ryer
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+A look at how Mat Ryer builds web services after doing so for the past eight years. Extremely practical, tried and tested patterns that everybody can start using today.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-how-uber-go-es.md
+++ b/blogposts/gophercon-2019-how-uber-go-es.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - How Uber 'Go'es"
+description: "Maintaining a large codebase with maximum readability and minimal overhead is hard. This is the story of how Go went from a few enthusiastic Gophers to the most popular language for microservices at Uber. Learn where we failed, and how that led us to solutions that we think are pretty darn neat!"
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-09:50
+tags: [
+  gophercon
+]
+slug: gophercon-2019-how-uber-go-es
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Elena Morozova
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Maintaining a large codebase with maximum readability and minimal overhead is hard. This is the story of how Go went from a few enthusiastic Gophers to the most popular language for microservices at Uber. Learn where we failed, and how that led us to solutions that we think are pretty darn neat!
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-on-the-road-to-go-2.md
+++ b/blogposts/gophercon-2019-on-the-road-to-go-2.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - On the road to Go 2"
+description: "We're on the road to Go 2. But where exactly are we? Where are we headed? Come find out."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-09:10
+tags: [
+  gophercon
+]
+slug: gophercon-2019-on-the-road-to-go-2
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Russ Cox
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+We're on the road to Go 2. But where exactly are we? Where are we headed? Come find out.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-optimization-for-number-of-goroutines-using-feedback-control.md
+++ b/blogposts/gophercon-2019-optimization-for-number-of-goroutines-using-feedback-control.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Optimization for number of goroutines using feedback control"
+description: "The design for the number of concurrency is important to achieve both speed and stability. To give a good performance without depending on platform and load conditions, it’s desirable for the number to be dynamic and rapidly controlled. In this talk, I will propose an architecture to solve this by utilizing feedback control."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-14:00
+tags: [
+  gophercon
+]
+slug: gophercon-2019-optimization-for-number-of-goroutines-using-feedback-control
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Yusuke Miyake
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+The design for the number of concurrency is important to achieve both speed and stability. To give a good performance without depending on platform and load conditions, it’s desirable for the number to be dynamic and rapidly controlled. In this talk, I will propose an architecture to solve this by utilizing feedback control.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-optimizing-go-code-without-a-blindfold.md
+++ b/blogposts/gophercon-2019-optimizing-go-code-without-a-blindfold.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Optimizing Go Code without a blindfold"
+description: "Making code faster is exciting, and benchmarks in Go make that easy to do! Not really. Optimizing a program can be complex and requires careful consideration to do so properly. This session will demonstrate techniques and tools which are a must for any performance aficionado."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-11:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-optimizing-go-code-without-a-blindfold
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Daniel Martí
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Making code faster is exciting, and benchmarks in Go make that easy to do! Not really. Optimizing a program can be complex and requires careful consideration to do so properly. This session will demonstrate techniques and tools which are a must for any performance aficionado.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-pki-for-gophers.md
+++ b/blogposts/gophercon-2019-pki-for-gophers.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - PKI for Gophers"
+description: "TLS is easy, PKI is hard. Learn about Go primitives for generating certificate hierarchies, instrumenting mTLS, hardware backed keys, and public infrastructure like Let's Encrypt and Certificate Transparency. Along the way we'll discuss roots of trust for automated issuance, nuances of revocation, and encourage you to roll your own PKI."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-14:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-pki-for-gophers
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Eric Chiang
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+TLS is easy, PKI is hard. Learn about Go primitives for generating certificate hierarchies, instrumenting mTLS, hardware backed keys, and public infrastructure like Let's Encrypt and Certificate Transparency. Along the way we'll discuss roots of trust for automated issuance, nuances of revocation, and encourage you to roll your own PKI.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-portable-immediate-mode-gui-programs-for-mobile-and-desktop-in-100-go.md
+++ b/blogposts/gophercon-2019-portable-immediate-mode-gui-programs-for-mobile-and-desktop-in-100-go.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Portable, immediate mode GUI programs for mobile and desktop in 100% Go"
+description: "Gio is a new open source Go library for writing immediate mode GUI programs that run on all the major platforms: Android, iOS/tvOS, macOS, Linux, Windows. The talk will cover Gio's unusual design and how it achieves simplicity, portability and performance."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-10:50
+tags: [
+  gophercon
+]
+slug: gophercon-2019-portable-immediate-mode-gui-programs-for-mobile-and-desktop-in-100-go
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Elias Naur
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Gio is a new open source Go library for writing immediate mode GUI programs that run on all the major platforms: Android, iOS/tvOS, macOS, Linux, Windows. The talk will cover Gio's unusual design and how it achieves simplicity, portability and performance.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-small-is-going-big-go-on-microcontrollers.md
+++ b/blogposts/gophercon-2019-small-is-going-big-go-on-microcontrollers.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Small is going big: Go On microcontrollers"
+description: "TinyGo takes the Go programming language to the 'final frontier' where we could not go before... running directly on microcontrollers like Arduino and more! In this talk I will introduce TinyGo (http://tinygo.org) a new miniature version of the Go language that uses the LLVM compiler toolchain to create native code that can run directly even on the smallest of computing devices. This talk will feature live coding demos of flying objects!"
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-11:20
+tags: [
+  gophercon
+]
+slug: gophercon-2019-small-is-going-big-go-on-microcontrollers
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Ron Evans
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+TinyGo takes the Go programming language to the 'final frontier' where we could not go before... running directly on microcontrollers like Arduino and more! In this talk I will introduce TinyGo (http://tinygo.org) a new miniature version of the Go language that uses the LLVM compiler toolchain to create native code that can run directly even on the smallest of computing devices. This talk will feature live coding demos of flying objects!
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-socket-to-me-where-do-sockets-live-in-go.md
+++ b/blogposts/gophercon-2019-socket-to-me-where-do-sockets-live-in-go.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Socket to me: Where do Sockets live in Go?"
+description: "Have you ever used HTTP server functions surfaced by the net/http package? Or gone down a couple of network levels and used TCP and UDP Listeners? Sockets are the secret sauce underlying these networking tools in Go. While Go abstracts away sockets, there are circumstances where knowing about sockets and how to configure them is instrumental. This talk will explain the fundamentals of socket-level programming in Go, and how and where to use it."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-11:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-socket-to-me-where-do-sockets-live-in-go
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Gabbi Fisher
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Have you ever used HTTP server functions surfaced by the net/http package? Or gone down a couple of network levels and used TCP and UDP Listeners? Sockets are the secret sauce underlying these networking tools in Go. While Go abstracts away sockets, there are circumstances where knowing about sockets and how to configure them is instrumental. This talk will explain the fundamentals of socket-level programming in Go, and how and where to use it.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-the-athens-project-a-proxy-server-for-go-modules.md
+++ b/blogposts/gophercon-2019-the-athens-project-a-proxy-server-for-go-modules.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - The Athens project: A proxy server for Go modules"
+description: "Go 1.11 was a big release for all of us because we got a new package management system called modules built right into the go CLI. If you tried out vgo before 1.11, you'll be familiar with modules. There's some really cool stuff in there, but there's one piece that a lot of us missed that we need to pay special attention to: the download API."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-09:10
+tags: [
+  gophercon
+]
+slug: gophercon-2019-the-athens-project-a-proxy-server-for-go-modules
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Aaron Schlessinger
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Go 1.11 was a big release for all of us because we got a new package management system called modules built right into the go CLI. If you tried out vgo before 1.11, you'll be familiar with modules. There's some really cool stuff in there, but there's one piece that a lot of us missed that we need to pay special attention to: the download API.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-the-gopher-s-manual-of-style.md
+++ b/blogposts/gophercon-2019-the-gopher-s-manual-of-style.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - The Gopher's manual of style"
+description: "Our industry has borrowed ideas and practices from a range of industries to improve the design and production of software. In this talk, we'll look to the publishing industry for ways to improve software development for our industry and within the Go community."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-25T00:00-14:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-the-gopher-s-manual-of-style
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Kris Brandow
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Our industry has borrowed ideas and practices from a range of industries to improve the design and production of software. In this talk, we'll look to the publishing industry for ways to improve software development for our industry and within the Go community.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-tracking-inter-process-dependencies-using-static-analysis.md
+++ b/blogposts/gophercon-2019-tracking-inter-process-dependencies-using-static-analysis.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Tracking inter-process dependencies using static analysis"
+description: "Using a service-oriented architecture instead of a monolithic architecture adds flexibility but also increases complexity. How will we keep track of which parts of our system depend on each other? To help solve this problem, I've been working on a project to analyze Go code (using Go!) to detect inter-process dependencies in our system. In this talk, I'll give a brief introduction to the static analysis libraries I used and share a few tips about how to use them effectively. I'll discuss obstacles I encountered along the way and my attempts to overcome them."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-14:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-tracking-inter-process-dependencies-using-static-analysis
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Mike Seplowitz
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Using a service-oriented architecture instead of a monolithic architecture adds flexibility but also increases complexity. How will we keep track of which parts of our system depend on each other? To help solve this problem, I've been working on a project to analyze Go code (using Go!) to detect inter-process dependencies in our system. In this talk, I'll give a brief introduction to the static analysis libraries I used and share a few tips about how to use them effectively. I'll discuss obstacles I encountered along the way and my attempts to overcome them.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes.md
+++ b/blogposts/gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - Two Go programs, three different profiling techniques, in 50 minutes"
+description: "Go, being a relatively recent statically typed, compiled language, is known to produce efficient programs. But writing a program in Go is not sufficient for good performance."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-14:55
+tags: [
+  gophercon
+]
+slug: gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Dave Cheney
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Go, being a relatively recent statically typed, compiled language, is known to produce efficient programs. But writing a program in Go is not sufficient for good performance.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-what-got-us-here-won-t-get-us-there.md
+++ b/blogposts/gophercon-2019-what-got-us-here-won-t-get-us-there.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - What got us here, won't get us there"
+description: "There's never been a better time to adopt Go. The language is attracting more newcomers every day and by all accounts, its community has a lot to do with it. If, however, we want to retain what makes Go special beyond the language itself, we, as a community, must recognize and amplify what makes us great and address what threatens our unity."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-16:25
+tags: [
+  gophercon
+]
+slug: gophercon-2019-what-got-us-here-won-t-get-us-there
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Johnny Boursiquot
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+There's never been a better time to adopt Go. The language is attracting more newcomers every day and by all accounts, its community has a lot to do with it. If, however, we want to retain what makes Go special beyond the language itself, we, as a community, must recognize and amplify what makes us great and address what threatens our unity.
+
+---
+
+Liveblog content here.

--- a/blogposts/gophercon-2019-you-can-t-go-your-own-way-the-standardization-of-go-at-github.md
+++ b/blogposts/gophercon-2019-you-can-t-go-your-own-way-the-standardization-of-go-at-github.md
@@ -1,0 +1,24 @@
+---
+title: "GopherCon 2019 - You can't Go your own way: The standardization of Go at GitHub"
+description: "Ever feel like moving code bases, even in the same language, can feel like working at an entirely new company? Over the past year, GitHub has been working on standardizing its' usage of Go to mitigate issues like this. This talk will cover challenges faced and lessons learned throughout this process."
+author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+publishDate: 2019-07-26T00:00-10:50
+tags: [
+  gophercon
+]
+slug: gophercon-2019-you-can-t-go-your-own-way-the-standardization-of-go-at-github
+heroImage: /gophercon2019.png
+published: false
+---
+
+Presenter: Jessica Lucci
+
+Liveblogger: [$LIVEBLOGGER_NAME]($LIVEBLOGGER_URL)
+
+## Overview
+
+Ever feel like moving code bases, even in the same language, can feel like working at an entirely new company? Over the past year, GitHub has been working on standardizing its' usage of Go to mitigate issues like this. This talk will cover challenges faced and lessons learned throughout this process.
+
+---
+
+Liveblog content here.

--- a/website/src/pages/go.tsx
+++ b/website/src/pages/go.tsx
@@ -11,7 +11,9 @@ export default class GoList extends React.Component<any, any> {
     }
 
     public render(): JSX.Element | null {
-        const goPosts = this.props.data.allMarkdownRemark.edges
+        const goPosts = this.props.data.allMarkdownRemark.edges.filter(
+            (post: any) => post.node.frontmatter.published === true
+        )
 
         return (
             <Layout location={this.props.location}>
@@ -54,6 +56,7 @@ export const pageQuery = graphql`
                         tags
                         publishDate(formatString: "MMMM D, YYYY")
                         slug
+                        published
                     }
                     html
                     excerpt(pruneLength: 300)


### PR DESCRIPTION
Create all GopherCon 2019 liveblog posts so livebloggers can fork, change and make a PR to get the post live.

Also made Go liveblog posts respect the `published` frontmatter value.