### PR TITLE
move some content from Graphbook to Sourcegraph handbook

### DIFF
--- a/company/remote/index.md
+++ b/company/remote/index.md
@@ -1,0 +1,5 @@
+# Remote
+
+Sourcegraph is a remote-first company.
+
+- [Tips for working remotely](tips.md)

--- a/company/remote/tips.md
+++ b/company/remote/tips.md
@@ -1,0 +1,23 @@
+# Tips for working remotely
+
+Welcome to our growing distributed team! We're excited to have you along for the #journey and have gathered some excellent tips and tricks from fellow distributed teammates on how to live your best distributed work life! Have some tips of your own you'd like to share? Add them here!
+
+## Home office and desk setup
+
+* **Separate work and home:** Try working in a separate space to where you relax/sleep - Keegan and Loic
+* **Ergonomics are key:** Consider getting an ergo friendly chair and standing desk – Julia and Christina
+* **Change the scenery:** Try working "offsite" at a coffee shop, library, or friend's house once a week - Loic
+* **Get a loud keyboard:** You can use a loud keyboard, unlike in an office environment - Keegan
+
+## Schedule
+
+* **Stick to a schedule:** When working from home, it’s VERY important to have a set schedule and the discipline to respect it, or you risk blurring the lines between work and life to an unhealthy degree. - Tomás
+* **Triage:** Morning I catch up on slack/github. I usually stick to triaging (recording in org-mode slack/issues to get back to). Smaller stuff I respond/review instantly. Then I create a plan for the rest of the day. - Keegan
+* **Timebox:** I work from around 8:30am to 5:30pm, sometimes starting 30min earlier and other times working a little bit longer. I personally need a schedule, because my productivity thrives with timeboxes. “I have two hours until lunch” or “I have one hour until the day is over” works much better for me than “let’s start working on this and see how long it takes”. - Thorsten
+
+
+## Communication
+
+* **Care:** Start by caring about your written communication. Well-written prose looks exactly like well-written, clean code: like someone cares. That means the writing has no obvious typos and grammar mistakes, but, most importantly, that it’s written for others to understand. Make sure you always reread and edit what you wrote to make sure what you want to communicate can be understood by someone who doesn’t have all of the context and knowledge you had when writing. Extra points for removing unnecessary sentences. - Thorsten
+* **Mind the round trip time:** People work in different time zones and might take a full working day or night for someone to respond to your messages. In order to avoid a multi-day back-and-forth keep this round trip time — from you to the receiver and back — in mind. In practical terms: try to provide as much information as necessary for the other person to answer your request without the need for them to ask follow-up questions. Of course that’s not always possible, but the goal should be to eliminate it as much as possible. - Thorsten
+* **Raise your voice:** When you’re working remotely none of your colleagues is going to bump into you on your way to the office kitchen, or stop by at your desk to ask you how your day is going. Nobody is going to meet you by accident. Or, in other words: you’re not visible if you don’t raise your voice. That means: actively communicate your progress, ask for help, document what you know as good as possible, etc. - Thorsten

