### PR TITLE
Simplify handbook index

### DIFF
--- a/handbook/index.md
+++ b/handbook/index.md
@@ -26,9 +26,6 @@ The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's pub
 ## Engineering
 
 - [Engineering](engineering/index.md)
-  - RFCs (requests for comment)
-     - [All RFC documents](https://drive.google.com/drive/folders/1bip_pMeWePyNNdCEETRzoyMdLtntcNKR) (Google Drive)
-     - [How we use RFCs](engineering/rfcs/index.md)
 
 ## Support
 


### PR DESCRIPTION
Subpoints should either all be inlined or be removed entirely. I think the latter is better to avoid duplication (unless you want to keep it updated automatically somehow).

I did not audit the non-engineering sections.