### PR TITLE
Update index.tsx

### DIFF
--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -46,8 +46,8 @@ export default ((props: any) => (
                                 style={{ width: '19px', height: '19px', verticalAlign: '-3px' }}
                                 src="/sourcegraph/sourcegraph-mark.svg"
                             />{' '}
-                            <strong>Sourcegraph</strong> provides this standard developer&nbsp;platform to every
-                            company, helping startups and large&nbsp;enterprises ship better software faster.
+                            <strong>Sourcegraph</strong> provides this standard developer&nbsp;platform to help
+                            every elite&nbsp;development team ship better software faster.
                         </p>
                         <RequestDemoAction className="mt-5" />
                         <ContactPresalesSupportAction className="text-light mt-3" />


### PR DESCRIPTION
Changes subheader to reflect elite development team copy @ryan-blunden suggested for the 'request to demo' page to reflect the elite development team copy and create a little bit of FOMO ("if we consider ourselves an elite development team, should we be using Sourcegraph?")