### PR TITLE
Update pricing page to properly reflect search notificaitons

### DIFF
--- a/website/src/components/PricingTable.tsx
+++ b/website/src/components/PricingTable.tsx
@@ -131,7 +131,7 @@ const DATA: PricingItemCategory[] = [
         title: 'Code alerts & automation',
         items: [
             { name: 'Saved searches', plans: ENTERPRISE_PLAN },
-            { name: 'Email, Slack, and webhook notifications', plans: ENTERPRISE_PLAN },
+            { name: 'Email notifications', plans: ENTERPRISE_PLAN },
             {
                 name: 'Large-scale code modifications',
                 description: 'Only available to select customers in preview',

--- a/website/src/components/PricingTable.tsx
+++ b/website/src/components/PricingTable.tsx
@@ -133,6 +133,11 @@ const DATA: PricingItemCategory[] = [
             { name: 'Saved searches', plans: ENTERPRISE_PLAN },
             { name: 'Email notifications', plans: ENTERPRISE_PLAN },
             {
+                name: 'Slack and webhook notifications',
+                description: 'Coming soon',
+                plans: ENTERPRISE_PLAN,
+            },
+            {
                 name: 'Large-scale code modifications',
                 description: 'Only available to select customers in preview',
                 plans: UNLIMITED_PLAN,


### PR DESCRIPTION
We had a customer ask about notifications for saved searches and realized we should be more clear about what is available vs. not since we had to deprecate the Slack integration.