### PR TITLE
add links to onboarding in Graphbook, add step to set up 1-1s

### DIFF
--- a/handbook/leadership/1-1.md
+++ b/handbook/leadership/1-1.md
@@ -11,7 +11,8 @@ The purpose of 1-1s is to:
 
 ## How we do 1-1s
 
-1. In most cases, meetings should be 25-30 minutes once a week.
+1. In most cases, 1-1s should be weekly recurring 25-minute meetings.
+   - When a new teammate joins, they [set up the 1-1 calendar event](../people-ops/onboarding/index.md#for-all-new-teammates).
 1. Create a Google Doc shared with only the manager and the direct report to keep notes from the current meeting and a list of topics to discuss next time (which can be added to throughout the week).
 1. Use a consistent agenda ([GitLab's suggested 1-1 agenda](https://about.gitlab.com/handbook/leadership/1-1/suggested-agenda-format/)).
 1. Both people should be contributing to the 1-1 agenda (things to talk about). If either person is not contributing much, that is an indication of a larger problem that you need to solve.

--- a/handbook/people-ops/index.md
+++ b/handbook/people-ops/index.md
@@ -1,6 +1,9 @@
 # People Ops
 
 - [Travel](travel.md)
+- [Onboarding](onboarding/index.md)
+- [Distributed work tips](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/Distributed%20work%20tips.md)
+- [Graphbook](https://github.com/sourcegraph/Graphbook) (People Ops content is the process of being migrated from the Graphbook to this Sourcegraph handbook)
 
 ## [Roles](roles.md)
 

--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -1,0 +1,15 @@
+# Onboarding
+
+Some [onboarding docs](https://github.com/sourcegraph/Graphbook/tree/master/Onboarding) are in the Graphbook (which are in the process of being migrated to this handbook):
+
+- [Distributed teammates (US-based)](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/Distributed%20teammates%20(US%20based).md)
+- [Distributed teammates (non-US-based)](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/Distributed%20teammates%20(international).md)
+- [Engineers](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/Engineers.md)
+- [SF-based teammates](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/SF%20based%20teammates.md)
+- [Sales team](../../sales/onboarding.md)
+
+## For all new teammates
+
+> NOTE: This list is incomplete because it includes only new steps added since the creation of the Sourcegraph handbook. Eventually all of the onboarding docs above will be migrated to this Sourcegraph handbook, then this list will be complete and this note can be removed.
+
+- [ ] Set up a recurring weekly 25-minute [1-1 meeting](../../leadership/1-1.md) with your manager (e.g., `1-1 $YOURNAME-$MANAGERNAME`).

--- a/handbook/sales/onboarding.md
+++ b/handbook/sales/onboarding.md
@@ -20,9 +20,9 @@ Welcome to Sourcegraph! As a member of the sales team, you represent us and our 
 [Recording on 2019-11-01](https://zoom.us/recording/play/m6olRsgG3vWpZ6ZJYg1FJr1RKeAPoUnsE4lvelSrs64_N-7AZ1QTSJ0eb8WXXSXk)
 
 - [People Ops](../people-ops/index.md)
-  - Systems, employment, and benefits setup
+  - [General onboarding steps](../people-ops/onboarding/index.md#for-all-new-teammates)
   - [Sourcegraph handbook](../index.md) intro
-  - GitHub account setup and intro
+  - GitHub account setup and tutorial
 - [CEO](../ceo/index.md)
   - Vision
   - [Values](../values.md)


### PR DESCRIPTION
I wanted to add a step to the onboarding checklist for all new teammates (not just engineers) to set up 1-1s with their manager. I saw that this was mentioned in the Graphbook. Instead of submitting a PR to the Graphbook (which will soon be migrated to this handbook) to add this, I added it here and added some links back to the Graphbook.