### PR TITLE
transition from remote-first to all-remote

### DIFF
--- a/company/index.md
+++ b/company/index.md
@@ -2,3 +2,6 @@
 
 - [**about.sourcegraph.com**](https://about.sourcegraph.com) for information about Sourcegraph (the product and the company)
 - [Sourcegraph handbook](../handbook/index.md#company)
+- [Objectives and Key Results (OKRS)](okrs/index.md)
+- [All-remote](remote/index.md)
+- [Open source, open company](open_source_open_company.md)

--- a/company/remote/index.md
+++ b/company/remote/index.md
@@ -1,5 +1,28 @@
-# Remote
+# All-remote
 
-Sourcegraph is a remote-first company.
+> NOTE: This page uses the present tense (about us being all-remote) for simplicity, but we are still [transitioning from remote-first to all-remote](#transition-to-all-remote).
+
+Sourcegraph is an all-remote company, which means:
+
+- All teammates work remotely.
+- Sourcegraph does not have any offices.
+- We work asynchronously across time zones and continents.
 
 - [Tips for working remotely](tips.md)
+
+## Transition to all-remote
+
+As of 2019-11, we are transitioning from remote-first (where we maintained a San Francisco office with about 1/3 of our team) to all-remote. When we get rid of our San Francisco office (date TBD), SF-based teammates will no longer have the option to work from a company-maintained office. They will still have the same choices as teammates anywhere else in the world: work from home, from a coworking space, or from some other place or office of their choosing.
+
+SF teammates who enjoy working in an office with other teammates are welcome to jointly coordinate working out of the same coworking space. We plan to formalize reimbursement of coworking spaces for teammates who prefer that to working from home.
+
+## Helpful links
+
+- [GitLab handbook: All-remote](https://about.gitlab.com/company/culture/all-remote)
+  - Sourcegraph is [all-remote, asynchronous across time zones](https://about.gitlab.com/company/culture/all-remote/stages/#all-remote-asynchronous-across-time-zones), according to GitLab's taxonomy
+- [Remote Work Encyclopedia](http://remoteworkencyclopedia.com/)
+- [Remote-only manifesto](https://www.remoteonly.org/)
+- [Zapier's guide to remote work](https://zapier.com/learn/remote-work/)
+- Invision all-remote blog posts [1](https://www.invisionapp.com/inside-design/studio-remote-design-team/) [2](https://www.invisionapp.com/inside-design/remote-company-culture/)
+- [Why Buffer became all-remote](https://open.buffer.com/no-office/)
+- [Martin Fowler on remote vs. co-located](https://martinfowler.com/articles/remote-or-co-located.html)

--- a/company/remote/index.md
+++ b/company/remote/index.md
@@ -4,11 +4,13 @@
 
 Sourcegraph is an all-remote company, which means:
 
-- All teammates work remotely.
-- Sourcegraph does not have any offices.
+- All teammates work remotely.*
+- Sourcegraph does not have any offices.*
 - We work asynchronously across time zones and continents.
 
 - [Tips for working remotely](tips.md)
+
+<small>* Except for a small office in San Francisco used to provide a mailing address, for corporate filings, and as legally required.</small>
 
 ## Transition to all-remote
 

--- a/company/remote/index.md
+++ b/company/remote/index.md
@@ -14,7 +14,7 @@ Sourcegraph is an all-remote company, which means:
 
 ## Transition to all-remote
 
-As of 2019-11, we are transitioning from remote-first (where we maintained a San Francisco office with about 1/3 of our team) to all-remote. When we get rid of our San Francisco office (date TBD), SF-based teammates will no longer have the option to work from a company-maintained office. They will still have the same choices as teammates anywhere else in the world: work from home, from a coworking space, or from some other place or office of their choosing.
+As of 2019-11, we are transitioning from remote-first (where we maintained a San Francisco office with about 1/3 of our team) to all-remote. When we get rid of our current San Francisco office (date TBD), SF-based teammates will no longer have the option to work from it. They will still have the same choices as teammates anywhere else in the world: work from home, from a coworking space, or from some other place or office of their choosing.
 
 SF teammates who enjoy working in an office with other teammates are welcome to jointly coordinate working out of the same coworking space. We plan to formalize reimbursement of coworking spaces for teammates who prefer that to working from home.
 

--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -1,6 +1,6 @@
 # Communication
 
-We're an [all-remote](../../company/remote/index.md) company, with teammates from all around the world and (soon) no primary office. To make this work, we 
+We're an [all-remote](../../company/remote/index.md) company, with teammates from all around the world and (soon) no primary office. To make this work, we need to be deliberate about how we communicate.
 
 ## Sources of truth
 

--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -1,5 +1,7 @@
 # Communication
 
+We're an [all-remote](../../company/remote/index.md) company, with teammates from all around the world and (soon) no primary office. To make this work, we 
+
 ## Sources of truth
 
 These places are the source of truth for information at Sourcegraph. Information in these places is expected to be accurate and up-to-date:
@@ -94,3 +96,5 @@ Most meetings at Sourcegraph are video calls. We prefer [Zoom](https://zoom.us) 
 ## Writing
 
 1. Always use [ISO dates](https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates) in all writing and legal documents because other formats [lead to online confusion](http://xkcd.com/1179/). Use `yyyy-mm-dd`, for example 2020-04-13, and never 04-13-2020, 13-04-2020, 2020/04/13, nor April 13, 2020. Even if you use an unambiguous alternative format, it is still harder to search for a date, sort on a date, and for other team members to know we use the ISO standard. For months use `yyyy-mm`, so 2020-01 for January 2020.
+
+

--- a/handbook/communication/rfcs/index.md
+++ b/handbook/communication/rfcs/index.md
@@ -1,6 +1,6 @@
 # Requests for comments (RFCs)
 
-We value writing down plans so that we can asynchronously communicate to and solicit feedback from our remote-first team. A good plan communicates what problem is being solved, why that problem is being prioritized now, and what the plan is to solve the identified problem.
+We value writing down plans so that we can asynchronously communicate to and solicit feedback from our [all-remote](../../../company/remote/index.md) team. A good plan communicates what problem is being solved, why that problem is being prioritized now, and what the plan is to solve the identified problem.
 
 This document describes how we operationalize written planning through our RFC process. RFC literally means "Request for Comments" and you can think about it as exactly that, no more, no less.
 

--- a/handbook/people-ops/index.md
+++ b/handbook/people-ops/index.md
@@ -9,7 +9,7 @@
 - [Spending company money](spending-company-money.md)
 - [Glossary](from-graphbook/glossary.md)
 - [Holidays](from-graphbook/holidays.md)
-- [Remote work](../../company/remote/index.md)
+- [All-remote work](../../company/remote/index.md)
 - [Teammate philosophy](teammate_philosophy.md)
 - [List of team members](../../company/team/index.md)
 

--- a/handbook/people-ops/travel.md
+++ b/handbook/people-ops/travel.md
@@ -1,13 +1,13 @@
 # Team travel budgets
 
-Sourcegraph is a remote-first company. This means that the traditional corporate hub-and-spoke travel model (the few remote teammates coming to HQ to meet the rest of the team) is not sufficient.
+Sourcegraph is an [all-remote](../../company/remote/index.md) company. This means that the traditional corporate hub-and-spoke travel model (the few remote teammates coming to HQ to meet the rest of the team) is not sufficient.
 
-We believe that team get-togethers are invaluable for building cohesiveness across distributed teams, and spreading Sourcegraph culture evenly across the company.
+We believe that team get-togethers are invaluable for building cohesiveness in remote teams, and spreading Sourcegraph culture evenly across the company.
 
 The budgets for each category of travel below are non-transferable (and each of the company-wide events are as well). Each should be considered "use it, or lose it".
 
 As examples:
-- A teammate cannot reallocate the budget from a company-wide event to an individual trip to HQ.
+- A teammate cannot reallocate the budget from a company-wide event to an individual trip.
 - A teammate cannot use their team budget for individual travel.
 - A teammate cannot skip the winter holiday party to get a longer stay at the Spring/Summer company-wide event.
 
@@ -15,7 +15,7 @@ There are four types of company-sponsored (and company-paid) travel.
 
 ## Company-wide events
 
-The first category of travel is company-wide events. Sourcegraph holds two company-wide events each year, each fully covered by the company. These include a winter holiday party (typically in San Francisco, near HQ), and a Spring/Summer event (occasionally overlapping with GopherCon or other conferences).
+The first category of travel is company-wide events. Sourcegraph holds two company-wide events each year, each fully covered by the company. These include a winter holiday party (typically in San Francisco), and a Spring/Summer event (occasionally overlapping with GopherCon or other conferences).
 
 ## Team events
 
@@ -35,9 +35,9 @@ Today, “teams” includes both permanent product teams and project-specific te
 
 ## Individual travel
 
-Each teammate has one full-paid trip per year to Sourcegraph HQ in San Francisco for up to seven days and six nights (or another city, if they choose to visit another teammate or group of teammates in another location) for individual work travel. This would come on top of the existing USD $1K per year budget for professional development.
+Each teammate has one fully-paid trip per year to meet up with a group of teammates in another location. This would come on top of the existing USD $1K per year budget for professional development.
 
-The purpose of providing one “trip” (versus providing a set dollar budget) is to avoid punishing teammates that live far away from California, and would face disproportionately high airfare costs.
+The purpose of providing one “trip” (versus providing a set dollar budget) is to avoid punishing teammates that live far away from other teammates, and who would therefore face disproportionately high airfare costs.
 
 ## Professional development and education
 

--- a/handbook/usage.md
+++ b/handbook/usage.md
@@ -6,7 +6,7 @@
 1. You look it up in the handbook.
    - If the handbook has what you need, you're done!
    - If the handbook is missing what you need or is inaccurate/outdated, ask for help (on Slack, Zoom, etc.) and ensure the handbook is updated.
-   
+
 Join the `#handbook` Slack channel to see proposed changes.
 
 ## Handbook guidelines
@@ -22,6 +22,7 @@ Join the `#handbook` Slack channel to see proposed changes.
 
 1. If you want to change a guideline or process, propose an edit to the handbook (by creating a pull request). Discuss the change on the pull request.
    - Don't discuss or draft the changes in some other channel (Slack, Google Doc, etc.) first. If (for example) you start discussing a proposed change on Slack and then create a PR, you'll end up with half of the discussion on Slack and the other half on the PR, which results in confusion and duplication.
+   - The pull request is where you justify and describe the change; your edits to handbook content should reflect the final state that you want. For example, to propose changing the format of our company meeting, edit [company_meeting.md](communication/company_meeting.md) to be how you'd like, instead of adding a new section to that file to propose your changes. As a reviewer, keep in mind that a pull request with a definitively written edit is still just a proposal that's up for discussion.
    - Learn [how to propose an edit the handbook](editing.md).
 1. If someone replies to a question with a newly typed-out answer that differs from what's in the handbook, gently ask them to either follow what's in the handbook or propose an edit to the handbook.
 1. To announce a changed or newly documented process, post a link (in Slack, and elsewhere as needed) to the merged commit that contains the before-and-after changes to the handbook.


### PR DESCRIPTION
Proposes transitioning Sourcegraph from a remote-first company to an all-remote company. We briefly discussed this at company meeting on 2019-11-11 and then [on Slack in #general](https://sourcegraph.slack.com/archives/C02FSM7DU/p1573498881167500). This is the actual proposal to change this aspect of Sourcegraph (in line with [Changing or defining a process](https://about.sourcegraph.com/handbook/usage#changing-or-defining-a-process) in the handbook).

Remote work has been a part of Sourcegraph since very early on, and it has worked extremely well. More than half of our team is remote now, and we anticipate the proportion of remote teammates will grow because the population of talented people in SF is tiny compared to the population of talented people worldwide.

We transitioned from remote-friendly to remote-first earlier this year. That switch was successful. Several teammates who otherwise would have felt obligated to work from our SF office instead chose to move to a location they favor over SF or work from home despite being based in the SF Bay Area. Those people are happier and more productive because of it. The switch also helped us attract new talented remote candidates who prefer remote-first companies to remote-friendly companies (which are hit-or-miss, sometimes they claim to be remote-friendly but without the forcing function of remote-first let their communication practices privilege local folks).

Now that we are remote-first, why go all-remote?

1. Having an office causes many SF-based people to feel obligated to come into the office more than is optimal. They tell us they do this because they "don't want the office to feel empty" despite reporting that they would feel more productive and happier working from home more of those days. This is an admirable impulse, but we don't want people to feel guilty about not coming into the office and therefore choose a non-optimal arrangement.
   - Could we just *really* clearly communicate to these people that they aren't obligated to come into the office? We've tried that, but it hasn't changed their behavior (they still feel obligated, and people still feel bad that the office is empty).
   - Could we just get a smaller official office location? We could try that, and it'd probably make the situation better but not completely fix it. For people who like having an office, we instead suggest they coordinate working out of a private office(s) in a coworking space with other like-minded teammates, and we will reimburse that. That yields a very similar outcome to the people who prefer an office without affecting other teammates.
1. All-remote is more appealing to talented people worldwide than remote-first because it means they are on a level playing field with everyone else at the company (and not at a slight, possibly in perception only, disadvantage to local teammates). Being all-remote will help us continue to grow our team with world-class teammates.

What about people who prefer having an office with other teammates? Some SF-based teammates expressed this. See the "Could we just get a smaller office?" point above. You can coordinate with other SF-based teammates to get a private office(s) at a coworking space, and we will reimburse that. (The same, of course, would apply to any teammate or group of teammates anywhere in the world.)

Notes:

- We're going to document a lot more of our practices and policies for remote work, such as how new teammate onboarding changes when everyone is remote. These will come in future edits to the handbook.
- Now that we're all remote, we don't need to use the term "distributed" in preference to "remote".