--- a/handbook/people-ops/from-graphbook/glossary.md
+++ b/handbook/people-ops/from-graphbook/glossary.md
@@ -1,0 +1,96 @@
+# Developer lingo for non-developers: a guide
+
+*This guide is made to define and explain many of the terms that are commonplace in conversations at the Sourcegraph office but not necessarily outside of it. The goal of this guide is to break down these terms in a way that your average person can comprehend, at least at very high level. Think of this as an "intro to dev-speak"* :)
+
+### Binary
+The simplest form of computer code or programming data. It is a series of 1s and 0s that makes up the “language” that computers understand.
+
+### Code
+The fundamental component of a computer program that is created by a developer. It can be read and understood by a human and then translated into machine language (binary machine code).
+
+Humans don’t usually write in the language that computers understand since it’s just a series of 1s and 0s. Instead they write in different programming languages that can be “translated” to instructions a computer can understand. 
+
+### Programming Language
+Language used by developers involving certain vocabulary and set of grammatical rules for instructing a computer to perform specific tasks. (examples: Go, JavaScript, Python, and many more). Basically, it's a type of language used by developers to make a computer do what they want.
+
+### Compiler
+A compiler takes computer programs written in a programming language and converts them into machine language that a computer can understand and run. 
+
+For example, if you’re  traveling to France, but you only speak English, you will have to figure out how to communicate in French. You will probably need some sort of translator (a friend, a book, an app, etc.) to translate your words from English to French. Compilers “translate” what developers write in a programming language to binary– a language that computers understand.
+
+### Open Source
+In software, open source code is any publicly accessible code/project/design that can be read and modified and redistributed for any personal, commercial or educational use. 
+
+For example, if you have a recipe  for cookies that you want to share with others, so you share it in a public blog– anyone now has the ability to read it, make it, and modify it for whatever they want. 
+
+### Editor
+A code editor is a text editor program specifically made for editing code of computer programs by developers. It may be a standalone application or it may be built into an integrated development environment (IDE) or web browser.
+
+Basically, it's the environment where developers write code. Similar to how someone can use Google Docs or Microsoft Word to write and edit an essay. 
+
+### IDE (Integrated Development Environment)
+A software development tool that is similar to an editor, but has other necessary tools (debugger, tester, compiler, etc.) integrated.
+
+Imagine a Google Doc that has tools built in for error detection, previews, and language translation.
+
+### Code Host
+A service like GitHub, GitLab, or Bitbucket which provides storage and remote access to code. It's basically where your code lives. 
+
+### Version Control
+A system that tracks changes to a document or project over time in an orderly and systematic way.
+
+This is similar to how a Google Doc allows you to review a document’s history (see what changes occured, who made which changes, etc.) Version control provides the ability to “time travel” and restore previous versions of the document in case something went wrong with one of the changes. 
+
+### Git
+A version control system, developed for the maintenance of code with particularly strong support or simultaneous efforts by many developers.
+
+### README
+This is the file outlining the project and is written by the project developers for others to read. It is comparable to a “front page” of a project, where the project is outlined and described by those that worked on it. 
+
+### Issue
+A report of a possible problem with a project or piece of software. (Just like a real issue!) It is something of concern that you want to flag so it can be corrected. 
+
+### Pull Request (AKA "PR")
+A request in GitHub for someone else to review your work for any possible errors or flaws before finalizing changes. For example, if had written an article, and you were almost ready to publish it but first you want someone else to review it. They would have the option to provide feedback through comments or approve it for publishing. 
+
+### Merge
+The act of taking a series of changes in a document or project (commits, for Git) in a branch and applying them to the existing repository. Generally, merging happens once your pull request has been approved. 
+
+### Commit
+In Git, a single set of changes. This is how you store changes in your repository. 
+
+### Repository (AKA "repo")
+A collection of (usually related) source code and other files, plus the history of those files. It is a location for your project, similar to a Google Drive folder that stores related documents in one place. 
+
+### Branch
+A specific series of changes in a repository, usually used to isolate changes during their development. Branching lets you make changes, test them in a staging area, then merge them into the “master branch” (the “live” part of your code).
+
+### Master Branch
+The primary branch of a repository, usually holding the actively-developed product and working of features (non-working versions tend to stay in branches). This is the “live” part of a project that can be viewed by the public.
+
+### Clone
+A copy of a repository, including its full history. Similar to a copy of a Google Doc with all its revision history. 
+
+### Fork
+Making of a new repository which starts as a clone of an existing repository. Usually used to create changes for submission back to the repository, but also used to make a version that has changes that the original repository’s owner won’t include. 
+
+For example, if you took a Google Doc template and made a copy of it so you could use it and edit it, but you also altered the original template to add things the original template didn’t include. 
+
+### Ship
+A word which simply means that you make a feature or product available to customers. 
+
+### Dogfood
+A word to describe the act of using your own feature or product. Software is often deployed internally for employees to use before going live for customers.
+
+### Markdown
+A text markup language to allow plain text to convert to styled text using common conventions, such as * italics * or ~~ strikethrough ~~ It's just a shortcut to edit text (bolding, italicizing, underlining, etc.) without having to click the buttons on a toolbar. 
+
+### Command Line (AKA "terminal")
+A text-based interface for controlling computers by issuing textual commands. Basically, it's a place where you can enter commands for your computer to execute. 
+
+### API (Application Programming Interface)
+An API allows a piece of software to interact with another piece of software
+
+
+### Server
+An instance of a computer program that accepts and responds to requests made by another program. There are several different kinds of servers (application server, web server, cloud server, etc.)

