### PR TITLE
Fix typos across sourcegraph about repository

### DIFF
--- a/blogposts/behaviors-of-channels.md
+++ b/blogposts/behaviors-of-channels.md
@@ -18,7 +18,7 @@ Note: This post was live-blogged at [dotGo 2017](https://www.dotgo.eu/). Let us 
 
 Writing a service for a TV, but the tv stream fails because you can't write logs anymore. To simulate this we set up a custom `io.Writer` to simulate problems that can happen called `device`. So we use the `log` package to log, but to our custom `io.Writer` `device`. When running the code the `device` fails and the whole app fails because the calls to `log.Println` are blocking.
 
-Bill then proceded to do live coding for a custom Logger which solves our problem, below is the code he wrote annotated with what he was explaining as he wrote it:
+Bill then proceeded to do live coding for a custom Logger which solves our problem, below is the code he wrote annotated with what he was explaining as he wrote it:
 
 <div class="src-snippet" data-file-path="test.go" data-commit="ad6f12f5071742201c61ea16f0a5d6e6f1dc17ec"></div>
 
@@ -50,7 +50,7 @@ func New(w io.Writer, cap int) *Logger {
 	l.wg.Add(1)
 	go func() {
 		// important to note everything we are doing is just the core
-		// langauge, not even the stdlib.
+		// language, not even the stdlib.
 		for v := range l.ch {
 			fmt.Fprintf(w, v)
 		}

--- a/blogposts/building-a-large-scale-multi-branded-web-app-on-gql-foundation.md
+++ b/blogposts/building-a-large-scale-multi-branded-web-app-on-gql-foundation.md
@@ -80,4 +80,4 @@ Also on the roadmap
 * Progressive web apps
     * This handles case of using the browser for your boarding pass, having terrible airport wfii and no data, and panicking right before your flight.
 * Persisted queries
-    * Saves bandwith, and therefore money for customers in many countries where data is expensive.
+    * Saves bandwidth, and therefore money for customers in many countries where data is expensive.

--- a/blogposts/github-universe-liveblog-innersource.md
+++ b/blogposts/github-universe-liveblog-innersource.md
@@ -18,7 +18,7 @@ Engineering leaders from Bloomberg, Walmart Labs, Line, HP, IBM, and GitHub talk
 
 “InnerSource” is a new term for something that programmers have been doing for a long time. It’s about openness, transparency, and increased efficiency. It’s easy to describe, hard to do, but if done right it can be transformative for your company’s processes and culture.
 
-Today, we hear from practioners on the forefront of adopting InnerSource for many different industries.
+Today, we hear from practitioners on the forefront of adopting InnerSource for many different industries.
 
 *   Panna Pavangadkar of **Bloomberg**, Global Head of Engineering Development Experience
 *   Yasuhiro Inami, iOS engineer of **Line**, one of the fastest growing social networks and messaging apps in Japan

--- a/blogposts/go-reliability-and-durability-at-dropbox-tammy-butow.md
+++ b/blogposts/go-reliability-and-durability-at-dropbox-tammy-butow.md
@@ -120,7 +120,7 @@ The biggest pain with Go that Tammy identified was in dealing with race conditio
 * The [Go data race detector](https://blog.golang.org/race-detector) doesn't always help. It's important to understand when it *won't* help you.
 * It's important to carefully design the way your Go program will access data concurrently.
 
-Dropbox hires engineers who care about reliability and durability, so this comes naturally to them (even though concurrency is perenially tough everywhere).
+Dropbox hires engineers who care about reliability and durability, so this comes naturally to them (even though concurrency is perennially tough everywhere).
 
 ---
 

--- a/blogposts/gophercon-2018-5-mistakes-c-c-devs-make-writing-go.md
+++ b/blogposts/gophercon-2018-5-mistakes-c-c-devs-make-writing-go.md
@@ -474,7 +474,7 @@ func connect(addr string) error {
             // return fmt.Errorf("failed to connect to %s: %v", err.Net, err)
             return errors.Wrapf(err, "failed to connect to %s", err.Net)
         default:
-            // return fmt.Errorf("unkown error: %v", err)
+            // return fmt.Errorf("unknown error: %v", err)
             return errors.Wrap(err, "unknown error")
         }
     }

--- a/blogposts/gophercon-2018-adventures-in-cgo-performance.md
+++ b/blogposts/gophercon-2018-adventures-in-cgo-performance.md
@@ -78,7 +78,7 @@ comment was written.
 ## Recommendations
 
 Batch your CGO calls. You should know this going into it, since it can
-fundementally affect your design. Additionally once you cross the boundary,
+fundamentally affect your design. Additionally once you cross the boundary,
 try to do as much on the other side as you can. So for go => "C" do as much as
 you can in a single "C" call. Similarly for "C" => go do as much as you can in
 a single go call. Even more so since the overhead is much higher.

--- a/blogposts/gophercon-2018-becoming-a-go-contributor.md
+++ b/blogposts/gophercon-2018-becoming-a-go-contributor.md
@@ -159,7 +159,7 @@ Just because commits are small don;t mean they aren't important. It's a good way
 
 This is very common. Small commits are important because they open the door to larger ownership over the codebase.
 
-## Practice commiting
+## Practice committing
 
 bit.ly/goscratch
 

--- a/blogposts/gophercon-2018-c-l-eye-catching-user-interfaces.md
+++ b/blogposts/gophercon-2018-c-l-eye-catching-user-interfaces.md
@@ -71,7 +71,7 @@ which has the following special characters:
 * `-[3]*` Left justify and pad by the value of arg 3
 * `[2]s` Print the string value of arg 2 (e.g. "====")
 
-If we were resizing the progress bar based on the size of ther terminal, we could pass this in as a variable.
+If we were resizing the progress bar based on the size of their terminal, we could pass this in as a variable.
 
 __Demo 2: Unicode__
 

--- a/blogposts/gophercon-2018-from-prototype-to-production-lessons-from-building-and.md
+++ b/blogposts/gophercon-2018-from-prototype-to-production-lessons-from-building-and.md
@@ -72,7 +72,7 @@ the system it is now in production.
 Some notable tools used in the ad-server infrastructure:
 - Apache Thrift for all RPCs. Thrift has been around since 2007, and Reddit has been using this since the very beginning. Every system Reddit builds must be able to talk thrift.
 - RocksDB for datastorage. It's an OSS key-value store built by Facebook. It is an embeddable data store, it avoids network hop, and is optimized for high reads and writes.
-- They also decided to use Go as the main backend language. It is quite an obvious choice in hindisght. This is the first time that Reddit has used Go in production. Prior to this, it's been mostly Python and Java at Reddit. The team wanted to make sure that Go would be a first class citizen in the set of languages Reddit used, and supported everything Reddit needed.
+- They also decided to use Go as the main backend language. It is quite an obvious choice in hindsight. This is the first time that Reddit has used Go in production. Prior to this, it's been mostly Python and Java at Reddit. The team wanted to make sure that Go would be a first class citizen in the set of languages Reddit used, and supported everything Reddit needed.
 
 
 
@@ -88,7 +88,7 @@ A brief overview of how it works:
 - After receiving the response from the enrichment service, ad selector selects the add, and returns the ad to reddit.com to be shown to the user. It also sends the response to Kafka.
 - Once the ad is shown to users, some post-processing needs to occur. The client sends an event HTTP request to the **event tracker** service. This event serves as confirmation that the ad got served. This event notification also gets shelled out to Kafka.
 - Kafka provides data to two Apache Spark jobs:
-  - The **Event Stats** streaming job is always running, and it writes to the enrichment service to provide infromation that is used for learning to select better ads.
+  - The **Event Stats** streaming job is always running, and it writes to the enrichment service to provide information that is used for learning to select better ads.
   - There is also the **Pacing** loop, which involves the Pacing Spark job. This involves a streaming job that counts how many ads have been shown for each advertiser, and and another job that makes sure advertisements are shown optimally.
 
 In this architecture, the Go services are:
@@ -161,9 +161,9 @@ There are some things to note about this architecture. The center service has 2 
 
 There are several middleware layers: tracing, logging, and metrics. Finally, the Thrift transport is at the top level. This structure makes it easy to make changes. For example, if they wanted to change the transport layer from Thrift to gRPC, they'd only need to change the top layer.
 
-Using Go-Kit was beneficial because it gave the team a good exmaple on how to structure Go code. They didn't have experience in this before, so using Go-Kit was helpful for understanding the typical structure for Go services.
+Using Go-Kit was beneficial because it gave the team a good example on how to structure Go code. They didn't have experience in this before, so using Go-Kit was helpful for understanding the typical structure for Go services.
 
-**Lesson 1: Use a framework/toolkit.** Not neccesarily for everything you use Go for, but for production services that require metrics, logging, and so on, use libraries that have solved the problem rather than trying to do it yourself.
+**Lesson 1: Use a framework/toolkit.** Not necessarily for everything you use Go for, but for production services that require metrics, logging, and so on, use libraries that have solved the problem rather than trying to do it yourself.
 
 #### Problem 2: How to roll out the new system safely and quickly?
 
@@ -265,7 +265,7 @@ Rapid iteration and complex business logic can lead to performance issues. The a
 Load testing using [bender](https://github.com/pinterest/bender):
 ![image](https://user-images.githubusercontent.com/16265452/44771811-5bfb3a00-ab29-11e8-995d-4ad98186ca70.png)
 
-This is what using you'd get in repsonse from Bender:
+This is what using you'd get in response from Bender:
 ![image](https://user-images.githubusercontent.com/16265452/44771832-6a495600-ab29-11e8-814f-82700d02f154.png)
 
 Load testing is really useful for testing changes under heavy load, and lets developers optimize new features for high load before pushing to production.

--- a/blogposts/gophercon-2018-painting-with-light.md
+++ b/blogposts/gophercon-2018-painting-with-light.md
@@ -95,7 +95,7 @@ Trying to create more sophisticated renderings, he ran into two obstacles that t
 
 ![snapseed](https://user-images.githubusercontent.com/16265452/44746600-0cd0ed00-aac8-11e8-902f-623ab4d608bc.jpg)
 
-One cool thing about the alogrithm is that it's "embarassingly parallel", so he scaled up to 10 workers. We'll revisit this at the end of the talk.
+One cool thing about the algorithm is that it's "embarassingly parallel", so he scaled up to 10 workers. We'll revisit this at the end of the talk.
 
 ## How to build a path tracer
 
@@ -151,7 +151,7 @@ That's where Monte Carlo integration comes back into the scene. The Monte Carlo 
 - Add them all up and **average** them
 - That's probably **close** to the real answer
 
-Combining the path tracing alogrithm and Monte Carlo integration yields an image like this:
+Combining the path tracing algorithm and Monte Carlo integration yields an image like this:
 
 ![image](https://user-images.githubusercontent.com/16265452/44736745-39c3d680-aaad-11e8-8b9c-4bad240cae0c.png)
 
@@ -193,7 +193,7 @@ type Direction Vector3
 ```
 
 Creating explicit types for Units, Direction, and Energy, which were all represented by Vector3s before helped find tons of bugs. It also helped performance a ton because he got rid of unnecessary work he was doing because of type confusion. He got rid of unnecessary conversions when he was unsure of the type, and similar issues.
-Ultimately, he found ways to get help from the complier.
+Ultimately, he found ways to get help from the compiler.
 
 The original function signature above would turn into something like this, which is much easier to read:
 

--- a/blogposts/gophercon-2019-how-uber-go-es.md
+++ b/blogposts/gophercon-2019-how-uber-go-es.md
@@ -122,7 +122,7 @@ structure](/gophercon-2019/gophercon-2019-uber-code-structure.jpg "Uber's
 divisions of services into transports, controllers, repositories, and
 gateways")
 
-## Swtiching to a monorepo
+## Switching to a monorepo
 
 Uber was initially using many repositories for its services. The boundaries
 created by all the separately-maintained repos made coordination difficult,

--- a/blogposts/graphql-at-twitter.md
+++ b/blogposts/graphql-at-twitter.md
@@ -194,7 +194,7 @@ Philosophically, GraphQL and Strato are very similar. Strato has many of the sam
 
 Strato has existed at Twitter much longer than GraphQL, and is used to power the GraphQL API. It integrates tightly with Twitter's Thrift services, and in combination with the GraphQL API, gives them **end-to-end types from database to the client**.  It is similar in spirit to many of the other technologies presented at this conference that stitch together multiple data sources into a single source of truth. This approach is extremely powerful.
 
-For example, The Strato team has made it possible to add data to the Strato Catalog with a simple config file, and made deploys automatic. This allows engineers to have much more power and flexibility by reducing coordination needed between teams. This is an example Strato column that would store the brithdays of Twitter users in a database. It's just a config:
+For example, The Strato team has made it possible to add data to the Strato Catalog with a simple config file, and made deploys automatic. This allows engineers to have much more power and flexibility by reducing coordination needed between teams. This is an example Strato column that would store the birthdays of Twitter users in a database. It's just a config:
 
 <img alt="Ashworth-3" src="//images.contentful.com/le3mxztn6yoo/2bKiqAhmKooYoyg4amKCSU/8ed0a5520b0ad8f5e629916f1513a277/Screen_Shot_2017-11-10_at_12.43.30_PM.png" class="flex center"/>
 

--- a/blogposts/how-we-run-end-to-end-e2e-tests-in-buildkite-ci.md
+++ b/blogposts/how-we-run-end-to-end-e2e-tests-in-buildkite-ci.md
@@ -86,7 +86,7 @@ Being run against an actual deployment, end-to-end tests are subject to latency,
 
 Mocha’s `--retries` option is also helpful to prevent flakiness, but be aware that this might hide actual failures that only happen a fraction of the time.
 
-To make sure end-to-end tests are not accidently broken, we use special CSS classes prefixed with `e2e` for elements that are asserted on in tests.
+To make sure end-to-end tests are not accidentally broken, we use special CSS classes prefixed with `e2e` for elements that are asserted on in tests.
 
 ## Giving insight into failures with screenshots
 

--- a/blogposts/runtime-generated-typesafe-and-declarative-pick-any-three.md
+++ b/blogposts/runtime-generated-typesafe-and-declarative-pick-any-three.md
@@ -47,7 +47,7 @@ We brag about language features. Take these examples:
 		my-list))
 ```
 
-"My langauge has generics"
+"My language has generics"
 ```
 case class ListNode(+T)(h: T, t: ListNode[T]) {
 	def head: T = h

--- a/blogposts/simulating-a-real-world-system-in-go.md
+++ b/blogposts/simulating-a-real-world-system-in-go.md
@@ -131,7 +131,7 @@ But why does throughput flatten after 4 CPUs?
 
 The first coffee runs on CPU1, taking 1 millisecond per stage. The second coffee waits 1 millisecond to use the grinder, then can proceed in parallel on CPU2. The third coffee waits again for the grinder and then proceeds on CPU3, and the same for the fourth coffee on CPU4.
 
-What about the fifth coffee? By the time the grinder is free, CPU1 is free again, so it can run there. It can't start sooner beacuse the grinder would be in use. This system has a maximum of 4 CPUs in parallel because of contention on the grinder, which is why the throughput of this system flattens at 1000 lattes per second: 4 CPUs running at 250 lattes per second.
+What about the fifth coffee? By the time the grinder is free, CPU1 is free again, so it can run there. It can't start sooner because the grinder would be in use. This system has a maximum of 4 CPUs in parallel because of contention on the grinder, which is why the throughput of this system flattens at 1000 lattes per second: 4 CPUs running at 250 lattes per second.
 
 Given this structural limit, how can we increase the performance of our system? When the critical resources you have are running at capactiy, the solution is to have more resources. So, having a second set of machines or a second coffee shop means more people could make coffee simultaneously.
 
@@ -211,7 +211,7 @@ When we look at the performance of this pipeline, it looks a lot like the fine-g
 The latency is the time it takes to run each of the 4 stages, so it makes sense that that would remain the same in the locking and pipeline implementations. But the pipeline’s throughput is less because it is not utilizing the three contended machines as efficiently.
 
 The real world analogy:
-Consider what happens when the person using the grinder finishes grinding the beans.  In the locking implementation, the person steps away and waits for the espressso machine, and someone else can use the grinder.
+Consider what happens when the person using the grinder finishes grinding the beans.  In the locking implementation, the person steps away and waits for the espresso machine, and someone else can use the grinder.
 
 But in the pipeline implementation, the person grinding beans has to wait to hand off the grounds to the person making espresso before they can start the next grind. If the second person is busy making espresso, the first person just stands there, holding out the grounds. This is a blocked channel send in our implementation.
 

--- a/blogposts/the-graphql-stack-how-everything-fits-together.md
+++ b/blogposts/the-graphql-stack-how-everything-fits-together.md
@@ -41,7 +41,7 @@ It's now easier to write a GraphQL server in any language (JS, Scala, Elixir, Py
 
 The GraphQL duality:
 * client sends detailed data reqs
-* Server provides felxible, performant capabilities
+* Server provides flexible, performant capabilities
 
 The GraphQL Query is a unit of data fetching
 1. Send all of the the requirements for a unit of your UI in ONE request

--- a/website/README.md
+++ b/website/README.md
@@ -48,7 +48,7 @@ Incorrect: \[example\]\(https://about.sourcegraph.com/example).
 
 Blog post images (both hero and inline) belong in the `/website/static/blog/` directory, and the path to the image in your post is `/blog/your-image.png`.
 
-Images should be sized and compressed appropriately to optimize the file size without noticeably degrading the image quality. [ImageOptim](https://imageoptim.com/) is a good (and free) image compresion tool.
+Images should be sized and compressed appropriately to optimize the file size without noticeably degrading the image quality. [ImageOptim](https://imageoptim.com/) is a good (and free) image compression tool.
 
 ### Previewing blog post drafts
 


### PR DESCRIPTION
:blue_heart: Fix typos across sourcegraph **about** repository

### Fixed files :wrench: 

<details><summary>See all fixed files</summary>
<p>

```
about/blogposts/behaviors-of-channels.md:21:10: "proceded" is a misspelling of "proceeded"
about/blogposts/behaviors-of-channels.md:53:5: "langauge" is a misspelling of "language"
about/blogposts/building-a-large-scale-multi-branded-web-app-on-gql-foundation.md:83:12: "bandwith" is a misspelling of "bandwidth"
about/blogposts/github-universe-liveblog-innersource.md:21:20: "practioners" is a misspelling of "practitioners"
about/blogposts/go-reliability-and-durability-at-dropbox-tammy-butow.md:123:127: "perenially" is a misspelling of "perennially"
about/blogposts/gophercon-2018-5-mistakes-c-c-devs-make-writing-go.md:477:34: "unkown" is a misspelling of "unknown"
about/blogposts/gophercon-2018-adventures-in-cgo-performance.md:81:0: "fundementally" is a misspelling of "fundamentally"
about/blogposts/gophercon-2018-becoming-a-go-contributor.md:162:12: "commiting" is a misspelling of "committing"
about/blogposts/gophercon-2018-c-l-eye-catching-user-interfaces.md:74:58: "ther" is a misspelling of "their"
about/blogposts/gophercon-2018-from-prototype-to-production-lessons-from-building-and.md:75:93: "hindisght" is a misspelling of "hindsight"
about/blogposts/gophercon-2018-from-prototype-to-production-lessons-from-building-and.md:91:108: "infromation" is a misspelling of "information"
about/blogposts/gophercon-2018-from-prototype-to-production-lessons-from-building-and.md:164:60: "exmaple" is a misspelling of "example"
about/blogposts/gophercon-2018-from-prototype-to-production-lessons-from-building-and.md:166:43: "neccesarily" is a misspelling of "necessarily"
about/blogposts/gophercon-2018-from-prototype-to-production-lessons-from-building-and.md:268:32: "repsonse" is a misspelling of "response"
about/blogposts/gophercon-2018-painting-with-light.md:98:25: "alogrithm" is a misspelling of "algorithm"
about/blogposts/gophercon-2018-painting-with-light.md:154:27: "alogrithm" is a misspelling of "algorithm"
about/blogposts/gophercon-2018-painting-with-light.md:196:47: "complier" is a misspelling of "compiler"
about/blogposts/gophercon-2019-how-uber-go-es.md:125:3: "Swtiching" is a misspelling of "Switching"
about/blogposts/graphql-at-twitter.md:197:302: "brithdays" is a misspelling of "birthdays"
about/blogposts/how-we-run-end-to-end-e2e-tests-in-buildkite-ci.md:89:38: "accidently" is a misspelling of "accidentally"
about/blogposts/runtime-generated-typesafe-and-declarative-pick-any-three.md:50:4: "langauge" is a misspelling of "language"
about/blogposts/simulating-a-real-world-system-in-go.md:134:125: "beacuse" is a misspelling of "because"
about/blogposts/simulating-a-real-world-system-in-go.md:214:157: "espressso" is a misspelling of "espresso"
about/blogposts/the-graphql-stack-how-everything-fits-together.md:44:18: "felxible" is a misspelling of "flexible"
about/website/README.md:51:191: "compresion" is a misspelling of "compression"
```

</p>
</details>

**FYI:** I used [**Go Spellchecker**](https://github.com/liamzdenek/go-spellcheck) :smile_cat: