### PR TITLE
Removing 3.7 warning after improved 3.7.2 release

### DIFF
--- a/blogposts/announcing-sourcegraph-3.7.md
+++ b/blogposts/announcing-sourcegraph-3.7.md
@@ -10,9 +10,6 @@ heroImage: https://about.sourcegraph.com/sourcegraph-mark.png
 published: true
 ---
  
-<div class="alert alert-warning">
-  Due to performance concerns around 3.7.1, we are recommending that all users upgrade to 3.6.2 at this time.
-</div>
 Sourcegraph is the standard developer platform for code search and navigation at many of the largest and most exacting technology companies. With Sourcegraph, every company has access to the same kind of tools that Google and Facebook developers use every day.
 
 <div style="padding-left: 2rem">


### PR DESCRIPTION
3.7.2 has been released, and addresses all previous performance concerns.