### PR TITLE
Adding the integration demo video back to GitLab blog post

### DIFF
--- a/blogposts/gitlab-integrates-sourcegraph-code-navigation-and-code-intelligence.md
+++ b/blogposts/gitlab-integrates-sourcegraph-code-navigation-and-code-intelligence.md
@@ -38,6 +38,13 @@ Sourcegraph provides these much-loved, much-used features at scale for all code,
 
 Because we have many satisfied customers in common, a shared focus on developers, and some [CEO-to-CEO discussion on Hacker News](https://news.ycombinator.com/item?id=18118924), GitLab chose Sourcegraph to integrate these essential code navigation and code intelligence features for the 100,000+ organizations who trust GitLab.
 
+<p class="container">
+  <div style="padding:56.25% 0 0 0;position:relative;">
+    <iframe src="https://player.vimeo.com/video/372226334?color=0CB6F4&amp;title=0&amp;byline=" style="position:absolute;top:0;left:0;width:100%;height:100%;" frameborder="0" webkitallowfullscreen="" mozallowfullscreen="" allowfullscreen=""></iframe>
+  </div>
+  <p style="text-align: center"><a href="https://vimeo.com/372226334" target="_blank">View on Vimeo</a></p>
+</p>
+
 ## Built-in IDE-like features improve code reviews
 
 Higher quality code reviews become possible when developers have more context about code they are reviewing. With this new integration, hover tooltips provide access to go-to-definition and find references in the browser on their code host. This means that developers can traverse the code they are reviewing, investigate the impact of code changes thoroughly by finding all affected references, and complete their code reviews faster, all without leaving the browser.


### PR DESCRIPTION
Adding the video back to create additional code views of the integration. Will work with @ryan-blunden  to update the video to have a code view overview shot.