### PR TITLE
rename Slack channel #go-to-market to #sales

### DIFF
--- a/handbook/communication/team_chat.md
+++ b/handbook/communication/team_chat.md
@@ -21,7 +21,8 @@ If you are a new member of the engineering team, you'll most likely want to join
 
 ## Business
 
-- #go-to-market - Going to market, selling to customers
+- #marketing - [Marketing](../marketing/index.md)
+- #sales - [Sales](../sales/index.md)
 - #marketintel - Market and industry intelligence - products, funding, competition
 - #payments - Customer payment notifications
 - #hiring-active - Candidate hiring


### PR DESCRIPTION
"Go-to-market" includes both marketing and sales, but we have a separate #marketing channel. To avoid confusion, rename #go-to-market to #sales. Also, it's shorter. :)