### PR TITLE
Meta fixes for blog pages

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -33,7 +33,7 @@ export default class Header extends React.Component<HeaderProps, any> {
                     <div className="gophercon">
                         <Link to="/go">
                             <span className="go-gopher" />
-                            Checkout the official <u>GopherCon Liveblog</u> proudly
+                            Check out the official <u>GopherCon Liveblog</u> proudly
                             hosted by Sourcegraph.
                         </Link>
                     </div>

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -5,6 +5,7 @@ import { ProductPopoverButton } from './ProductPopover'
 
 interface HeaderProps {
     isHome?: boolean
+    isBlog?: boolean
     isProductPage?: boolean
     minimal?: boolean
 }
@@ -28,7 +29,7 @@ export default class Header extends React.Component<HeaderProps, any> {
     public render(): JSX.Element | null {
         return (
             <>
-                {this.props.isHome && (
+                {(this.props.isHome || this.props.isBlog) && (
                     <div className="gophercon">
                         <Link to="/go">
                             <span className="go-gopher" />

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -8,7 +8,7 @@ interface LayoutProps {
     meta?: {
         title?: string
         description?: string
-        image: string
+        image?: string
         icon?: string
     }
     location: {
@@ -21,7 +21,7 @@ interface LayoutProps {
 export default class Layout extends React.PureComponent<LayoutProps> {
     public render(): JSX.Element | null {
         const defaultMetaProps: LayoutProps['meta'] = {
-            title: 'Sourcegraph',
+            title: 'Sourcegraph - Code search and intelligence',
             description:
                 'Sourcegraph is a free, self-hosted code search and intelligence server that helps developers find, review, understand, and debug code. Use it with any Git code host for teams from 1 to 10,000+.',
             image: 'https://about.sourcegraph.com/sourcegraph-mark.png',
@@ -29,13 +29,14 @@ export default class Layout extends React.PureComponent<LayoutProps> {
         }
         const pathname = this.props.location.pathname
         const isHome = pathname === '/'
+        const isBlog = pathname === '/blog'
         const isProductPage = pathname.startsWith('/product/')
-        const metaProps = this.props.meta || defaultMetaProps
+        const metaProps = {...defaultMetaProps, ...this.props.meta}
 
         return (
             <div className="flex flex-column fill-height">
                 <Helmet>
-                    <title>Sourcegraph - Code search and intelligence</title>
+                    <title>{metaProps.title}</title>
                     <meta name="twitter:title" content={metaProps.title} />
                     <meta name="twitter:site" content="@srcgraph" />
                     <meta name="twitter:image" content={metaProps.image} />
@@ -54,7 +55,7 @@ export default class Layout extends React.PureComponent<LayoutProps> {
 
                     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet" />
                 </Helmet>
-                <Header isHome={isHome} isProductPage={isProductPage} minimal={this.props.minimal} />
+                <Header isHome={isHome} isBlog={isBlog} isProductPage={isProductPage} minimal={this.props.minimal} />
                 <section className="d-flex flex-column fill-height">{this.props.children}</section>
                 <Footer minimal={this.props.minimal} />
             </div>

--- a/website/src/pages/blog.tsx
+++ b/website/src/pages/blog.tsx
@@ -1,6 +1,5 @@
 import { graphql } from 'gatsby'
 import * as React from 'react'
-import { Helmet } from 'react-helmet'
 import BlogHeadLinks from '../components/BlogHeadLinks'
 import BlogPosts from '../components/BlogPosts'
 import Layout from '../components/Layout'
@@ -14,15 +13,19 @@ export default class BlogList extends React.Component<any, any> {
         const markdownBlogPosts = this.props.data.allMarkdownRemark.edges.filter(
             (post: any) => post.node.frontmatter.published === true
         )
+        const metaProps = {
+            title: 'Sourcegraph blog',
+            description: 'Plain text - the official Sourcegraph blog.',
+        }
 
         return (
-            <Layout location={this.props.location}>
+            <Layout
+                location={this.props.location}
+                meta={{
+                    title: metaProps.title,
+                    description: metaProps.description
+            }}>
                 <div className="blog bg-white text-dark">
-                    <Helmet>
-                        <title>Sourcegraph blog</title>
-                        <meta name="twitter:title" content="Sourcegraph blog" />
-                        <meta property="og:title" content="Sourcegraph blog" />
-                    </Helmet>
                     <div className="blog blog__head">
                         <h1>Sourcegraph blog</h1>
                         <BlogHeadLinks />
@@ -44,13 +47,13 @@ export const pageQuery = graphql`
                 node {
                     frontmatter {
                         title
+                        description
                         heroImage
                         author
                         tags
                         publishDate(formatString: "MMMM D, YYYY")
                         slug
                         published
-                        description
                     }
                     html
                     excerpt(pruneLength: 300)

--- a/website/src/pages/go.tsx
+++ b/website/src/pages/go.tsx
@@ -1,8 +1,6 @@
 import { graphql } from 'gatsby'
 import * as _ from 'lodash'
 import * as React from 'react'
-import Helmet from 'react-helmet'
-import BlogHeadLinks from '../components/BlogHeadLinks'
 import BlogPosts from '../components/BlogPosts'
 import Layout from '../components/Layout'
 export default class GoList extends React.Component<any, any> {
@@ -21,26 +19,27 @@ export default class GoList extends React.Component<any, any> {
     }
 
     public render(): JSX.Element | null {
+        const metaProps = {
+            title: 'GopherCon and dotGo Liveblogs by Sourcegraph',
+            description: 'Checkout the official GopherCon 2019 Liveblog proudly hosted by Sourcegraph.',
+            image: 'https://about.sourcegraph.com/gophercon-2019/gophercon-2019-banner.png'
+        }
         const goPosts = this.props.data.allMarkdownRemark.edges.filter(
             (post: any) => post.node.frontmatter.published === true
         )
 
         return (
-            <Layout location={this.props.location}>
+            <Layout
+            location={this.props.location}
+            meta={{
+                title: metaProps.title,
+                description: metaProps.description,
+                image: metaProps.image
+            }}>
                 <div className="gray-9 bg-white text-dark">
-                    <Helmet>
-                        <title>GopherCon and dotGo liveblogs by Sourcegraph</title>
-                        <meta name="twitter:title" content="GopherCon and dotGo liveblogs by Sourcegraph" />
-                        <meta property="og:title" content="GopherCon and dotGo liveblogs by Sourcegraph" />
-                        <meta
-                            property="og:image"
-                            content="https://about.sourcegraph.com/gophercon-2019/gophercon-2019-banner.png"
-                        />
-                    </Helmet>
-
                     <div>
                         <div className="blog blog__head">
-                            <h1 class="pb-4 sr-only">GopherCon 2019 liveblog</h1>
+                            <h1 class="pb-4 sr-only">{metaProps.title}</h1>
                             <div className="container subscription-grid">
                                 <div className="grid-item-1 flex-0 rounded rounded-lg py-4 px-6 bg-white h-100">
                                     <h4>Subscribe to the GopherCon 2019 Liveblog</h4>
@@ -52,7 +51,7 @@ export default class GoList extends React.Component<any, any> {
                                     </div>
                                 </div>
                                 <div className="grid-item-2">
-                                    <img className="grid-image" src="/gophercon-2019/gophercon-thumbnail.png"></img>
+                                    <img className="grid-image" src="/gophercon-2019/gophercon-thumbnail.png" alt="GopherCon 2019 Liveblog proudly hosted by Sourcegraph"></img>
                                 </div>
                             </div>
                         </div>

--- a/website/src/pages/go.tsx
+++ b/website/src/pages/go.tsx
@@ -21,7 +21,7 @@ export default class GoList extends React.Component<any, any> {
     public render(): JSX.Element | null {
         const metaProps = {
             title: 'GopherCon and dotGo Liveblogs by Sourcegraph',
-            description: 'Checkout the official GopherCon 2019 Liveblog proudly hosted by Sourcegraph.',
+            description: 'Check out the official GopherCon 2019 Liveblog proudly hosted by Sourcegraph.',
             image: 'https://about.sourcegraph.com/gophercon-2019/gophercon-2019-banner.png'
         }
         const goPosts = this.props.data.allMarkdownRemark.edges.filter(

--- a/website/src/pages/graphql.tsx
+++ b/website/src/pages/graphql.tsx
@@ -1,29 +1,32 @@
 import { graphql } from 'gatsby'
 import * as _ from 'lodash'
 import * as React from 'react'
-import Helmet from 'react-helmet'
-import BlogHeadLinks from '../components/BlogHeadLinks'
 import BlogPosts from '../components/BlogPosts'
 import Layout from '../components/Layout'
+
 export default class GraphQLSummitList extends React.Component<any, any> {
     constructor(props: any) {
         super(props)
     }
 
     public render(): JSX.Element | null {
+        const metaProps = {
+            title: 'GraphQL Summit 2017 Liveblog',
+            description: 'Checkout the official GraphQL Summit 2017 Liveblog proudly hosted by Sourcegraph.'
+        }
         const graphqlPosts = this.props.data.allMarkdownRemark.edges
 
         return (
-            <Layout location={this.props.location}>
+            <Layout
+            location={this.props.location}
+            meta={{
+                title: metaProps.title,
+                description: metaProps.description,
+            }}>
                 <div className="gray-9 bg-white text-dark">
-                    <Helmet>
-                        <title>GraphQL Summit 2017 liveblog by Sourcegraph</title>
-                        <meta name="twitter:title" content="GraphQL Summit 2017 liveblog by Sourcegraph" />
-                        <meta property="og:title" content="GraphQL Summit 2017 liveblog by Sourcegraph" />
-                    </Helmet>
                     <div>
                         <div className="blog blog__head">
-                            <h1>GraphQL Summit 2017 liveblog</h1>
+                            <h1>GraphQL Summit 2017 Liveblog</h1>
                         </div>
                         <BlogPosts blogType="graphql" posts={graphqlPosts} />
                     </div>
@@ -43,6 +46,7 @@ export const pageQuery = graphql`
                 node {
                     frontmatter {
                         title
+                        description
                         heroImage
                         author
                         tags

--- a/website/src/pages/graphql.tsx
+++ b/website/src/pages/graphql.tsx
@@ -12,7 +12,7 @@ export default class GraphQLSummitList extends React.Component<any, any> {
     public render(): JSX.Element | null {
         const metaProps = {
             title: 'GraphQL Summit 2017 Liveblog',
-            description: 'Checkout the official GraphQL Summit 2017 Liveblog proudly hosted by Sourcegraph.'
+            description: 'Check out the official GraphQL Summit 2017 Liveblog proudly hosted by Sourcegraph.'
         }
         const graphqlPosts = this.props.data.allMarkdownRemark.edges
 

--- a/website/src/templates/blogPostTemplate.tsx
+++ b/website/src/templates/blogPostTemplate.tsx
@@ -1,7 +1,6 @@
 import { graphql } from 'gatsby'
 import { Link } from 'gatsby'
 import * as React from 'react'
-import { Helmet } from 'react-helmet'
 import Layout from '../components/Layout'
 import SocialLinks from '../components/SocialLinks'
 import { eventLogger } from '../EventLogger'
@@ -32,10 +31,10 @@ export default class ContentfulTemplate extends React.Component<any, any> {
     public render(): JSX.Element | null {
         const md = this.props.data.markdownRemark
         const title = md.frontmatter.title
+        const description = md.frontmatter.description ? md.frontmatter.description : md.excerpt
         const author = md.frontmatter.author
         const content = md.html
         const date = md.frontmatter.publishDate
-        const excerpt = md.excerpt
         const tags = md.frontmatter.tags || ''
         const image = md.frontmatter.heroImage
             ? `${md.frontmatter.heroImage}`
@@ -54,26 +53,14 @@ export default class ContentfulTemplate extends React.Component<any, any> {
             readMoreLink = '/blog'
         }
         const meta = {
+            title,
             image,
+            description
         }
         return (
             <Layout location={this.props.location} meta={meta}>
                 <div className="bg-white text-dark">
-                    <Helmet>
-                        <title>{title}</title>
-                        <meta property="og:title" content={title} />
-                        <meta property="og:url" content={`https://about.sourcegraph.com/${slug}`} />
-                        <meta property="og:description" content={excerpt} />
-                        <meta property="og:image" content={image} />
-                        <meta property="og:type" content="website" />
 
-                        <meta name="twitter:site" content="@srcgraph" />
-                        <meta name="twitter:card" content="summary_large_image" />
-                        <meta name="twitter:title" content={title} />
-                        <meta name="twitter:image" content={image} />
-                        <meta name="twitter:description" content={excerpt} />
-                        <meta name="description" content={excerpt} />
-                    </Helmet>
                     <div className="blog-post">
                         <div className="blog-post__wrapper">
                             <section className="blog-post__title">
@@ -110,6 +97,7 @@ export const pageQuery = graphql`
         markdownRemark(fields: { slug: { eq: $fileSlug } }) {
             frontmatter {
                 title
+                description
                 heroImage
                 author
                 tags


### PR DESCRIPTION
 - Layout.tsx: Page title is now settable and passed in meta object is now merged with default meta props
 - Header.tsx: Header link to liveblog now shown on the blog index page
 - Removed `Helmet` usage from blog list and detail pages and used meta parameter instead