### PR TITLE
add common questions from prospective customers, move product comparison here

### DIFF
--- a/handbook/sales/common_customer_questions.md
+++ b/handbook/sales/common_customer_questions.md
@@ -1,0 +1,56 @@
+# Common questions from prospective customers
+
+This page lists common questions we hear from prospective customers who are considering Sourcegraph.
+
+Most questions include an example answer and explanation. The explanation is formatted as normal text, and the example answer is formatted in a blockquote:
+
+> like this.
+
+## How is Sourcegraph different from the built-in code search of our code host?
+
+This somewhat depends on which code host they're using. Look up the [product comparison with their code host](../../workflow/index.md#other-tools) for details.
+
+Generally, though, code hosts offer very basic code search functionality that isn't *actually* very useful for developers. If someone asks this question, they probably don't use code search very frequently, because if they did use their code host's code search, they would be familiar with its shortcomings. It is very, very rare that someone asking this question is an avid user of their code host's code search and wants to know the feature-by-feature comparison.
+
+Here is a strategy for handling this question live (for simplicity, this assumes their code host is GitHub):
+
+> Well, first, how often do you use GitHub code search? [Their response is almost always "a few times a week" or less.] Makes total sense. The most helpful way to think about the difference is that with really good code search, you'd actually use code search many times *per day*. Sourcegraph becomes the first place you go to answer questions and unblock yourself while coding. I'll send you the public stats and docs (and the [Yelp usage chart](https://engineeringblog.yelp.com/2019/11/winning-the-hackathon-with-sourcegraph.html)) about code search usage inside our customers and Google and Facebook, which all have really good code search. We usually see around 10-20% of developers inside an organization immediately becoming daily code search users, and over the next few weeks or months as other developers get accustomed to it, that number grows to 60-90% of all developers.
+>
+> - [If they want more specific feature information, run through the [Sourcegraph tour](https://docs.sourcegraph.com/user/tour) and show them how Sourcegraph can answer questions that come up many times per day while coding.]
+> - [If they want to see these usage claims backed up by data, walk through the materials you mentioned with them live.]
+
+## Should I deploy using Docker or to a cluster?
+
+> Start with the Docker quickstart (https://docs.sourcegraph.com/#quickstart) to try out Sourcegraph locally. When you're ready to deploy Sourcegraph for your organization, deploy using Docker (https://docs.sourcegraph.com/admin/install/docker) in most cases. The cluster deployment (https://docs.sourcegraph.com/admin/install/cluster) is easy to migrate to later for high scalability and high availability. Of course, if you just prefer deploying on Kubernetes, then starting with the cluster deployment is fine.
+
+## Does Sourcegraph respect GitHub (or other code host) permissions?
+
+> Yes, see repository permissions documentation (https://docs.sourcegraph.com/admin/repo/permissions).
+
+## Needs answer
+
+- What’s the recommended resource provisioning on our end for optimal search performance at scale?
+- Can we use LDAP/AD to assign license keys?
+- How can I make sure certain repositories are not indexed?
+- How often does Sourcegraph index/update our repositories? Is it real-time?
+- We have a ton of repositories. Will Sourcegraph put too much load on our Bitbucket Server/GitHub/etc. instance and take it down?
+- Do you support non-git-based code hosts like Perforce/TFS2010? Are there any limitations with using Sourcegraph?
+- Can Sourcegraph search across both a git-based code host and a non-git-based code host?
+- Why do I need to use the Chrome extension?
+- Do you have plans to update the Firefox browser extension for compatibility?
+- Are there plans for a deeper integration with editors like IntelliJ or Visual Studio Code?
+- What are the advantages of using Sourcegraph over running a script and searching with grep?
+- How often would the average user use Sourcegraph? Do you have more IC devs or tech leads/management using Sourcegraph?
+- What languages does Sourcegraph support with full semantic search / precise code intelligence?
+- Does Sourcegraph support cross-repository code intelligence?
+- Our Security team will likely have concerns about who will have access to our data when we clone our repos. Can you tell me how permissioning works and how to appease their concerns?
+- If our developers have all of our code on their local machines, what advantages are there for using Sourcegraph?
+- How does Sourcegraph rank search results?
+- Can any user customize the search filters, or just our site admin?
+- Do you support negative regex look arounds?
+- Can Sourcegraph search within our code review comments?
+- Does Sourcegraph have a Slack integration for notifications from Saved Searches?
+- When should I expect Sourcegraph Automation to be available? Can I access the feature set today?
+- Why is Sourcegraph more expensive than GitHub Enterprise / Stack Overflow / Slack / Asana / JIRA licenses?
+- Can you break down your pricing fees for managed instances?
+- Why should I pay for Sourcegraph and not just use a free/open-source self-hosted instance?

--- a/handbook/sales/index.md
+++ b/handbook/sales/index.md
@@ -3,6 +3,7 @@
 The Sales team represents us and our values to customers, bringing back dollars and feedback to help us grow.
 
 - [Pricing](https://about.sourcegraph.com/pricing)
+- [Common questions from prospective customers](common_customer_questions.md)
 - [Sales team onboarding](onboarding/index.md)
 
 ## Pipeline and models

--- a/handbook/sales/onboarding/index.md
+++ b/handbook/sales/onboarding/index.md
@@ -80,6 +80,7 @@ Welcome to Sourcegraph! As a member of the sales team, you represent us and our 
 
 - Checkpoint
   - Conduct a 30-minute intro call (pitch, discovery, product walkthrough)
+  - Answer all [common customer questions](../common_customer_questions.md) in a live quiz (note: this doc will have all of the questions answered prior to anyone needing to do this quiz)
 
 
 ## Helpful links

--- a/workflow/index.md
+++ b/workflow/index.md
@@ -1,0 +1,27 @@
+# Sourcegraph workflow
+
+Sourcegraph helps [<!-- personas -->](../handbook/product/personas.md) organizations with the following stages of the development workflow:
+
+- **Code:** Unblock yourself while coding by finding answers in the code and every bit of related information.
+- **Review:** Review code, find problems early, and share knowledge.
+- **Verify:** Uphold code quality standards and comply with required processes on all code changes.
+- **Monitor:** Monitor services and quickly respond to incidents in your production environment.
+- **Automate:** Automate error-prone and time-consuming workflows such as refactors and triage, coordinated across projects and teams.
+- **Manage:** All of your repositories and users, configured and accessible in one place.
+
+# Other tools
+
+See product comparisons and integrations with:
+
+- [Atlassian Fisheye](tools/atlassian_fisheye_vs_sourcegraph.md)
+- [Bitbucket Cloud](tools/bitbucket_cloud_vs_sourcegraph.md)
+- [Bitbucket Server](tools/bitbucket_server_vs_sourcegraph.md)
+- [GitHub](tools/github_vs_sourcegraph.md)
+- [GitLab](tools/gitlab_vs_sourcegraph.md)
+- [Google Cloud Source Repositories](tools/google_cloud_source_repositories_vs_sourcegraph.md)
+- [Hound](tools/hound_vs_sourcegraph.md)
+- [Livegrep](tools/livegrep_vs_sourcegraph.md)
+- [OpenGrok](tools/opengrok_vs_sourcegraph.md)
+- [Phabricator](tools/phabricator_vs_sourcegraph.md)
+
+([File an issue](https://github.com/sourcegraph/about/issues) if you want us to add a page about another product.)

--- a/workflow/tools/atlassian_fisheye_vs_sourcegraph.md
+++ b/workflow/tools/atlassian_fisheye_vs_sourcegraph.md
@@ -1,0 +1,18 @@
+# Atlassian Fisheye vs. Sourcegraph
+
+[Atlassian Fisheye](https://www.atlassian.com/software/fisheye) was released around 2007, initially as a source browser for companies who (before the advent of GitHub/Bitbucket) mostly lacked web-based source code browsers. It later added code search capabilities.
+
+You can try it out on [JBoss’ public Fisheye instance](https://source.jboss.org/browse) (see [example quick search results page](https://source.jboss.org/qsearch?q=open&t=3&s=2&bucket=ANY_DATE&userFilter=) and [example advanced search results page](https://source.jboss.org/search/Aesh/?head=true&comment=&contents=open&addedText=&deletedText=&filename=&branch=&tag=&fromdate=&todate=&datesortorder=DESCENDING&groupby=file&col=path&col=revision&col=author&col=date&col=csid&refresh=y)).
+
+Sourcegraph is a good replacement for Fisheye as a code search tool when the primary usage is developers searching for code.
+
+## Pros
+
+* Tight integration with the Atlassian suite of products, especially with builds from Atlassian Bamboo
+* Perforce support (as well as Git, Subversion, Mercurial, and CVS)
+
+## Cons
+
+* Common developer sentiment: "It feels like Fisheye’s code search is for managers to report on changes, not for developers in their daily workflow"
+* Poor integration with GitHub and GitLab
+* Deprioritized by Atlassian, with [only infrequent and minor feature releases](https://confluence.atlassian.com/fisheye/fisheye-releases-960155725.html)

--- a/workflow/tools/bitbucket_cloud_vs_sourcegraph.md
+++ b/workflow/tools/bitbucket_cloud_vs_sourcegraph.md
@@ -1,0 +1,11 @@
+# Bitbucket Cloud vs. Sourcegraph
+
+[Bitbucket Cloud](https://github.com) is a code host and review tool. Sourcegraph and Bitbucket Cloud integrate well together.
+
+- [Bitbucket Cloud integration with Sourcegraph](https://docs.sourcegraph.com/integration/bitbucket_cloud) (Sourcegraph documentation)
+
+> Sourcegraph also supports [Bitbucket Server](bitbucket_server_vs_sourcegraph.md), Atlassian's self-hosted code host.
+
+## Code search
+
+Bitbucket Cloud offers limited [code search](https://confluence.atlassian.com/bitbucket/search-873876782.html), which is acceptable for smaller teams using Bitbucket Cloud with simple/infrequent code search needs. The main pain points we hear are lack of support for literal/regexp queries, and that the UI is not optimized for searching across multiple repositories. For medium and large organizations, Sourcegraph is a better alternative to Bitbucket Cloud's built-in code search.

--- a/workflow/tools/bitbucket_server_vs_sourcegraph.md
+++ b/workflow/tools/bitbucket_server_vs_sourcegraph.md
@@ -1,0 +1,11 @@
+# Bitbucket Server vs. Sourcegraph
+
+[Bitbucket Server](https://github.com) is a code host and review tool. Sourcegraph and Bitbucket Server integrate well together.
+
+- [Bitbucket Server integration with Sourcegraph](https://docs.sourcegraph.com/integration/bitbucket_server) (Sourcegraph documentation)
+
+> Sourcegraph also supports [Bitbucket Cloud](bitbucket_cloud_vs_sourcegraph.md), Atlassian's cloud-hosted code host.
+
+## Code search
+
+Bitbucket Server offers limited [code search](https://confluence.atlassian.com/bitbucketserver/search-for-code-in-bitbucket-server-814204781.html), which is acceptable for smaller teams using Bitbucket Server with simple/infrequent code search needs. The main pain points we hear are lack of support for literal/regexp queries, and that the UI is not optimized for searching across multiple repositories. For medium and large organizations, Sourcegraph is a better alternative to Bitbucket Server's built-in code search.

--- a/workflow/tools/github_vs_sourcegraph.md
+++ b/workflow/tools/github_vs_sourcegraph.md
@@ -1,0 +1,23 @@
+# GitHub vs. Sourcegraph
+
+[GitHub](https://github.com) is a development platform with code hosting, issue tracking, code review, and more. Sourcegraph and GitHub integrate well together.
+
+- [GitHub integration with Sourcegraph](https://docs.sourcegraph.com/integration/github) (Sourcegraph documentation)
+
+## Code search
+
+GitHub offers [code search](https://help.github.com/en/articles/searching-code), which is acceptable for smaller teams using GitHub with simple/infrequent code search needs. The main pain points we hear are lack of support for literal/regexp queries and filters, and that the UI is not optimized for searching across multiple repositories. For medium and large organizations, Sourcegraph is a better alternative to GitHub's built-in code search.
+
+## Code navigation
+
+GitHub offers limited [code navigation](https://help.github.com/en/github/managing-files-in-a-repository/navigating-code-on-github) features for certain languages and repositories.
+
+[Sourcegraph code intelligence](https://docs.sourcegraph.com/user/code_intelligence) integrates seamlessly with GitHub and offers the following benefits over what GitHub provides:
+
+- Support for many more languages
+- Cross-repository definitions and references
+- Integration with pull requests (to get code intelligence in code review)
+- Precise (non-heuristic-based) definitions and references
+- Support for all repositories (public, private, and on GitHub Enterprise Server)
+
+Any organization that sees value in GitHub's code navigation features should consider upgrading to Sourcegraph code intelligence for these benefits.

--- a/workflow/tools/gitlab_vs_sourcegraph.md
+++ b/workflow/tools/gitlab_vs_sourcegraph.md
@@ -1,0 +1,10 @@
+# GitLab vs. Sourcegraph
+
+[GitLab](https://about.gitlab.com) is a single application for the entire DevOps lifecycle. Sourcegraph and GitLab integrate well together (and offer largely complementary, not overlapping, features).
+
+- [GitLab integration with Sourcegraph](https://docs.sourcegraph.com/integration/gitlab) (Sourcegraph documentation)
+- Upcoming native integration: [GitLab blog post](https://about.gitlab.com/blog/2019/11/12/sourcegraph-code-intelligence-integration-for-gitlab/) and [Sourcegraph blog post](https://about.sourcegraph.com/blog/gitlab-integrates-sourcegraph-code-navigation-and-code-intelligence)
+
+## Code search
+
+GitLab offers [code search](https://docs.gitlab.com/ee/user/search/advanced_global_search.html), which is acceptable for smaller teams using GitLab with simple/infrequent code search needs. The main pain points we hear are lack of support for literal/regexp queries and filters, and that the UI is not optimized for searching across multiple repositories. For medium and large organizations, Sourcegraph is a better alternative to GitLab's built-in code search.

--- a/workflow/tools/google_cloud_source_repositories_vs_sourcegraph.md
+++ b/workflow/tools/google_cloud_source_repositories_vs_sourcegraph.md
@@ -1,0 +1,5 @@
+# Google Cloud Source Repositories code search vs. Sourcegraph
+
+[Cloud Source Repositories](https://cloud.google.com/source-repositories/) is a Git code host offering from Google Cloud. It offers [code search](https://cloud.google.com/source-repositories/docs/searching-code) for repositories hosted on Cloud Source Repositories.
+
+You can try a public demo of the code search tool at [source.bazel.build](https://source.bazel.build/).

--- a/workflow/tools/hound_vs_sourcegraph.md
+++ b/workflow/tools/hound_vs_sourcegraph.md
@@ -1,0 +1,17 @@
+# Hound
+
+[Hound](https://github.com/etsy/hound) was created inside Etsy by [Kelly Norton](https://github.com/kellegous) and others and open-sourced in 2015. It appears to not be actively maintained anymore, with the most recent commit (as of this document's publishing) being more than 5 months old, and many open PRs unattended to.
+
+Sourcegraph is a good replacement for Hound for almost every organization.
+
+## Pros
+
+* Very simple deployment
+* Very simple interface
+
+## Cons
+
+* Apparent unmaintained status
+* Poor scalability to many repositories (both performance-wise and UX-wise)
+* Limited filtering available for search queries
+* No support for code navigation (code intelligence and/or ctags)

--- a/workflow/tools/index.md
+++ b/workflow/tools/index.md
@@ -1,0 +1,3 @@
+# Tools
+
+See "[Other tools](../index.md#other-tools)" for comparisons between other tools and Sourcegraph.

--- a/workflow/tools/livegrep_vs_sourcegraph.md
+++ b/workflow/tools/livegrep_vs_sourcegraph.md
@@ -1,0 +1,16 @@
+# Livegrep
+
+[Livegrep](https://github.com/livegrep/livegrep) is maintained by a Stripe developer and is used inside Stripe. It has a slick demo on the Linux source code at livegrep.com.
+
+Sourcegraph is a good replacement for Livegrep for almost every organization.
+
+## Pros
+
+* Instant, as-you-type search results
+* Quick search filters to narrow by path, etc.
+
+## Cons
+
+* No support for code navigation (code intelligence and/or ctags)
+* Difficult to manage and scale (requires building custom infrastructure)
+* Although it’s used heavily by a small number of companies, it’s maintained part-time by a single developer, so future trajectory is limited

--- a/workflow/tools/opengrok_vs_sourcegraph.md
+++ b/workflow/tools/opengrok_vs_sourcegraph.md
@@ -1,0 +1,20 @@
+# Oracle OpenGrok
+
+[Oracle OpenGrok](https://github.com/oracle/opengrok) was traditionally the most popular open-source code search tool. Originally developed inside Sun Microsystems around 2004, it’s now an Oracle open-source project after Oracle acquired Sun.
+
+Sourcegraph is a good replacement for OpenGrok for almost every organization.
+
+- [Migrating from OpenGrok to Sourcegraph](https://docs.sourcegraph.com/admin/migration/opengrok) (Sourcegraph documentation)
+
+## Pros
+
+* Simple interface
+* Support for non-Git repositories
+* Easy deployment (for Java shops)
+
+## Cons
+
+* Slow and difficult-to-manage indexing process (leading to stale results for users)
+* Poor support for searching/browsing multiple commits and branches
+* Poor scalability to many repositories and for large repositories
+* Inflexible and buggy API (using the new REST API)

--- a/workflow/tools/phabricator_vs_sourcegraph.md
+++ b/workflow/tools/phabricator_vs_sourcegraph.md
@@ -1,0 +1,5 @@
+# Phabricator vs. Sourcegraph
+
+[Phabricator](https://www.phacility.com/phabricator/) is an all-in-one development platform that was initially built inside Facebook. Sourcegraph and Phabricator integrate well together (and offer complementary, not overlapping, features).
+
+- [Phabricator integration with Sourcegraph](https://docs.sourcegraph.com/integration/phabricator) (Sourcegraph documentation)


### PR DESCRIPTION
- Adds answers to common questions from prospective customers. Not all questions are answered yet, but it's a start.
- Moves the product comparisons here from the docs site. This is because the comparisons are company/product-marketing material, not product documentation material. (And they are referenced from answers to the common prospect questions.)