### PR TITLE
Fix company meeting time

### DIFF
--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -26,7 +26,7 @@ The following places are not sources of truth. Treat documents and conversations
 
 ## Meetings
 
-- [Company meeting](company_meeting.md) (Mondays 11:00-11:30am PST/PDT)
+- [Company meeting](company_meeting.md) (Mondays 10:30-11:00am PST/PDT)
 
 ### Internal meetings
 


### PR DESCRIPTION
The time is not the same as [the link it points to](https://about.sourcegraph.com/handbook/communication/company_meeting), nor does it reflect the current truth.

Not sure if this is intended but at least we have inconsistency in the handbook.