### PR TITLE
Update announcing-sourcegraph-3.7.md

### DIFF
--- a/blogposts/announcing-sourcegraph-3.7.md
+++ b/blogposts/announcing-sourcegraph-3.7.md
@@ -55,25 +55,14 @@ Sourcegraph couldn't be what it is without the community.
   <p style="text-align: center"><a href="https://vimeo.com/354904682" target="_blank">View on Vimeo</a></p>
 </p>
 
-Symbol search (`type:symbol`) is a powerful feature for finding specific symbols, such as a function, variable, or package, and not just all text occurrences of your query. More and more users are taking advantage of symbol search results, which was leading to performance issues for some users with large instances. **Symbol search is now indexed for default branches**, which will be a major improvement for both users running symbol searches, and the users with large instances who were having performance issues.
+Symbol search (`type:symbol`) is a powerful feature for finding specific symbols, such as a function, variable, or package, and not just all text occurrences of your query. More and more users are taking advantage of symbol search results, which was leading to performance issues for some users with large instances. **Symbol search is now indexed for default branches**, which is a major improvement for both users running symbol searches and admins with large instances that were having performance issues. On large symbol searches, we've seen speed ups by factor of 20x ([benchmarks](https://docs.google.com/spreadsheets/d/1oPzePjD8YLrnppLm3nk46h48_Cxipz4_QqRMBYaIOYQ/edit?usp=sharing)).
 
-This update is enabled by default for all instances using indexed search. If you would like to [opt-out of adding symbols to your search index](https://docs.sourcegraph.com/admin/config/site_config#search-index-symbols-enabled), you can set `"search.index.symbols.enabled": false` in your site config.
+Upon upgrading, Sourcegraph will seamlessly & automatically re-index repositories in the background. Once finished, you'll see substantially improved symbol search performance. In the meantime, Sourcegraph will perform as it would normally.
 
 <div class="alert alert-info">
   <h4 class="alert-heading">Deployment note</h4>
-  <p>Upon upgrading, Sourcegraph will automatically re-index all repositories on your instance in the background. Sourcegraph cluster deployments will index at approximately 6,000 repositories per hour. Improvements from this change should not be expected until the re-index has completed. Monitor the reindex status of your instance at e.g. <a href="https://sourcegraph.example.com/site-admin/repositories?filter=needs-index">https://sourcegraph.example.com/site-admin/repositories?filter=needs-index</a>.</p>
-  <p>While reindexing is ongoing, search results will still be served from the old index and you can expect normal performance.</p>
-
+  <p>Prior to upgrading, please consult our <a href="https://docs.sourcegraph.com/admin/migration/3_7">3.7.2+ migration guide</a> to ensure you have enough free disk space.</p>
   <hr />
-
-  <h4>Instance resourcing</h4>
-  <p class="mb-0">This change will increase the resources required by your Sourcegraph instance <code class="language-text">zoekt-indexserver</code> (k8s pod: <code class="language-text">indexed-search</code>), so please make the following changes if needed:
-    <ul>
-      <li>Increase disk space by 30%.</li>
-      <li>Increase memory by 30%.</li>
-      <li>Reduce <code class="language-text">symbol</code> replicas by a comparable amount.</li>
-    </ul>
-  </p>
 </div>
 
 ## Search performance, efficiency, and reliability improvements


### PR DESCRIPTION
- Do not mention opting out, that is not a useful property (and more likely to cause issues than benefits for anyone).
- 6,000 repos/hr was inaccurate, 1,400 repos/hr is the corrected number.
- Link to benchmarks, mention 20x speedup of large symbol searches.
- Replace alert section with link to 3.7.2+ migration guide.
- Remove mention of monitoring via https://sourcegraph.example.com/site-admin/repositories?filter=needs-index -- that no longer works in 3.7.2. See migration guide for how to monitor.
- Remove mention of 30% disk space increase, in 3.7.2 it is now 130% increase since we retain old index version. Migration guide mentions this.
- Remove memory increase mention, migration guide covers this better mentioning gains we made in 3.6 which negate this.