### PR TITLE
Add pricing tier, update pricing basis from user accounts to MAUs

### DIFF
--- a/website/src/components/HoverablePopover.tsx
+++ b/website/src/components/HoverablePopover.tsx
@@ -28,13 +28,13 @@ export const HoverablePopover: React.FunctionComponent<{
     }
 
     return (
-        <div ref={targetRef}>
+        <span ref={targetRef}>
             {child && React.cloneElement(child, triggerProps)}
             <Overlay show={isOpen} placement={placement} target={target || undefined}>
                 <Popover onMouseEnter={setIsOpenTrue} onMouseLeave={setIsOpenFalse} id="popover">
                     {component}
                 </Popover>
             </Overlay>
-        </div>
+        </span>
     )
 }

--- a/website/src/components/PricingFreeTierPopover.tsx
+++ b/website/src/components/PricingFreeTierPopover.tsx
@@ -24,7 +24,6 @@ interface ProductPopoverButtonProps {
 export const PricingFreeTierPopoverButton: React.FunctionComponent<ProductPopoverButtonProps> = ({ className = '' }) => (
     <HoverablePopover placement="bottom" delay={{ show: 0, hide: 500 }} component={<PricingFreeTierPopoverBody />}>
         <a className={`pricing-free-tier-popover-body outline-0 ${className}`} href="https://docs.sourcegraph.com">
-            and other limited features
             <span className="text-muted ml-1 mr-1">
                 <QuestionMarkCircleOutlineIcon />
             </span>

--- a/website/src/components/PricingFreeTierPopover.tsx
+++ b/website/src/components/PricingFreeTierPopover.tsx
@@ -11,7 +11,7 @@ const PricingFreeTierPopoverBody: React.FunctionComponent<any> = () =>
                 <li className="nav-item mb-1">Editor and code host integrations</li>
                 <li className="nav-item mb-1">Sourcegraph extensions</li>
                 <li className="nav-item mb-1">Single sign-on (SSO)</li>
-                <li className="nav-item mb-1">20-user limit</li>
+                <li className="nav-item mb-1">10 monthly active user limit</li>
                 <li className="nav-item">Community support</li>
             </ul>
         </div>
@@ -24,7 +24,7 @@ interface ProductPopoverButtonProps {
 export const PricingFreeTierPopoverButton: React.FunctionComponent<ProductPopoverButtonProps> = ({ className = '' }) => (
     <HoverablePopover placement="bottom" delay={{ show: 0, hide: 500 }} component={<PricingFreeTierPopoverBody />}>
         <a className={`pricing-free-tier-popover-body outline-0 ${className}`} href="https://docs.sourcegraph.com">
-            and more
+            and other limited features
             <span className="text-muted ml-1 mr-1">
                 <QuestionMarkCircleOutlineIcon />
             </span>

--- a/website/src/components/PricingFreeTierPopover.tsx
+++ b/website/src/components/PricingFreeTierPopover.tsx
@@ -11,7 +11,8 @@ const PricingFreeTierPopoverBody: React.FunctionComponent<any> = () =>
                 <li className="nav-item mb-1">Editor and code host integrations</li>
                 <li className="nav-item mb-1">Sourcegraph extensions</li>
                 <li className="nav-item mb-1">Single sign-on (SSO)</li>
-                <li className="nav-item">20-user limit</li>
+                <li className="nav-item mb-1">20-user limit</li>
+                <li className="nav-item">Community support</li>
             </ul>
         </div>
     )

--- a/website/src/components/PricingFreeTierPopover.tsx
+++ b/website/src/components/PricingFreeTierPopover.tsx
@@ -1,0 +1,32 @@
+import QuestionMarkCircleOutlineIcon from 'mdi-react/QuestionMarkCircleOutlineIcon'
+import React from 'react'
+import { HoverablePopover } from './HoverablePopover'
+
+const PricingFreeTierPopoverBody: React.FunctionComponent<any> = () =>
+    (
+        <div className="p-3">
+            <ul className="nav flex-column">
+                <li className="nav-item mb-1">Code search</li>
+                <li className="nav-item mb-1">Code navigation (definitions and references)</li>
+                <li className="nav-item mb-1">Editor and code host integrations</li>
+                <li className="nav-item mb-1">Sourcegraph extensions</li>
+                <li className="nav-item mb-1">Single sign-on (SSO)</li>
+                <li className="nav-item">20-user limit</li>
+            </ul>
+        </div>
+    )
+
+interface ProductPopoverButtonProps {
+    className?: string
+}
+
+export const PricingFreeTierPopoverButton: React.FunctionComponent<ProductPopoverButtonProps> = ({ className = '' }) => (
+    <HoverablePopover placement="bottom" delay={{ show: 0, hide: 500 }} component={<PricingFreeTierPopoverBody />}>
+        <a className={`pricing-free-tier-popover-body outline-0 ${className}`} href="https://docs.sourcegraph.com">
+            and more
+            <span className="text-muted ml-1 mr-1">
+                <QuestionMarkCircleOutlineIcon />
+            </span>
+        </a>
+    </HoverablePopover>
+)

--- a/website/src/components/PricingPlan.tsx
+++ b/website/src/components/PricingPlan.tsx
@@ -30,7 +30,7 @@ export const PricingPlan: React.FunctionComponent<Props> = ({
     price,
     priceInterval = (
         <>
-            per user
+            per active user
             <br />
             per month
         </>

--- a/website/src/components/PricingTable.tsx
+++ b/website/src/components/PricingTable.tsx
@@ -11,16 +11,18 @@ import {
 
 enum Plan {
     OpenSource = 'Open source',
-    Core = 'Core',
+    Free = 'Free',
     Enterprise = 'Enterprise',
-    Unlimited = 'Unlimited',
+    EnterprisePlus = 'Enterprise Plus',
+    Elite = 'Elite',
 }
 
 const PLAN_CHECK_ICON_CLASS: Record<Plan, string> = {
     'Open source': 'text-dark',
-    Core: 'text-success',
+    Free: 'text-success',
     Enterprise: 'text-success',
-    Unlimited: 'text-success',
+    'Enterprise Plus': 'text-success',
+    Elite: 'text-success',
 }
 
 interface PricingItemCategory {
@@ -36,13 +38,15 @@ interface PricingItem {
     plans: Partial<Record<Plan, boolean | string>>
 }
 
-const ALL_PLANS: PricingItem['plans'] = { 'Open source': true, Core: true, Enterprise: true, Unlimited: true }
+const ALL_PLANS: PricingItem['plans'] = { 'Open source': true, Free: true, Enterprise: true, 'Enterprise Plus': true, Elite: true }
 
-const CORE_PLAN: PricingItem['plans'] = { Core: true, Enterprise: true, Unlimited: true }
+const FREE_PLAN: PricingItem['plans'] = { Free: true, Enterprise: true, 'Enterprise Plus': true, Elite: true }
 
-const ENTERPRISE_PLAN: PricingItem['plans'] = { Enterprise: true, Unlimited: true }
+const ENTERPRISE_PLAN: PricingItem['plans'] = { Enterprise: true, 'Enterprise Plus': true, Elite: true }
 
-const UNLIMITED_PLAN: PricingItem['plans'] = { Unlimited: true }
+const ENTERPRISE_PLUS_PLAN: PricingItem['plans'] = { 'Enterprise Plus': true, Elite: true }
+
+const ELITE_PLAN: PricingItem['plans'] = { Elite: true }
 
 const DATA: PricingItemCategory[] = [
     {
@@ -56,13 +60,13 @@ const DATA: PricingItemCategory[] = [
             { name: 'Repository, path, & language filters', plans: ALL_PLANS },
             { name: 'Regular expression queries', plans: ALL_PLANS },
             { name: 'Browser search shortcuts', plans: ALL_PLANS },
+            { name: 'High-scale clustered search', plans: ENTERPRISE_PLAN },
             {
                 name: 'Per-user repository permissions',
                 description: 'From your code host (GitHub or GitLab only)',
                 url: 'https://docs.sourcegraph.com/admin/repo/permissions',
-                plans: ENTERPRISE_PLAN,
+                plans: ENTERPRISE_PLUS_PLAN,
             },
-            { name: 'High-scale clustered search', plans: ENTERPRISE_PLAN },
         ],
     },
     {
@@ -95,7 +99,7 @@ const DATA: PricingItemCategory[] = [
                 name: 'Per-user repository permissions',
                 description: 'From your code host (GitHub or GitLab only)',
                 url: 'https://docs.sourcegraph.com/admin/repo/permissions',
-                plans: ENTERPRISE_PLAN,
+                plans: ENTERPRISE_PLUS_PLAN,
             },
         ],
     },
@@ -106,9 +110,9 @@ const DATA: PricingItemCategory[] = [
             {
                 name: `${SUPPORTED_PROGRAMMING_LANGUAGES_COUNT} supported languages`,
                 url: SUPPORTED_PROGRAMMING_LANGUAGES_URL,
-                plans: CORE_PLAN,
+                plans: FREE_PLAN,
             },
-            { name: 'Single repository definitions and references', plans: CORE_PLAN },
+            { name: 'Single repository definitions and references', plans: FREE_PLAN },
             { name: 'Cross-repository definitions and references', plans: ENTERPRISE_PLAN },
             {
                 name: 'High-scale clustered language servers',
@@ -117,7 +121,7 @@ const DATA: PricingItemCategory[] = [
             {
                 name: 'Remote development environment',
                 description: 'Coming soon',
-                plans: UNLIMITED_PLAN,
+                plans: ELITE_PLAN,
             },
         ],
     },
@@ -140,12 +144,12 @@ const DATA: PricingItemCategory[] = [
             {
                 name: 'Large-scale code modifications',
                 description: 'Only available to select customers in preview',
-                plans: UNLIMITED_PLAN,
+                plans: ELITE_PLAN,
             },
             {
                 name: 'License compliance and security analysis',
                 description: 'Coming soon',
-                plans: UNLIMITED_PLAN,
+                plans: ELITE_PLAN,
             },
         ],
     },
@@ -181,7 +185,7 @@ const DATA: PricingItemCategory[] = [
             {
                 name: 'Sourcegraph.com extension registry',
                 url: 'https://sourcegraph.com/extensions',
-                plans: CORE_PLAN,
+                plans: FREE_PLAN,
             },
         ],
     },
@@ -192,21 +196,16 @@ const DATA: PricingItemCategory[] = [
             {
                 name: 'User authentication via SSO (SAML/OpenID Connect/etc.)',
                 url: 'https://docs.sourcegraph.com/admin/auth',
-                plans: CORE_PLAN,
+                plans: FREE_PLAN,
             },
             {
-                name: 'Per-user repository permissions',
-                url: 'https://docs.sourcegraph.com/admin/repo/permissions',
+                name: 'Audit logs',
+                description: 'Coming soon',
                 plans: ENTERPRISE_PLAN,
             },
             {
                 name: 'External database storage',
                 url: 'https://docs.sourcegraph.com/admin/external_database',
-                plans: ENTERPRISE_PLAN,
-            },
-            {
-                name: 'Custom branding',
-                url: 'https://docs.sourcegraph.com/admin/config/site_config#reference',
                 plans: ENTERPRISE_PLAN,
             },
             {
@@ -218,16 +217,21 @@ const DATA: PricingItemCategory[] = [
             {
                 name: 'Private extension registry',
                 url: 'https://docs.sourcegraph.com/admin/extensions',
-                plans: UNLIMITED_PLAN,
+                plans: ENTERPRISE_PLUS_PLAN,
+            },
+            {
+                name: 'Custom branding',
+                url: 'https://docs.sourcegraph.com/admin/config/site_config#reference',
+                plans: ENTERPRISE_PLUS_PLAN,
+            },
+            {
+                name: 'Per-user repository permissions',
+                url: 'https://docs.sourcegraph.com/admin/repo/permissions',
+                plans: ENTERPRISE_PLUS_PLAN,
             },
             {
                 name: 'Unlimited guest users',
-                plans: UNLIMITED_PLAN,
-            },
-            {
-                name: 'Audit logs',
-                description: 'Coming soon',
-                plans: UNLIMITED_PLAN,
+                plans: ELITE_PLAN,
             },
         ],
     },
@@ -261,7 +265,8 @@ const DATA: PricingItemCategory[] = [
                     'Have Sourcegraph run and manage your instance, using our secure infrastructure or a sub-account on your own cloud provider',
                 plans: {
                     Enterprise: 'Additional fees per user',
-                    Unlimited: true,
+                    'Enterprise Plus': 'Additional fees per user',
+                    Elite: true,
                 },
             },
         ],
@@ -281,11 +286,14 @@ const DATA: PricingItemCategory[] = [
             },
             {
                 name: '24/7 uptime support',
-                plans: UNLIMITED_PLAN,
+                plans: {
+                    'Enterprise Plus': 'Additional fees per user',
+                    Elite: true,
+                },
             },
             {
                 name: 'Dedicated support',
-                plans: UNLIMITED_PLAN,
+                plans: ELITE_PLAN,
             },
         ],
     },
@@ -294,7 +302,7 @@ const DATA: PricingItemCategory[] = [
 export const PricingTable: React.FunctionComponent<{
     allPlans?: Plan[]
     categoriesAndItems?: PricingItemCategory[]
-}> = ({ allPlans = [Plan.OpenSource, Plan.Core, Plan.Enterprise, Plan.Unlimited], categoriesAndItems = DATA }) => (
+}> = ({ allPlans = [Plan.OpenSource, Plan.Free, Plan.Enterprise, Plan.EnterprisePlus, Plan.Elite], categoriesAndItems = DATA }) => (
     <div className="pricing-table">
         <div className="row align-items-center border border-gray">
             <div className="col-4 py-3">
@@ -305,17 +313,19 @@ export const PricingTable: React.FunctionComponent<{
                     src="/sourcegraph/logo.svg"
                 />
             </div>
-            {allPlans.map(plan => (
-                <div className="col-2 py-3 px-3 border-left border-gray">
-                    <h3 className="h4 mb-0 text-center">{plan}</h3>
-                </div>
-            ))}
+            <div className="col-8 row">
+                {allPlans.map(plan => (
+                        <div className="col py-3 px-3 border-left border-gray">
+                            <h3 className="h4 mb-0 text-center">{plan}</h3>
+                        </div>
+                ))}
+            </div>
         </div>
         <div>
             {categoriesAndItems.map(({ id, title, items }, i) => (
                 <React.Fragment key={i}>
                     <div id={id} className="pricing-table__category row mt-5 pt-4 px-2 py-1">
-                        <h6 className="col-12 text-uppercase text-muted font-weight-bold">{title}</h6>
+                        <h6 className="col-14 text-uppercase text-muted font-weight-bold">{title}</h6>
                     </div>
                     {items.map(({ name, description, url, plans }, i) => (
                         <div
@@ -346,13 +356,15 @@ export const PricingTable: React.FunctionComponent<{
                                     </OverlayTrigger>
                                 </div>
                             </div>
-                            {allPlans.map(plan => (
-                                <div className="col-2 p-2 border-left border-gray text-center">
-                                    {typeof plans[plan] === 'string'
-                                        ? plans[plan]
-                                        : plans[plan] && <CheckIcon className={PLAN_CHECK_ICON_CLASS[plan]} />}
-                                </div>
-                            ))}
+                            <div className="col-8 row">
+                                {allPlans.map(plan => (
+                                    <div className="col p-2 border-left border-gray text-center">
+                                        {typeof plans[plan] === 'string'
+                                            ? plans[plan]
+                                            : plans[plan] && <CheckIcon className={PLAN_CHECK_ICON_CLASS[plan]} />}
+                                    </div>
+                                ))}
+                            </div>
                         </div>
                     ))}
                 </React.Fragment>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -38,7 +38,7 @@ export default ((props: any) => (
                     <h4 className="font-weight-light">
                         Sourcegraph code search, code navigation,&nbsp;
                         <PricingFreeTierPopoverButton />
-                        are free for individuals and small teams (up to 20 users). <a href="https://docs.sourcegraph.com">Install</a> to get started today!
+                        are free for individuals and small teams. <a href="https://docs.sourcegraph.com">Install</a> to get started today!
                     </h4>
                 </ContentSection>
                 <div className="container-fluid pricing-page__plans">
@@ -58,6 +58,7 @@ export default ((props: any) => (
                                         id: 'deployment',
                                     },
                                     { name: 'Single sign-on (SSO)', id: 'admin' },
+                                    { name: 'Technical support', id: 'support' },
                                     { name: 'Cloud-managed option', id: 'deployment' },
                                 ]}
                                 // plusEverythingIn="Core"

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -36,7 +36,7 @@ export default ((props: any) => (
             <div className="pricing-page">
                 <ContentSection color="white" className="hero-section text-center py-5">
                     <h4 className="font-weight-light">
-                        Sourcegraph code search, code navigation,&nbsp;
+                        Sourcegraph code search, code navigation, and other limited features
                         <PricingFreeTierPopoverButton />
                         are free for individuals and small teams. <a href="https://docs.sourcegraph.com">Install</a> to get started today!
                     </h4>
@@ -61,9 +61,8 @@ export default ((props: any) => (
                                     { name: 'Technical support', id: 'support' },
                                     { name: 'Cloud-managed option', id: 'deployment' },
                                 ]}
-                                // plusEverythingIn="Core"
-                                buttonLabel="Buy now"
-                                buttonHref="http://sourcegraph.com/subscriptions/new"
+                                buttonLabel="Try now"
+                                buttonHref="http://about.sourcegraph.com/contact/sales/?form_submission_source=pricing-enterprise"
                             />
                         </div>
                         <div className="col-8 col-md-4 mx-auto mb-4">
@@ -81,8 +80,8 @@ export default ((props: any) => (
                                     { name: 'Priority support', id: 'support' },
                                 ]}
                                 plusEverythingIn="Enterprise"
-                                buttonLabel="Buy now"
-                                buttonHref="http://sourcegraph.com/subscriptions/new"
+                                buttonLabel="Try now"
+                                buttonHref="http://about.sourcegraph.com/contact/sales/?form_submission_source=pricing-enterprise-plus"
                             />
                         </div>
                         <div className="col-8 col-md-4 mx-auto mb-4">
@@ -113,8 +112,8 @@ export default ((props: any) => (
                                     { name: 'Dedicated support available', id: 'support' },
                                 ]}
                                 plusEverythingIn="Enterprise Plus"
-                                buttonLabel="Buy now"
-                                buttonHref="http://sourcegraph.com/subscriptions/new"
+                                buttonLabel="Try now"
+                                buttonHref="http://about.sourcegraph.com/contact/sales/?form_submission_source=pricing-elite"
                             />
                         </div>
                     </div>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -51,7 +51,7 @@ export default ((props: any) => (
                                 price="$29"
                                 features={[
                                     { name: 'Code review & pull request integration', id: 'code-review' },
-                                    { name: 'Code alerts & automation', id: 'code-alerts-automation' },
+                                    { name: 'Code alerts', id: 'code-alerts-automation' },
                                     { name: 'Deployment metrics & monitoring', id: 'deployment' },
                                     {
                                         name: 'High-scale/availability cluster deployment option',
@@ -120,7 +120,7 @@ export default ((props: any) => (
                 </div>
             </div>
             <ContentSection color="white" className="hero-section text-center py-5">
-                                * Limitations apply
+                * Limitations apply
             </ContentSection>
             <ContentSection color="purple" className="hero-section text-center py-5">
                 <h2>Try Sourcegraph Enterprise Plus risk-free for 30 days</h2>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -1,9 +1,13 @@
 import { Link } from 'gatsby'
+// import QuestionMarkCircleOutlineIcon from 'mdi-react/QuestionMarkCircleOutlineIcon'
 import * as React from 'react'
+// import OverlayTrigger from 'react-bootstrap/OverlayTrigger'
+// import Tooltip from 'react-bootstrap/Tooltip'
 import Helmet from 'react-helmet'
 import { ContentSection } from '../components/content/ContentSection'
 import { Jumbotron } from '../components/Jumbotron'
 import Layout from '../components/Layout'
+import { PricingFreeTierPopoverButton } from '../components/PricingFreeTierPopover'
 import { PricingPlan } from '../components/PricingPlan'
 import { PricingTable } from '../components/PricingTable'
 import { GetSourcegraphNowActions } from '../css/components/actions/GetSourcegraphNowActions'
@@ -30,58 +34,33 @@ export default ((props: any) => (
                 <link rel="icon" type="image/png" href="https://about.sourcegraph.com/favicon.png" />
             </Helmet>
             <div className="pricing-page">
+                <ContentSection color="white" className="hero-section text-center py-5">
+                    <h4 className="font-weight-light">
+                        Sourcegraph code search, code navigation,&nbsp;
+                        <PricingFreeTierPopoverButton />
+                        are free for individuals and small teams (up to 20 users). <a href="https://docs.sourcegraph.com">Install</a> to get started today!
+                    </h4>
+                </ContentSection>
                 <div className="container-fluid pricing-page__plans">
                     <div className="row pt-6">
                         <div className="col-8 col-md-4 mx-auto mb-4">
                             <PricingPlan
                                 className="pricing__plan"
-                                name="Core"
-                                description="Helping developers search, browse, and grok their code, for faster software development and incident response."
-                                price="$0"
-                                priceInterval=""
-                                priceCaption={
-                                    <>
-                                        for individuals
-                                        <br />
-                                        and small teams
-                                    </>
-                                }
-                                features={[
-                                    { name: 'Code search', id: 'code-search' },
-                                    { name: 'Code navigation (definitions & references)', id: 'code-navigation' },
-                                    { name: 'Sourcegraph extensions', id: 'integrations' },
-                                    { name: 'Code host & editor integration', id: 'integrations' },
-                                    {
-                                        name: 'Single sign-on (SSO) user authentication',
-                                        id: 'admin',
-                                    },
-                                    { name: '20-user limit', id: 'admin' },
-                                ]}
-                                buttonLabel="Install"
-                                buttonHref="https://docs.sourcegraph.com/#quickstart"
-                            />
-                        </div>
-                        <div className="col-8 col-md-4 mx-auto mb-4">
-                            <PricingPlan
-                                className="pricing__plan"
                                 name="Enterprise"
-                                description="Enabling engineering and DevOps leaders to speed up the organization's software lifecycle and monitor risks."
-                                price="$19"
-                                priceCaption="(billed annually)"
+                                description="Enabling engineering and DevOps leaders to speed up the organization's software development and monitor risks."
+                                price="$29"
                                 features={[
                                     { name: 'Code review & pull request integration', id: 'code-review' },
                                     { name: 'Code alerts & automation', id: 'code-alerts-automation' },
-                                    { name: 'Repository access permissions', id: 'admin' },
-                                    { name: 'Custom branding', id: 'admin' },
                                     { name: 'Deployment metrics & monitoring', id: 'deployment' },
                                     {
                                         name: 'High-scale/availability cluster deployment option',
                                         id: 'deployment',
                                     },
+                                    { name: 'Single sign-on (SSO)', id: 'admin' },
                                     { name: 'Cloud-managed option', id: 'deployment' },
-                                    { name: 'Priority support', id: 'support' },
                                 ]}
-                                plusEverythingIn="Core"
+                                // plusEverythingIn="Core"
                                 buttonLabel="Buy now"
                                 buttonHref="http://sourcegraph.com/subscriptions/new"
                             />
@@ -89,21 +68,37 @@ export default ((props: any) => (
                         <div className="col-8 col-md-4 mx-auto mb-4">
                             <PricingPlan
                                 className="pricing__plan"
-                                name="Unlimited"
-                                description="Enabling businesses to transform the software lifecycle with automation and intelligence."
-                                price="$99"
-                                priceCaption="(billed annually)"
+                                name="Enterprise Plus"
+                                description="Enabling large and complex organizations to accelerate the software lifecycle universally, across teams."
+                                price="$69"
                                 features={[
-                                    { name: 'Free guest users', id: 'admin' },
+                                    { name: 'Repository access permissions', id: 'admin' },
+                                    { name: 'Custom branding', id: 'admin' },
+                                    { name: 'Sourcegraph extension whitelist', id: 'admin' },
+                                    { name: 'Code reporting & analytics', id: 'admin', future: true },
+                                    { name: 'Audit logs', id: 'admin', future: true },
+                                    { name: 'Priority support', id: 'support' },
+                                ]}
+                                plusEverythingIn="Enterprise"
+                                buttonLabel="Buy now"
+                                buttonHref="http://sourcegraph.com/subscriptions/new"
+                            />
+                        </div>
+                        <div className="col-8 col-md-4 mx-auto mb-4">
+                            <PricingPlan
+                                className="pricing__plan"
+                                name="Elite"
+                                description="Enabling businesses to transform the software lifecycle with automation and intelligence."
+                                price="$149"
+                                features={[
+                                    { name: 'Free guest users*', id: 'admin' },
                                     { name: 'Private Sourcegraph extension registry', id: 'admin' },
                                     { name: '24/7 uptime support', id: 'support' },
-                                    { name: 'Dedicated support', id: 'support' },
                                     {
                                         name: 'Large-scale code modifications/refactoring',
                                         id: 'code-alerts-automation',
                                         future: true,
                                     },
-                                    { name: 'Code reporting & analytics', id: 'admin', future: true },
                                     {
                                         name: 'License compliance and security analysis',
                                         id: 'code-alerts-automation',
@@ -114,9 +109,9 @@ export default ((props: any) => (
                                         id: 'code-intelligence',
                                         future: true,
                                     },
-                                    { name: 'Audit logs', id: 'admin', future: true },
+                                    { name: 'Dedicated support available', id: 'support' },
                                 ]}
-                                plusEverythingIn="Enterprise"
+                                plusEverythingIn="Enterprise Plus"
                                 buttonLabel="Buy now"
                                 buttonHref="http://sourcegraph.com/subscriptions/new"
                             />
@@ -124,8 +119,11 @@ export default ((props: any) => (
                     </div>
                 </div>
             </div>
+            <ContentSection color="white" className="hero-section text-center py-5">
+                                * Limitations apply
+            </ContentSection>
             <ContentSection color="purple" className="hero-section text-center py-5">
-                <h2>Try Sourcegraph Unlimited risk-free for 30 days</h2>
+                <h2>Try Sourcegraph Enterprise Plus risk-free for 30 days</h2>
                 <Link className="btn btn-lg btn-outline-light mt-3 font-weight-normal" to="/contact/request-demo">
                     Free trial
                 </Link>


### PR DESCRIPTION
Updated pricing:
1) Adds a new tier ("Enterprise Plus")
2) Converts all pricing from user-account-based to MAU-based
3) Converts all pricing from annual/paid-up-front to monthly subscriptions

![image](https://user-images.githubusercontent.com/5589410/62961574-e035e400-bdb1-11e9-9f14-3c93d4a6f6ef.png)
![image](https://user-images.githubusercontent.com/5589410/62961601-eaf07900-bdb1-11e9-904b-e815b5d304ae.png)
![image](https://user-images.githubusercontent.com/5589410/62961610-ee840000-bdb1-11e9-81d4-ff9b4b00ff80.png)
![image](https://user-images.githubusercontent.com/5589410/62961620-f2178700-bdb1-11e9-9a04-ed2d8e6a2c7b.png)
![image](https://user-images.githubusercontent.com/5589410/62961630-f5127780-bdb1-11e9-8bca-ac0bc4629e51.png)
![image](https://user-images.githubusercontent.com/5589410/62961635-f8a5fe80-bdb1-11e9-8543-2b0a5ca06aea.png)