--- a/handbook/people-ops/from-graphbook/holidays.md
+++ b/handbook/people-ops/from-graphbook/holidays.md
@@ -1,0 +1,17 @@
+# Holiday schedule
+
+The Company’s office is closed on the following dates: 
+
+* Observed January 1st - New Years Day
+
+* Observed 3rd Monday in January - Martin Luther King Jr. Day
+
+* Observed Last Monday in May - Memorial Day
+
+* Observed July 4th - Independence Day
+
+* Observed 1st Monday in September - Labor Day
+
+* Observed 4th Thursday and Friday in November - Thanksgiving and Black Friday
+
+* Observed December 24th - January 1st - Winter Break

--- a/handbook/people-ops/from-graphbook/index.md
+++ b/handbook/people-ops/from-graphbook/index.md
@@ -1,0 +1,11 @@
+# Documents copied over from Graphbook
+
+The [Graphbook](https://github.com/sourcegraph/Graphbook) was the precursor to the [Sourcegraph handbook](../../index.md). These documents were copied over and have not yet been reorganized for the handbook.
+
+- Onboarding
+  - [Remote teammates (US-based)](onboarding_remote_us.md)
+  - [Remote teammates (non-US-based)](onboarding_remote_non_us.md)
+  - [Engineers](onboarding_engineers.md)
+  - [SF-based teammates](onboarding_san_francisco.md)
+- [Holidays](holidays.md)
+- [Glossary](glossary.md)

--- a/handbook/people-ops/from-graphbook/onboarding_engineers.md
+++ b/handbook/people-ops/from-graphbook/onboarding_engineers.md
@@ -1,0 +1,35 @@
+# Engineer onboarding
+
+## Nick to-do's
+
+Grant access to the following services:
+  - [ ] **[GitHub](https://github.com/sourcegraph)**: Our code host
+  - [ ] **[Buildkite](https://buildkite.com/)**: Continuous integration tests
+  - [ ] **[Google Cloud Platform](https://cloud.google.com/)**: Compute infrastructure in the cloud
+  - [ ] **[Opsgenie](https://www.opsgenie.com/)**: On call rotation
+  - [ ] **[Docker Hub](https://hub.docker.com/)**: Docker image host
+- [ ] Schedule a recurring 1:1.
+- [ ] Schedule time to discuss Sourcegraph's system architecture and tech stack.
+- [ ] Update the on-call rotation.
+
+## New hire
+
+Your priority is to start building relationships with the team and learning our high level architecture so you have all the context that you need to be successful on our team.
+
+- [ ] Schedule a ~30 minute chat with everyone on the team to get to know them. Here are some examples:
+  - What brought them to Sourcegraph?
+  - What have they been working on at Sourcegraph?
+  - What do they like to do for fun?
+  - What is a crazy life goal that they have?
+- [ ] Schedule future ~30 minute chats with the following people to discuss your progress at Sourcegraph and any feedback that you have:
+  - [ ] Dan (@dadlerj) one month from now
+  - [ ] Beyang (@beyang) two months from now
+  - [ ] Quinn (@sqs) three months from now
+- [ ] Setup your [local development environment](https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/local_development.md) and make any improvements to the setup documentation to help the next person that runs through these instructions.
+- [ ] Kickoff a project with your manager ([roadmap](https://docs.sourcegraph.com/dev/roadmap)).
+- [ ] Join the relevant Slack channels and [get an overview](https://github.com/sourcegraph/infrastructure/blob/master/docs/slack-channels.md#sourcegraph-slack-channels).
+- [ ] Take a look at our documentation for fellow engineers:
+  - The [doc/dev folder](https://github.com/sourcegraph/sourcegraph/tree/master/doc/dev)
+  - The [on-call documentation](https://github.com/sourcegraph/infrastructure/blob/master/docs/on-call.md)
+  - The [Kubernetes documentation](https://github.com/sourcegraph/infrastructure/tree/master/kubernetes) 
+  - The [repository overview document](https://github.com/sourcegraph/infrastructure/blob/master/docs/repository-overview.md#repository-overview)

--- a/handbook/people-ops/from-graphbook/onboarding_remote_non_us.md
+++ b/handbook/people-ops/from-graphbook/onboarding_remote_non_us.md
@@ -1,0 +1,83 @@
+# Onboarding prep for internationally distributed teammates
+
+The following are the to-do's necessary to prep for a new teammate's onboarding ahead of their first day.
+
+## Dan to-do's
+
+- [ ] Alert Officengine of new hire.
+
+- [ ] Set up Gusto account (if applicable).
+
+- [ ] Fill out I-9 paperwork (if applicable).
+.
+- [ ] Fill out E-Verify (if applicable).
+
+- [ ] Send Looker invite (if applicable).
+
+- [ ] Send HubSpot invite (if applicable).
+
+## Noemi to-do's
+
+- [ ] Send new teammate welcome email– ask them to bring their I9 docs on first day if onsite (if not, request for them to mail to HQ), ask for computer preference, birthday, shirt size, mailing address, and a picture of themselves.
+
+- [ ] Order computer, keyboard, mouse, and noise cancelling headphones.
+
+- [ ] Send Fiverr artist the new teammate's picture to create their caricature.
+
+- [ ] Confirm we have proper onboarding swag (Patagonia jacket, 2 shirts, notebooks, water bottle).
+
+- [ ] Ship them onboarding swag.
+
+- [ ] Assign them a buddy (consult their manager).
+
+- [ ] Create first day schedule.
+
+- [ ] Create Gmail account and add to appropriate email groups (team@sourcegraph.com, etc.).
+
+- [ ] Share team calendars ("Sourcegraph office" and "Not working").
+
+- [ ] Add them to recurring team meeting + demos calendar invite.
+
+- [ ] Add their birthday and start/Sourcegraph anniversary date to the "Sourcegraph office" calendar.
+
+- [ ] Create Slack account.
+
+- [ ] Create Lattice account (add manager, department, and profile picture).
+
+- [ ] Create 1Password account.
+
+- [ ] Add a welcome slide to the Monday team meeting's slide deck.
+
+- [ ] Print Sourcegraph welcome letter (template in Google Docs– contains set-up instructions, first day schedule, Teammate Bingo).
+
+- [ ] Have Officengine send them an Expensify invite.
+
+- [ ] Have Officengine send them a Veem invite for international payments. 
+
+- [ ] Send JamfNow enrollment instructions.
+
+# New teammate to-do's: First day
+
+Welcome! We're excited to have you get started, so here is a list of the accounts that you will need to get started. You will receive invites for HR and general setup from Noemi and Dan. If you are missing any of the following accounts, please let them know :)
+
+## HR setup
+
+- [ ] **[Gusto](https://gusto.com/)**: Check out your benefits, pay, or tax forms.
+
+- [ ] **[Expensify](https://www.expensify.com/signin):** Upload any work related expenses for reimbursement.
+
+- [ ] **[Human Interest](https://humaninterest.com/):** Check on your 401k.
+
+## General setup
+
+- [ ] **[G Suite/Gmail](https://www.google.com/gmail/)**: Access all G Suite apps in our org (Gmail, Google Docs, Google Sheets, Google Calendar, G Hire).
+
+- [ ] **[Slack](https://slack.com/)**: Access our team communication tool.
+
+- [ ] **[GitHub](https://github.com/sourcegraph/Graphbook)**: Access the Graphbook (employee handbook).
+
+- [ ] **[Jamf Now](https://sourcegraph.jamfcloud.com)**: Enroll your device in our MDM (ask Noemi for your access code).
+
+- [ ] **[Lattice](https://sourcegraph.latticehq.com/)**: Access our teammate feedback cycles (takes place every quarter– Noemi will send out details).
+
+- [ ] **[1Password](https://1password.com/)**: Access shared team passwords and store your own passwords.

--- a/handbook/people-ops/from-graphbook/onboarding_remote_us.md
+++ b/handbook/people-ops/from-graphbook/onboarding_remote_us.md
@@ -1,0 +1,81 @@
+# Onboarding prep for US based teammates
+
+The following are the to-do's necessary to prep for a new teammate's onboarding ahead of their first day.
+
+## Dan to-do's
+
+- [ ] Alert Officengine of new hire.
+
+- [ ] Set up Gusto account.
+
+- [ ] Fill out I-9 paperwork.
+
+- [ ] Fill out E-Verify.
+
+- [ ] Send Looker invite (if applicable).
+
+- [ ] Send HubSpot invite (if applicable).
+
+## Noemi to-do's
+
+- [ ] Send new teammate welcome email– ask them to bring their I9 docs on first day if onsite (if not, request for them to mail to HQ), ask for computer preference, birthday, shirt size, mailing address, and a picture of themselves.
+
+- [ ] Order computer, keyboard, mouse, and noise cancelling headphones.
+
+- [ ] Send Fiverr artist the new teammate's picture to create their caricature.
+
+- [ ] Confirm we have proper onboarding swag (Patagonia jacket, 2 shirts, notebooks, water bottle).
+
+- [ ] Ship them onboarding swag.
+
+- [ ] Assign them a buddy (consult their manager).
+
+- [ ] Create first day schedule.
+
+- [ ] Create Gmail account and add to appropriate email groups (team@sourcegraph.com, etc.).
+
+- [ ] Share team calendars ("Sourcegraph office" and "Not working").
+
+- [ ] Add them to recurring team meeting + demos calendar invite.
+
+- [ ] Add their birthday and start/Sourcegraph anniversary date to the "Sourcegraph office" calendar.
+
+- [ ] Create Slack account.
+
+- [ ] Create Lattice account (add manager, department, and profile picture).
+
+- [ ] Create 1Password account.
+
+- [ ] Add a welcome slide to the Monday team meeting's slide deck.
+
+- [ ] Print Sourcegraph welcome letter (template in Google Docs– contains set-up instructions, first day schedule, Teammate Bingo).
+
+- [ ] Have Officengine send them an Expensify invite.
+
+ - [ ] Send JamfNow enrollment instructions.
+
+# New teammate to-do's: First day
+
+Welcome! We're excited to have you get started, so here is a list of the accounts that you will need to get started. You will receive invites for HR and general setup from Noemi and Dan. If you are missing any of the following accounts, please let them know :)
+
+## HR setup
+
+- [ ] **[Gusto](https://gusto.com/)**: Check out your benefits, pay, or tax forms.
+
+- [ ] **[Expensify](https://www.expensify.com/signin):** Upload any work related expenses for reimbursement.
+
+- [ ] **[Human Interest](https://humaninterest.com/):** Check on your 401k.
+
+## General setup
+
+- [ ] **[G Suite/Gmail](https://www.google.com/gmail/)**: Access all G Suite apps in our org (Gmail, Google Docs, Google Sheets, Google Calendar, G Hire).
+
+- [ ] **[Slack](https://slack.com/)**: Access our team communication tool.
+
+- [ ] **[GitHub](https://github.com/sourcegraph/Graphbook)**: Access the Graphbook (employee handbook).
+
+- [ ] **[Jamf Now](https://sourcegraph.jamfcloud.com)**: Enroll your device in our MDM (ask Noemi for your access code).
+
+- [ ] **[Lattice](https://sourcegraph.latticehq.com/)**: Access our teammate feedback cycles (takes place every quarter– Noemi will send out details).
+
+- [ ] **[1Password](https://1password.com/)**: Access shared team passwords and store your own passwords.

--- a/handbook/people-ops/from-graphbook/onboarding_san_francisco.md
+++ b/handbook/people-ops/from-graphbook/onboarding_san_francisco.md
@@ -1,0 +1,83 @@
+# Onboarding prep for SF based teammates
+
+The following are the to-do's necessary to prep for a new teammate's onboarding ahead of their first day.
+
+## Dan to-do's
+
+- [ ] Alert Officengine of new hire.
+
+- [ ] Set up Gusto account.
+
+- [ ] Fill out I-9 paperwork.
+
+- [ ] Fill out E-Verify.
+
+- [ ] Send Looker invite (if applicable).
+
+- [ ] Send HubSpot invite (if applicable).
+
+## Noemi to-do's
+
+- [ ] Send new teammate welcome email– ask them to bring their I9 docs on first day, ask for their computer and monitor preference (1 or 2), birthday, shirt size, dietary restrictions, and a picture of themselves.
+
+- [ ] Order computer (Required for engineers: MacBook Pro model– 13 inch, 16GB memory, 256GB storage), keyboard, mouse, and noise cancelling headphones.
+
+- [ ] Send Fiverr artist new teammate's picture to create their caricature.
+
+- [ ] Confirm we have proper onboarding swag (Patagonia jacket, 2 shirts, notebooks, water bottle).
+
+- [ ] Give them a key and key card to the office.
+
+- [ ] Assign them a buddy (consult their manager).
+
+- [ ] Create first day schedule.
+
+- [ ] Create Gmail account and add to appropriate email groups (team@sourcegraph.com, sf-local@sourcegraph.com, etc.).
+
+- [ ] Share team calendars ("Sourcegraph office" and "Not working") with new teammate.
+
+- [ ] Add them to recurring team meeting + demos calendar invite.
+
+- [ ] Add their birthday and start/Sourcegraph anniversary date to the "Sourcegraph office" calendar.
+
+- [ ] Create Slack account and add them to @sf
+
+- [ ] Create Lattice account (add manager, department, and profile picture).
+
+- [ ] Create 1Password account.
+
+- [ ] Add a welcome slide to the Monday team meeting's slide deck.
+
+- [ ] Print Sourcegraph welcome letter (template in Google Docs– contains set-up instructions, first day schedule, Teammate Bingo).
+
+- [ ] Delete any conversations referencing new teammate in #hiring-active.
+
+- [ ] Have Officengine send them an Expensify invite.
+
+- [ ] Send GrubHub for Work invite. 
+
+# New teammate to-do's: First day
+
+Welcome! We're excited to have you get started, so here is a list of the accounts that you will need to get started. You will receive invites for HR and general setup from Noemi and Dan. If you are missing any of the following accounts, please let them know :)
+
+## HR setup
+
+- [ ] **[Gusto](https://gusto.com/)**: Check out your benefits, pay, or tax forms.
+
+- [ ] **[Expensify](https://www.expensify.com/signin):** Upload any work related expenses for reimbursement.
+
+- [ ] **[Human Interest](https://humaninterest.com/):** Check on your 401k.
+
+## General setup
+
+- [ ] **[G Suite/Gmail](https://www.google.com/gmail/)**: Access all G Suite apps in our org (Gmail, Google Docs, Google Sheets, Google Calendar, G Hire).
+
+- [ ] **[Slack](https://slack.com/)**: Access our team communication tool.
+
+- [ ] **[GitHub](https://github.com/sourcegraph/Graphbook)**: Access the Graphbook (employee handbook).
+
+- [ ] **[Jamf Now](https://sourcegraph.jamfcloud.com)**: Enroll your device in our MDM (ask Noemi for your access code).
+
+- [ ] **[Lattice](https://sourcegraph.latticehq.com/)**: Access our teammate feedback cycles (takes place every quarter– Noemi will send out details).
+
+- [ ] **[1Password](https://1password.com/)**: Access shared team passwords and store your own passwords.

--- a/handbook/people-ops/index.md
+++ b/handbook/people-ops/index.md
@@ -2,8 +2,9 @@
 
 - [Travel](travel.md)
 - [Onboarding](onboarding/index.md)
-- [Distributed work tips](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/Distributed%20work%20tips.md)
-- [Graphbook](https://github.com/sourcegraph/Graphbook) (People Ops content is the process of being migrated from the Graphbook to this Sourcegraph handbook)
+- [Glossary](from-graphbook/glossary.md)
+- [Holidays](from-graphbook/holidays.md)
+- [Remote work](../../company/remote/index.md)
 
 ## [Roles](roles.md)
 

--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -1,11 +1,9 @@
 # Onboarding
 
-Some [onboarding docs](https://github.com/sourcegraph/Graphbook/tree/master/Onboarding) are in the Graphbook (which are in the process of being migrated to this handbook):
-
-- [Distributed teammates (US-based)](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/Distributed%20teammates%20(US%20based).md)
-- [Distributed teammates (non-US-based)](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/Distributed%20teammates%20(international).md)
-- [Engineers](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/Engineers.md)
-- [SF-based teammates](https://github.com/sourcegraph/Graphbook/blob/master/Onboarding/SF%20based%20teammates.md)
+- [Remote teammates (US-based)](../from-graphbook/onboarding_remote_us.md)
+- [Remote teammates (non-US-based)](../from-graphbook/onboarding_remote_non_us.md)
+- [Engineers](../from-graphbook/onboarding_engineers.md)
+- [SF-based teammates](../from-graphbook/onboarding_san_francisco.md)
 - [Sales team](../../sales/onboarding/index.md)
 
 ## For all new teammates


### PR DESCRIPTION
This moves some pages from the Graphbook (https://github.com/sourcegraph/Graphbook) to the new Sourcegraph handbook. Only pages that could be moved easily are included here. I will work with @mercadon to move the rest of the pages later this week.