### PR TITLE
Mark three unpublished 2019 liveblogs as published

### DIFF
--- a/blogposts/gophercon-2019-death-by-three-thousand-timers-streaming-video-on-demand-for-cable-tv.md
+++ b/blogposts/gophercon-2019-death-by-three-thousand-timers-streaming-video-on-demand-for-cable-tv.md
@@ -2,13 +2,13 @@
 title: "GopherCon 2019 - Death by three thousand timers: Streaming video-on-demand for Cable TV"
 description: "Can Go handle soft real-time applications? Learn about the challenges my team overcame to deliver video-on-demand MPEG streams to millions of cable TV customers using pure Go. Along the way we'll dig deeper into how Go manages timers and goroutine scheduling."
 author: Larry Clapp for the GopherCon 2019 Liveblog
-publishDate: 2019-07-26T00:00-11:55
+publishDate: 2019-07-29T15:14-11:55
 tags: [
   gophercon
 ]
 slug: gophercon-2019-death-by-three-thousand-timers-streaming-video-on-demand-for-cable-tv
 heroImage: https://about.sourcegraph.com/gophercon2019.png
-published: false
+published: true
 ---
 
 Presenter: Chris Hines

--- a/blogposts/gophercon-2019-go-linters-myths-and-best-practices.md
+++ b/blogposts/gophercon-2019-go-linters-myths-and-best-practices.md
@@ -2,13 +2,13 @@
 title: "GopherCon 2019 - Go Linters: Myths and best practices"
 description: "Go contains over 50 different linters. For linter adepts, I'll reveal how to use their full power, as well as little-known tips and tricks to get ahead. For linters beginners, this presentation explains what they are, the benefit of their use, and the best way to introduce them into a workflow."
 author: John Reese for the GopherCon 2019 Liveblog
-publishDate: 2019-07-26T00:00-14:00
+publishDate: 2019-07-29T15:15-14:00
 tags: [
   gophercon
 ]
 slug: gophercon-2019-go-linters-myths-and-best-practices
 heroImage: https://about.sourcegraph.com/gophercon2019.png
-published: false
+published: true
 ---
 
 Presenter: Denis Isaev

--- a/blogposts/gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes.md
+++ b/blogposts/gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes.md
@@ -2,13 +2,13 @@
 title: "GopherCon 2019 - Two Go programs, three different profiling techniques, in 50 minutes"
 description: "Go, being a relatively recent statically typed, compiled language, is known to produce efficient programs. But writing a program in Go is not sufficient for good performance."
 author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
-publishDate: 2019-07-26T00:00-14:55
+publishDate: 2019-07-29T15:18-14:55
 tags: [
   gophercon
 ]
 slug: gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes
 heroImage: https://about.sourcegraph.com/gophercon2019.png
-published: false
+published: true
 ---
 
 Presenter: Dave Cheney

--- a/blogposts/gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes.md
+++ b/blogposts/gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes.md
@@ -1,7 +1,7 @@
 ---
 title: "GopherCon 2019 - Two Go programs, three different profiling techniques, in 50 minutes"
 description: "Go, being a relatively recent statically typed, compiled language, is known to produce efficient programs. But writing a program in Go is not sufficient for good performance."
-author: $LIVEBLOGGER_NAME for the GopherCon 2019 Liveblog
+author: Anton Velikanov for the GopherCon 2019 Liveblog
 publishDate: 2019-07-29T15:18-14:55
 tags: [
   gophercon


### PR DESCRIPTION
blogposts/gophercon-2019-death-by-three-thousand-timers-streaming-video-on-demand-for-cable-tv.md
blogposts/gophercon-2019-go-linters-myths-and-best-practices.md
blogposts/gophercon-2019-two-go-programs-three-different-profiling-techniques-in-50-minutes.md