### PR TITLE
Use light theme for GitLab integration section

### DIFF
--- a/website/src/components/product/GitLabIntegrationSection.tsx
+++ b/website/src/components/product/GitLabIntegrationSection.tsx
@@ -6,7 +6,7 @@ export const GitLabIntegrationSection: React.FunctionComponent<{ className?: str
     className = '',
 }) => (
 
-    <div className="gitlab-integration-section py-5 row justify-content-center ">
+    <div className="gitlab-integration-section py-5 row justify-content-center text-dark">
         <div className="row justify-content-center container">
             <h2 className="text-center display-4 mb-2">
                 <div className="gitlab-integration-section__new-badge">New</div>
@@ -21,13 +21,13 @@ export const GitLabIntegrationSection: React.FunctionComponent<{ className?: str
                         Sid Sijbrandij, GitLab CEO
                     </footer>
                 </div>
-                <p class="container">
+                <p className="container">
                     <div style={{padding: '56.25% 0 0 0', position:'relative'}}>
                         <iframe src="https://player.vimeo.com/video/372590007?color=0CB6F4&amp;title=0&amp;byline=" style={{position:'absolute',top:0,left:0,width:'100%',height:'100%'}} webkitallowfullscreen="" mozallowfullscreen="" allowfullscreen=""></iframe>
                     </div>
                 </p>
                 <p className="home__intro-text font-weight-light">
-                GitLab and Sourcegraph just announced a partnership to provide code navigation natively to GitLab users
+                GitLab and Sourcegraph just announced a partnership to provide code navigation natively to GitLab users.
                 </p>
                 <RequestDemoAction className="mt-5" />
                 <a className="mt-3 d-flex align-items-center text-decoration-none" href="https://about.sourcegraph.com/blog/gitlab-integrates-sourcegraph-code-navigation-and-code-intelligence" target="_blank">

--- a/website/src/css/components/product/_GitLabIntegrationSection.scss
+++ b/website/src/css/components/product/_GitLabIntegrationSection.scss
@@ -1,6 +1,6 @@
 .gitlab-integration-section {
     $max-width: 135px;
-    background-color: #111111;
+    background-color: $light-9;
 
     &__title {
         display: inline;


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/5589410/68726458-5fd07c00-0576-11ea-822a-5b90039b63dc.png)

Having trouble figuring out what to pass in to get the input box to be light themed... Seems like we only define `$input-bg` without a light-themed option. I still think this PR is an improvement.