### PR TITLE
enforce Slack 90-day message retention to encourage better documentation

### DIFF
--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -64,9 +64,10 @@ See [example of deprecated Google Doc](https://docs.google.com/document/d/1M22s-
 
 ## Slack
 
-We use Slack for team chat, which means ephemeral conversations. Any important decisions or changes need to be reflected in the [source of truth](#sources-of-truth).
+We use Slack for team chat, which means ephemeral conversations. To enforce this, only 90 days of Slack activity in public channels is retained. Any important decisions or changes need to be reflected in the [source of truth](#sources-of-truth).
 
-See [common channels](team_chat.md).
+- [Common channels](team_chat.md)
+- [Historical archive of Slack messages prior to 2019-11-09](https://drive.google.com/file/d/1FUbOEsMM4fWRpxymgNHZCAssOPEFDelJ/view?usp=sharing): unzip and open `sourcegraph-slack-archive-to-20191109/index.html` to view. If you consult this, please be sure to add whatever information you learn to a source of truth so we reduce our reliance on this archive.
 
 ### Avoid private messages
 


### PR DESCRIPTION
Discussions that occur on Slack (about a source-of-truth doc like an RFC, issue, PR, HubSpot record, etc.) are not discoverable by people looking at the source-of-truth doc. This causes people to:

- miss important context (because they have no way to know that discussion occurred on Slack)
- duplicate discussions and effort (e.g., often one person asks a question on Slack and someone else asks the same question on the RFC gdoc)
- consider the source-of-truth doc as not-quite-canonical (and trust it less, or invest less time in it) because they know there's likely crucial info scattered on Slack, too

To avoid this, I am proposing to configure our Slack workspace to delete messages in public after 90 days (in [Slack workspace settings > Data retention](https://sourcegraph.slack.com/admin/settings#data_retention)), and to communicate this to the team in the handbook. This will be a forcing function to everyone to update the source of truth after any significant Slack discussions.

Private channels and direct messages will remain "Keep all messages forever" because messages in those channels rarely pertain to source-of-truth docs anyway.

(GitLab has the [same policy](https://about.gitlab.com/handbook/communication/#slack).)