### PR TITLE
Fix careers button link

### DIFF
--- a/website/src/pages/contact/index.tsx
+++ b/website/src/pages/contact/index.tsx
@@ -54,7 +54,7 @@ export default ((props: any) => (
                             <h5 className="card-header">Jobs</h5>
                             <div className="card-body">
                                 <p className="card-text">For information about joining our team:</p>
-                                <Link className="btn btn-outline-primary stretched-link" to="/contact/sales">
+                                <Link className="btn btn-outline-primary stretched-link" to="/jobs">
                                     See career opportunities
                                 </Link>
                             </div>

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -66,3 +66,4 @@
 /blog/github-universe-liveblog-innersource-and-reaping-the-benefits-of-open-source-behind-your-firewall /blog/github-universe-liveblog-innersource 301
 /blog/google-i-o-talk-building-sourcegraph-a-large-scale-code-search-cross-reference-engine-in-go /blog/google-i-o-talk-building-sourcegraph 301
 /product/code-alerts-automation /product/automation 301
+/careers /jobs 301


### PR DESCRIPTION
It is pointing to "Sales" page right now.