### PR TITLE
add list of team members page to handbook

### DIFF
--- a/company/team/index.md
+++ b/company/team/index.md
@@ -28,8 +28,17 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Beyang Liu is CTO and co-founder of Sourcegraph. Prior to Sourcegraph, Beyang was a software engineer at Palantir Technologies, where he developed new data analysis software on a small, customer-facing team working with Fortune 500 companies. Beyang studied Computer Science at Stanford, where he published research in probabilistic graphical models and computer vision at the Stanford AI Lab and thoroughly enjoyed his compilers course.
 
 ## Christina Forney
+
 - Product Manager
 - Redwood City, CA, USA 🇺🇸
 - [christina@sourcegraph.com](mailto:christina@sourcegraph.com), [@christina4nee](https://twitter.com/christina4nee), [LinkedIn](https://www.linkedin.com/in/christinaforney)
 - Christina loves riding and spending time with her two horses, Comet and Bentley. Prior to Sourcegraph, Christina was the head of product development and lead a small dev team at Platinum Performance. At Palantir Technologies, lead the Internal Tools team that was responsible for the code hosts, build systems, and artifact management systems at Palantir. Christina attended Cal Poly, San Luis Obispo where she earned a BS in Animal Science and a MS in Computer Science. 
+
+## Stephen Gutekanst
+
+- Distribution / Software Engineer
+- Phoenix, AZ, USA 🇺🇸
+- [stephen@sourcegraph.com](mailto:stephen@sourcegraph.com), [@slimsag](https://twitter.com/slimsag), [LinkedIn](https://www.linkedin.com/in/slimsag)
+- Stephen enjoys spending time with his numerous kittos in his Phoenix home while solving some of the most critical and technically challenging issues he can get his hands on. Rapid iteration, working directly with some of our biggest customers, and relentlessly advocating for users to find solutions is what he thrives on. Prior to Sourcegraph, he worked 3 years full-time on an open-source game engine in Go.
+
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -44,7 +44,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 ## Ryan Slade
 
 - Software Engineer
-- Cape Town, South Africa :south_africa:
+- Cape Town, South Africa 🇿🇦
 - [rslade@sourcegraph.com](mailto:rslade@sourcegraph.com), [@frefity](https://twitter.com/frefity), [LinkedIn](https://www.linkedin.com/in/ryan-slade-1bb36bb/)
 - Ryan enjoys spending time with his family, mountain biking and playing squash. Prior to Sourcegraph he helped develop a real time bidding system for online advertisers at Avocet and worked for a taxi hailing company in London, Hailo. He studied Computer Science at the University of Cape Town and has lived in the South Africa, the UK, Singapore and the US.
 
@@ -59,21 +59,21 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 - Software Engineer
 - Milwaukee, WI, USA 🇺🇸
-- [eric@sourcegraph.com](mailto:eric@sourcegraph.com), [:octocat: efritz](https://github.com/efritz), [LinkedIn](https://www.linkedin.com/in/eric-fritz-414a9411/)
+- [eric@sourcegraph.com](mailto:eric@sourcegraph.com), [efritz](https://github.com/efritz), [LinkedIn](https://www.linkedin.com/in/eric-fritz-414a9411/)
 - Eric received a PhD in Computer Science from the University of Wisconsin - Milwaukee where he published research on compiler construction and taught courses in compilers and software engineering. Prior to Sourcegraph, Eric built infrastructure for UCaaS products. While not programming, Eric enjoys cooking while muttering Gordon Ramsay deep cuts to himself.
 
 ## Keegan Carruthers-Smith
 
 - Software Engineer
-- Cape Town, South Africa :south_africa:
-- [keegan@sourcegraph.com](mailto:keegan@sourcegraph.com), [:octocat: keegancsmith](https://github.com/keegancsmith), [@keegan_csmith](https://twitter.com/keegan_csmith)
+- Cape Town, South Africa 🇿🇦
+- [keegan@sourcegraph.com](mailto:keegan@sourcegraph.com), [keegancsmith](https://github.com/keegancsmith), [@keegan_csmith](https://twitter.com/keegan_csmith)
 - Keegan likes living in places with lots of sun and fibre internet. Prior to Sourcegraph, Keegan worked on the developer tools team at Facebook and spent too much time studying Mathematics and Computer Science. When not doing his day job, Keegan is usually out and about with his wife and son. He can also be found in a skatepark, on a squash court or on a mountain.
 
 ## Uwe Hoffmann
 
 - Software Engineer
 - San Francisco Bay Area, CA, USA 🇺🇸
-- [uwe@sourcegraph.com](mailto:uwe@sourcegraph.com), [:octocat: uwedeportivo](https://github.com/uwedeportivo)
+- [uwe@sourcegraph.com](mailto:uwe@sourcegraph.com), [uwedeportivo](https://github.com/uwedeportivo)
 - Uwe has finally given up on his dream of playing in the NBA and has decided that writing software is not that bad after all.
 
 ## Joe Chen
@@ -87,7 +87,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 - Content Engineer
 - San Francisco, CA, USA 🇺🇸
-- [vanesa@sourcegraph.com](mailto:vanesa@sourcegraph.com), [:octocat: vanesa](https://github.com/vanesa), [@vanesacodes](https://twitter.com/vanesacodes), [LinkedIn](https://www.linkedin.com/in/vanesaortiz/)
+- [vanesa@sourcegraph.com](mailto:vanesa@sourcegraph.com), [vanesa](https://github.com/vanesa), [@vanesacodes](https://twitter.com/vanesacodes), [LinkedIn](https://www.linkedin.com/in/vanesaortiz/)
 - Vanesa loves to travel (45 countries so far), spend time with her daughter and husband, sing and make jewelry. She grew up in the jungle and is really good at catching lizards. Prior to Sourcegraph, she lived in Germany and built dev tools for the infrastructure team at Lovoo. She used to be a human rights researcher for the London School of Economics and Political Science before transtitioning to software engineering. Her weakness is sushi.
 
 ## Noemi Mercado
@@ -95,18 +95,18 @@ To add yourself to this page, copy the following template, paste it at the end o
 - People Ops
 - San Francisco, CA, USA 🇺🇸
 - [noemi@sourcegraph.com](mailto:noemi@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/noem%C3%AD-mercado-3aa92798/)
-- Noemi is a Bay Area native that spends her free time caring for her cacti collection and volunteering with the local chapter of Border Angels. She has two teenage brothers that keep her up to date on the latest trends and lingo. Before Sourcegraph, she helped run hiring and onboarding at the homecare startup, Honor. Prior to that, she worked in HR at a non-profit supporting children in foster care. She also has a pug named Pumba.
+- Noemi is a Bay Area native that spends her free time caring for her cacti collection and volunteering with the local chapter of Border Angels. She has two teenage brothers that keep her up to date on the latest trends and lingo. Before Sourcegraph, she helped run hiring and onboarding at the homecare startup Honor. Prior to that, she worked in HR at a non-profit supporting children in foster care. She also has a pug named Pumba.
 
 ## Nick Snyder
 
 - VP Engineering
 - Belmont, CA, USA 🇺🇸
 - [nick@sourcegraph.com](mailto:nick@sourcegraph.com), [@nickdsnyder](https://twitter.com/nickdsnyder), [LinkedIn](https://www.linkedin.com/in/nickdsnyder/)
-- Nick is a career software engineer turned people manager. He started writing code in CS 101 at Vanderbilt and loved it so much that he graduated 4 years later with a M.S. in Computer Science and a B.S. in Computer Science (major), Math (major), and Economics (minor). Since then, Nick has had the priviledge to work at multiple startups (AdMob, Maybe) and big companies (Google, LinkedIn), and he appreciates the perspectives that those experiences have given him. Nick has a wife, a daughter, and a son, and likes to sail on the SF Bay as often as his calendar permits. 
+- Nick is a career software engineer turned people manager. He started writing code in CS 101 at Vanderbilt and loved it so much that he graduated 4 years later with a M.S. in Computer Science and a B.S. in Computer Science (major), Math (major), and Economics (minor). Since then, Nick has had the privilege to work at multiple startups (AdMob, Maybe) and big companies (Google, LinkedIn), and he appreciates the perspectives that those experiences have given him. Nick has a wife, a daughter, and a son, and likes to sail on the SF Bay as often as his calendar permits. 
 
 
 ## Christopher Flournoy
-- San Francisco, CA USA
+- San Francisco, CA, USA 🇺🇸
 - [christopher@sourcegraph.com](mailto:christopher@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/chrisflournoy/)
 - Chris enjoys new adventures, traveling with his wife, wine-tasting and spending time with friends and family. Depending on the season, you'll either find him skiing or attending professional sporting events.  Prior to Sourcegraph, Chris helped expand BetterCloud's sales presence out west, and has held various sales roles within software companies. Chris attended Temple University where he earned a BS in Business Administration. 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -90,4 +90,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [vanesa@sourcegraph.com](mailto:vanesa@sourcegraph.com), [:octocat: vanesa](https://github.com/vanesa), [@vanesacodes](https://twitter.com/vanesacodes), [LinkedIn](https://www.linkedin.com/in/vanesaortiz/)
 - Vanesa loves to travel (45 countries so far), spend time with her daughter and husband, sing and make jewelry. She grew up in the jungle and is really good at catching lizards. Prior to Sourcegraph, she lived in Germany and built dev tools for the infrastructure team at Lovoo. She used to be a human rights researcher for the London School of Economics and Political Science before transtitioning to software engineering. Her weakness is sushi.
 
+## Noemi Mercado
+
+- People Ops
+- San Francisco, CA, USA 🇺🇸
+- [noemi@sourcegraph.com](mailto:noemi@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/noem%C3%AD-mercado-3aa92798/)
+- Noemi is a Bay Area native that spends her free time caring for her cacti collection and volunteering with the local chapter of Border Angels. She has two teenage brothers that keep her up to date on the latest trends and lingo. Before Sourcegraph, she helped run hiring and onboarding at the homecare startup, Honor. Prior to that, she worked in HR at a non-profit supporting children in foster care. She also has a pug named Pumba.
+
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -97,4 +97,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [noemi@sourcegraph.com](mailto:noemi@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/noem%C3%AD-mercado-3aa92798/)
 - Noemi is a Bay Area native that spends her free time caring for her cacti collection and volunteering with the local chapter of Border Angels. She has two teenage brothers that keep her up to date on the latest trends and lingo. Before Sourcegraph, she helped run hiring and onboarding at the homecare startup, Honor. Prior to that, she worked in HR at a non-profit supporting children in foster care. She also has a pug named Pumba.
 
+## Nick Snyder
+
+- VP Engineering
+- Belmont, CA, USA 🇺🇸
+- [nick@sourcegraph.com](mailto:nick@sourcegraph.com), [@nickdsnyder](https://twitter.com/nickdsnyder), [LinkedIn](https://www.linkedin.com/in/nickdsnyder/)
+- Nick is a career software engineer turned people manager. He started writing code in CS 101 at Vanderbilt and loved it so much that he graduated 4 years later with a M.S. in Computer Science and a B.S. in Computer Science (major), Math (major), and Economics (minor). Since then, Nick has had the priviledge to work at multiple startups (AdMob, Maybe) and big companies (Google, LinkedIn), and he appreciates the perspectives that those experiences have given him. Nick has a wife, a daughter, and a son, and likes to sail on the SF Bay as often as his calendar permits. 
+
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -53,6 +53,6 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Software Engineer
 - Phoenix, AZ, USA 🇺🇸
 [rijnard@sourcegraph.com](mailto:rijnard@sourcegraph.com), [@rvtond](https://twitter.com/rvtond), [LinkedIn](https://www.linkedin.com/in/rijnard)
-- Rijnard just wants to stop the proliferation of bad code. Seriously, it's out of control. His favorite color is OCaml, and he collects stamps and flashlights. He currently lives a pretty unthethered life while working for Sourcegraph. Incidentally, this aligns well with his goal of building future thinking dev tools that improve the state of software. Rijnard holds a PhD in Computer Science from Carnegie Mellon University, where his research focused on automated bug finding and bug fixing.
+- Rijnard just wants to stop the proliferation of bad code. Seriously, it's out of control. His favorite color is OCaml, and he collects stamps and flashlights. He currently lives a pretty untethered life while working for Sourcegraph. Incidentally, this aligns well with his goal of building future thinking dev tools that improve the state of software. Rijnard holds a PhD in Computer Science from Carnegie Mellon University, where his research focused on automated bug finding and bug fixing.
 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -55,4 +55,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [rijnard@sourcegraph.com](mailto:rijnard@sourcegraph.com), [@rvtond](https://twitter.com/rvtond), [LinkedIn](https://www.linkedin.com/in/rijnard)
 - Rijnard just wants to stop the proliferation of bad code. Seriously, it's out of control. His favorite color is OCaml, and he collects stamps and flashlights. He currently lives a pretty untethered life while working for Sourcegraph. Incidentally, this aligns well with his goal of building future thinking dev tools that improve the state of software. Rijnard holds a PhD in Computer Science from Carnegie Mellon University, where his research focused on automated bug finding and bug fixing.
 
+## Eric Fritz
+
+- Software Engineer
+- Milwaukee, WI, USA 🇺🇸
+- [eric@sourcegraph.com](mailto:eric@sourcegraph.com), [:octocat: efritz](https://github.com/efritz), [LinkedIn](https://www.linkedin.com/in/eric-fritz-414a9411/)
+- Eric received a PhD in Computer Science from the University of Wisconsin - Milwaukee where he published research on compiler construction and taught courses in compilers and software engineering. Prior to Sourcegraph, Eric built infrastructure for UCaaS products. While not programming, Eric enjoys cooking while muttering Gordon Ramsay deep cuts to himself.
+
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -27,4 +27,9 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [beyang@sourcegraph.com](mailto:beyang@sourcegraph.com), [@beyang](https://twitter.com/beyang), [LinkedIn](https://www.linkedin.com/in/beyang-liu-07651227)
 - Beyang Liu is CTO and co-founder of Sourcegraph. Prior to Sourcegraph, Beyang was a software engineer at Palantir Technologies, where he developed new data analysis software on a small, customer-facing team working with Fortune 500 companies. Beyang studied Computer Science at Stanford, where he published research in probabilistic graphical models and computer vision at the Stanford AI Lab and thoroughly enjoyed his compilers course.
 
+## Christina Forney
+- Product Manager
+- Redwood City, CA, USA 🇺🇸
+- [christina@sourcegraph.com](mailto:christina@sourcegraph.com), [@christina4nee](https://twitter.com/christina4nee), [LinkedIn](https://www.linkedin.com/in/christinaforney)
+- Christina loves riding and spending time with her two horses, Comet and Bentley. Prior to Sourcegraph, Christina was the head of product development and lead a small dev team at Platinum Performance. At Palantir Technologies, lead the Internal Tools team that was responsible for the code hosts, build systems, and artifact management systems at Palantir. Christina attended Cal Poly, San Luis Obispo where she earned a BS in Animal Science and a MS in Computer Science. 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -104,4 +104,10 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [nick@sourcegraph.com](mailto:nick@sourcegraph.com), [@nickdsnyder](https://twitter.com/nickdsnyder), [LinkedIn](https://www.linkedin.com/in/nickdsnyder/)
 - Nick is a career software engineer turned people manager. He started writing code in CS 101 at Vanderbilt and loved it so much that he graduated 4 years later with a M.S. in Computer Science and a B.S. in Computer Science (major), Math (major), and Economics (minor). Since then, Nick has had the priviledge to work at multiple startups (AdMob, Maybe) and big companies (Google, LinkedIn), and he appreciates the perspectives that those experiences have given him. Nick has a wife, a daughter, and a son, and likes to sail on the SF Bay as often as his calendar permits. 
 
+## Christopher Flournoy
+
+- Account Executive 
+- San Francisco, CA 🇺🇸
+- [christopher@sourcegraph.com](mailto:christopher@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/chrisflournoy/)
+- Chris enjoys new adventures, traveling with his wife, wine-tasting and spending time with friends and family. Depending on the season, you'll either find him skiing or attending professional sporting events.  Prior to Sourcegraph, Chris helped expand BetterCloud's sales presence out west and has held various sales roles within software companies. Chris attended Temple University where he earned a BS in Business Administration. 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -52,7 +52,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 - Software Engineer
 - Phoenix, AZ, USA 🇺🇸
-[rijnard@sourcegraph.com](mailto:rijnard@sourcegraph.com), [@rvtond](https://twitter.com/rvtond), [LinkedIn](https://www.linkedin.com/in/rijnard)
+- [rijnard@sourcegraph.com](mailto:rijnard@sourcegraph.com), [@rvtond](https://twitter.com/rvtond), [LinkedIn](https://www.linkedin.com/in/rijnard)
 - Rijnard just wants to stop the proliferation of bad code. Seriously, it's out of control. His favorite color is OCaml, and he collects stamps and flashlights. He currently lives a pretty untethered life while working for Sourcegraph. Incidentally, this aligns well with his goal of building future thinking dev tools that improve the state of software. Rijnard holds a PhD in Computer Science from Carnegie Mellon University, where his research focused on automated bug finding and bug fixing.
 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -69,11 +69,18 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [keegan@sourcegraph.com](mailto:keegan@sourcegraph.com), [:octocat: keegancsmith](https://github.com/keegancsmith), [@keegan_csmith](https://twitter.com/keegan_csmith)
 - Keegan likes living in places with lots of sun and fibre internet. Prior to Sourcegraph, Keegan worked on the developer tools team at Facebook and spent too much time studying Mathematics and Computer Science. When not doing his day job, Keegan is usually out and about with his wife and son. He can also be found in a skatepark, on a squash court or on a mountain.
 
-## Full Name
+## Uwe Hoffmann
 
 - Software Engineer
 - San Francisco Bay Area, CA, USA 🇺🇸
 - [uwe@sourcegraph.com](mailto:uwe@sourcegraph.com), [:octocat: uwedeportivo](https://github.com/uwedeportivo)
 - Uwe has finally given up on his dream of playing in the NBA and has decided that writing software is not that bad after all.
+
+## Joe Chen
+
+- Software Engineer
+- Boston, MA, USA 🇺🇸
+- [joe@sourcegraph.com](mailto:joe@sourcegraph.com), [@unknwon](https://github.com/unknwon), [LinkedIn](https://www.linkedin.com/in/jiahua-chen-86218a81/)
+- Joe lives in his little dark room. Prior to Sourcegraph, Joe created the Gogs project, a painless self-hosted Git service. Joe graduated with a MS in Software Development from Boston University.
 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -107,6 +107,6 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 ## Christopher Flournoy
 - San Francisco, CA USA
-- [christopher@sourcegraph.com](mailto:christopher@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/eric-fritz-414a9411/)
+- [christopher@sourcegraph.com](mailto:christopher@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/chrisflournoy/)
 - Chris enjoys new adventures, traveling with his wife, wine-tasting and spending time with friends and family. Depending on the season, you'll either find him skiing or attending professional sporting events.  Prior to Sourcegraph, Chris helped expand BetterCloud's sales presence out west, and has held various sales roles within software companies. Chris attended Temple University where he earned a BS in Business Administration. 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -32,7 +32,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Product Manager
 - Redwood City, CA, USA 🇺🇸
 - [christina@sourcegraph.com](mailto:christina@sourcegraph.com), [@christina4nee](https://twitter.com/christina4nee), [LinkedIn](https://www.linkedin.com/in/christinaforney)
-- Christina loves riding and spending time with her two horses, Comet and Bentley. Prior to Sourcegraph, Christina was the head of product development and lead a small dev team at Platinum Performance. At Palantir Technologies, lead the Internal Tools team that was responsible for the code hosts, build systems, and artifact management systems at Palantir. Christina attended Cal Poly, San Luis Obispo where she earned a BS in Animal Science and a MS in Computer Science. 
+- Christina loves riding and spending time with her two horses, Comet and Bentley. Prior to Sourcegraph, Christina was the head of product development and lead a small dev team at Platinum Performance. At Palantir Technologies, lead the Internal Tools team that was responsible for the code hosts, build systems, and artifact management systems at Palantir. Christina attended Cal Poly, San Luis Obispo where she earned a BS in Animal Science and a MS in Computer Science.
 
 ## Stephen Gutekanst
 
@@ -44,8 +44,15 @@ To add yourself to this page, copy the following template, paste it at the end o
 ## Ryan Slade
 
 - Software Engineer
-- Cape Town, South Africa :south_africa: 
+- Cape Town, South Africa :south_africa:
 - [rslade@sourcegraph.com](mailto:rslade@sourcegraph.com), [@frefity](https://twitter.com/frefity), [LinkedIn](https://www.linkedin.com/in/ryan-slade-1bb36bb/)
 - Ryan enjoys spending time with his family, mountain biking and playing squash. Prior to Sourcegraph he helped develop a real time bidding system for online advertisers at Avocet and worked for a taxi hailing company in London, Hailo. He studied Computer Science at the University of Cape Town and has lived in the South Africa, the UK, Singapore and the US.
+
+## Rijnard van Tonder
+
+- Software Engineer
+- Phoenix, AZ, USA 🇺🇸
+[rijnard@sourcegraph.com](mailto:rijnard@sourcegraph.com), [@rvtond](https://twitter.com/rvtond), [LinkedIn](https://www.linkedin.com/in/rijnard)
+- Rijnard just wants to stop the proliferation of bad code. Seriously, it's out of control. His favorite color is OCaml, and he collects stamps and flashlights. He is currently living a pretty unthethered life while working for Sourcegraph. Incidentally, this aligns well with his goals of building future thinking dev tools that improve the state of software. Rijnard holds a PhD in Computer Science from Carnegie Mellon University, where his research focused on automated bug finding and bug fixing.
 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -116,5 +116,5 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Growth & Business Operations 
 - San Francisco, CA 🇺🇸
 - [ericbm@sourcegraph.com](mailto:ericbm@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/ericbm/), [:octocat: ebrodymoore](https://github.com/ebrodymoore)
-- Eric splits his weekends eating his way through the Bay Area and getting out of town to explore the west coast nature, snowboard or golf. Prior to Sourcegraph, Eric was the first hire at Drift Marketplace, where he built the finance and analytics functions, and Deloitte Consulting’s strategy and operations practice. Eric graduated with a BS in Finance from University of Washington.
+- Eric splits his weekends eating his way through the Bay Area and getting out of town to explore the west coast nature, snowboard or golf. Prior to Sourcegraph, Eric was the first hire at Drift Marketplace, where he built the finance and analytics functions, and Deloitte Consulting’s strategy and operations practice. Eric graduated with a BS in Finance from the University of Washington.
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -62,4 +62,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [eric@sourcegraph.com](mailto:eric@sourcegraph.com), [:octocat: efritz](https://github.com/efritz), [LinkedIn](https://www.linkedin.com/in/eric-fritz-414a9411/)
 - Eric received a PhD in Computer Science from the University of Wisconsin - Milwaukee where he published research on compiler construction and taught courses in compilers and software engineering. Prior to Sourcegraph, Eric built infrastructure for UCaaS products. While not programming, Eric enjoys cooking while muttering Gordon Ramsay deep cuts to himself.
 
+## Keegan Carruthers-Smith
+
+- Software Engineer
+- Cape Town, South Africa :south_africa:
+- [keegan@sourcegraph.com](mailto:keegan@sourcegraph.com), [:octocat: keegancsmith](https://github.com/keegancsmith), [@keegan_csmith](https://twitter.com/keegan_csmith)
+- Keegan likes living in places with lots of sun and fibre internet. Prior to Sourcegraph, Keegan worked on the developer tools team at Facebook and spent too much time studying Mathematics and Computer Science. When not doing his day job, Keegan is usually out and about with his wife and son. He can also be found in a skatepark, on a squash court or on a mountain.
+
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -32,7 +32,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Product Manager
 - Redwood City, CA, USA 🇺🇸
 - [christina@sourcegraph.com](mailto:christina@sourcegraph.com), [@christina4nee](https://twitter.com/christina4nee), [LinkedIn](https://www.linkedin.com/in/christinaforney)
-- Christina loves riding and spending time with her two horses, Comet and Bentley. Prior to Sourcegraph, Christina was the head of product development and lead a small dev team at Platinum Performance. At Palantir Technologies, lead the Internal Tools team that was responsible for the code hosts, build systems, and artifact management systems at Palantir. Christina attended Cal Poly, San Luis Obispo where she earned a BS in Animal Science and a MS in Computer Science.
+- Christina loves riding and spending time with her two horses, Comet and Bentley. Prior to Sourcegraph, Christina was the head of product development and lead a small dev team at Platinum Performance. At Palantir Technologies, she lead the Internal Tools team that was responsible for the code hosts, build systems, and artifact management systems at Palantir. Christina attended Cal Poly, San Luis Obispo where she earned a BS in Animal Science and a MS in Computer Science.
 
 ## Stephen Gutekanst
 

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -1,0 +1,30 @@
+# Sourcegraph team
+
+<!--
+
+To add yourself to this page, copy the following template, paste it at the end of this file, and make it about yourself!
+
+## Full Name
+
+- Role(s)
+- City, region, country, country flag emoji
+- [you@sourcegraph.com](mailto:you@sourcegraph.com), other social media links (if any)
+- Bio (hobbies, work experience, family, pets, etc.)
+
+-->
+
+## Quinn Slack
+
+- [CEO](../../handbook/ceo/index.md), Co-founder, Board of Directors
+- San Francisco, CA, USA 🇺🇸
+- [sqs@sourcegraph.com](mailto:sqs@sourcegraph.com), [@sqs](https://twitter.com/sqs), [LinkedIn](https://www.linkedin.com/in/quinnslack)
+- Quinn lives just north of the Golden Gate Bridge with his wife and daughter. Prior to Sourcegraph, Quinn co-founded Blend Labs, an enterprise technology company with ~500 employees dedicated to improving home lending. At Palantir Technologies, he created a technology platform to help two of the top five U.S. banks recover from the housing crisis. He was the first employee and developer at Bleacher Report after graduating from high school. Quinn graduated with a BS in Computer Science from Stanford.
+
+## Beyang Liu
+
+- CTO, Co-founder, Board of Directors
+- San Francisco, CA, USA 🇺🇸
+- [beyang@sourcegraph.com](mailto:beyang@sourcegraph.com), [@beyang](https://twitter.com/beyang), [LinkedIn](https://www.linkedin.com/in/beyang-liu-07651227)
+- Beyang Liu is CTO and co-founder of Sourcegraph. Prior to Sourcegraph, Beyang was a software engineer at Palantir Technologies, where he developed new data analysis software on a small, customer-facing team working with Fortune 500 companies. Beyang studied Computer Science at Stanford, where he published research in probabilistic graphical models and computer vision at the Stanford AI Lab and thoroughly enjoyed his compilers course.
+
+<!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -104,17 +104,9 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [nick@sourcegraph.com](mailto:nick@sourcegraph.com), [@nickdsnyder](https://twitter.com/nickdsnyder), [LinkedIn](https://www.linkedin.com/in/nickdsnyder/)
 - Nick is a career software engineer turned people manager. He started writing code in CS 101 at Vanderbilt and loved it so much that he graduated 4 years later with a M.S. in Computer Science and a B.S. in Computer Science (major), Math (major), and Economics (minor). Since then, Nick has had the priviledge to work at multiple startups (AdMob, Maybe) and big companies (Google, LinkedIn), and he appreciates the perspectives that those experiences have given him. Nick has a wife, a daughter, and a son, and likes to sail on the SF Bay as often as his calendar permits. 
 
+
 ## Christopher Flournoy
-
-- Account Executive 
-- San Francisco, CA 🇺🇸
-- [christopher@sourcegraph.com](mailto:christopher@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/chrisflournoy/)
-- Chris enjoys new adventures, traveling with his wife, wine-tasting and spending time with friends and family. Depending on the season, you'll either find him skiing or attending professional sporting events.  Prior to Sourcegraph, Chris helped expand BetterCloud's sales presence out west and has held various sales roles within software companies. Chris attended Temple University where he earned a BS in Business Administration. 
-
-## Eric Brody-Moore
-
-- Growth & Business Operations 
-- San Francisco, CA 🇺🇸
-- [ericbm@sourcegraph.com](mailto:ericbm@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/ericbm/), [:octocat: ebrodymoore](https://github.com/ebrodymoore)
-- Eric splits his weekends eating his way through the Bay Area and getting out of town to explore the west coast nature, snowboard or golf. Prior to Sourcegraph, Eric was the first hire at Drift Marketplace, where he built the finance and analytics functions, and Deloitte Consulting’s strategy and operations practice. Eric graduated with a BS in Finance from the University of Washington.
+- San Francisco, CA USA
+- [christopher@sourcegraph.com](mailto:christopher@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/eric-fritz-414a9411/)
+- Chris enjoys new adventures, traveling with his wife, wine-tasting and spending time with friends and family. Depending on the season, you'll either find him skiing or attending professional sporting events.  Prior to Sourcegraph, Chris helped expand BetterCloud's sales presence out west, and has held various sales roles within software companies. Chris attended Temple University where he earned a BS in Business Administration. 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -110,4 +110,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - San Francisco, CA 🇺🇸
 - [christopher@sourcegraph.com](mailto:christopher@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/chrisflournoy/)
 - Chris enjoys new adventures, traveling with his wife, wine-tasting and spending time with friends and family. Depending on the season, you'll either find him skiing or attending professional sporting events.  Prior to Sourcegraph, Chris helped expand BetterCloud's sales presence out west and has held various sales roles within software companies. Chris attended Temple University where he earned a BS in Business Administration. 
+
+## Eric Brody-Moore
+
+- Growth & Business Operations 
+- San Francisco, CA 🇺🇸
+- [ericbm@sourcegraph.com](mailto:ericbm@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/ericbm/), [:octocat: ebrodymoore](https://github.com/ebrodymoore)
+- Eric splits his weekends eating his way through the Bay Area and getting out of town to explore the west coast nature, snowboard or golf. Prior to Sourcegraph, Eric was the first hire at Drift Marketplace, where he built the finance and analytics functions, and Deloitte Consulting’s strategy and operations practice. Eric graduated with a BS in Finance from University of Washington.
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -41,4 +41,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [stephen@sourcegraph.com](mailto:stephen@sourcegraph.com), [@slimsag](https://twitter.com/slimsag), [LinkedIn](https://www.linkedin.com/in/slimsag)
 - Stephen enjoys spending time with his numerous kittos in his Phoenix home while solving some of the most critical and technically challenging issues he can get his hands on. Rapid iteration, working directly with some of our biggest customers, and relentlessly advocating for users to find solutions is what he thrives on. Prior to Sourcegraph, he worked 3 years full-time on an open-source game engine in Go.
 
+## Ryan Slade
+
+- Software Engineer
+- Cape Town, South Africa :south_africa: 
+- [rslade@sourcegraph.com](mailto:rslade@sourcegraph.com), [@frefity](https://twitter.com/frefity), [LinkedIn](https://www.linkedin.com/in/ryan-slade-1bb36bb/)
+- Ryan enjoys spending time with his family, mountain biking and playing squash. Prior to Sourcegraph he helped develop a real time bidding system for online advertisers at Avocet and worked for a taxi hailing company in London, Hailo. He studied Computer Science at the University of Cape Town and has lived in the South Africa, the UK, Singapore and the US.
+
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -53,6 +53,6 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Software Engineer
 - Phoenix, AZ, USA 🇺🇸
 [rijnard@sourcegraph.com](mailto:rijnard@sourcegraph.com), [@rvtond](https://twitter.com/rvtond), [LinkedIn](https://www.linkedin.com/in/rijnard)
-- Rijnard just wants to stop the proliferation of bad code. Seriously, it's out of control. His favorite color is OCaml, and he collects stamps and flashlights. He is currently living a pretty unthethered life while working for Sourcegraph. Incidentally, this aligns well with his goals of building future thinking dev tools that improve the state of software. Rijnard holds a PhD in Computer Science from Carnegie Mellon University, where his research focused on automated bug finding and bug fixing.
+- Rijnard just wants to stop the proliferation of bad code. Seriously, it's out of control. His favorite color is OCaml, and he collects stamps and flashlights. He currently lives a pretty unthethered life while working for Sourcegraph. Incidentally, this aligns well with his goal of building future thinking dev tools that improve the state of software. Rijnard holds a PhD in Computer Science from Carnegie Mellon University, where his research focused on automated bug finding and bug fixing.
 
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -83,4 +83,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [joe@sourcegraph.com](mailto:joe@sourcegraph.com), [@unknwon](https://github.com/unknwon), [LinkedIn](https://www.linkedin.com/in/jiahua-chen-86218a81/)
 - Joe lives in his little dark room. Prior to Sourcegraph, Joe created the Gogs project, a painless self-hosted Git service. Joe graduated with a MS in Software Development from Boston University.
 
+## Vanesa Ortiz
+
+- Content Engineer
+- San Francisco, CA, USA 🇺🇸
+- [vanesa@sourcegraph.com](mailto:vanesa@sourcegraph.com), [:octocat: vanesa](https://github.com/vanesa), [@vanesacodes](https://twitter.com/vanesacodes), [LinkedIn](https://www.linkedin.com/in/vanesaortiz/)
+- Vanesa loves to travel (45 countries so far), spend time with her daughter and husband, sing and make jewelry. She grew up in the jungle and is really good at catching lizards. Prior to Sourcegraph, she lived in Germany and built dev tools for the infrastructure team at Lovoo. She used to be a human rights researcher for the London School of Economics and Political Science before transtitioning to software engineering. Her weakness is sushi.
+
 <!-- Paste *your* section above this line! -->

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -62,6 +62,13 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [eric@sourcegraph.com](mailto:eric@sourcegraph.com), [efritz](https://github.com/efritz), [LinkedIn](https://www.linkedin.com/in/eric-fritz-414a9411/)
 - Eric received a PhD in Computer Science from the University of Wisconsin - Milwaukee where he published research on compiler construction and taught courses in compilers and software engineering. Prior to Sourcegraph, Eric built infrastructure for UCaaS products. While not programming, Eric enjoys cooking while muttering Gordon Ramsay deep cuts to himself.
 
+## Eric Brody-Moore
+
+- Growth & Business Operations 
+- San Francisco, CA 🇺🇸
+- [ericbm@sourcegraph.com](mailto:ericbm@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/ericbm/), [:octocat: ebrodymoore](https://github.com/ebrodymoore)
+- Eric splits his weekends eating his way through the Bay Area and getting out of town to explore the west coast nature, snowboard or golf. Prior to Sourcegraph, Eric was the first hire at Drift Marketplace, where he built the finance and analytics functions, and Deloitte Consulting’s strategy and operations practice. Eric graduated with a BS in Finance from the University of Washington.
+
 ## Keegan Carruthers-Smith
 
 - Software Engineer

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -69,4 +69,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [keegan@sourcegraph.com](mailto:keegan@sourcegraph.com), [:octocat: keegancsmith](https://github.com/keegancsmith), [@keegan_csmith](https://twitter.com/keegan_csmith)
 - Keegan likes living in places with lots of sun and fibre internet. Prior to Sourcegraph, Keegan worked on the developer tools team at Facebook and spent too much time studying Mathematics and Computer Science. When not doing his day job, Keegan is usually out and about with his wife and son. He can also be found in a skatepark, on a squash court or on a mountain.
 
+## Full Name
+
+- Software Engineer
+- San Francisco Bay Area, CA, USA 🇺🇸
+- [uwe@sourcegraph.com](mailto:uwe@sourcegraph.com), [:octocat: uwedeportivo](https://github.com/uwedeportivo)
+- Uwe has finally given up on his dream of playing in the NBA and has decided that writing software is not that bad after all.
+
 <!-- Paste *your* section above this line! -->

--- a/handbook/index.md
+++ b/handbook/index.md
@@ -8,6 +8,7 @@ The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's pub
 - [Handbook usage](usage.md)
 - [Communication](communication/index.md)
   - [Style guide](communication/style_guide.md)
+- [Team](../company/team/index.md)
 - [CEO](ceo/index.md)
 
 ## People Ops

--- a/handbook/people-ops/index.md
+++ b/handbook/people-ops/index.md
@@ -11,6 +11,7 @@
 - [Holidays](from-graphbook/holidays.md)
 - [Remote work](../../company/remote/index.md)
 - [Teammate philosophy](teammate_philosophy.md)
+- [List of team members](../../company/team/index.md)
 
 ## [Roles](roles.md)
 

--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -12,3 +12,4 @@
 
 - [ ] Set up a recurring weekly 25-minute [1-1 meeting](../../leadership/1-1.md) with your manager (e.g., `1-1 $YOURNAME-$MANAGERNAME`).
 - [ ] Complete the [git introduction](git_intro.md)
+- [ ] Add yourself to the [team page](../../../company/team/index.md).

--- a/website/src/pages/about.tsx
+++ b/website/src/pages/about.tsx
@@ -166,7 +166,7 @@ export default class About extends React.Component<any, any> {
                                             <p>
                                                 Quinn Slack is CEO and co-founder of Sourcegraph. Prior to Sourcegraph,
                                                 Quinn co-founded Blend Labs, an enterprise technology company with over
-                                                100 employees dedicated to improving home lending.
+                                                500 employees dedicated to improving home lending.
                                             </p>
                                             <p>
                                                 At Palantir Technologies, he created a technology platform to help two
@@ -218,7 +218,7 @@ export default class About extends React.Component<any, any> {
                                             </div>
                                             <p>
                                                 Beyang Liu is CTO and co-founder of Sourcegraph. Prior to Sourcegraph,
-                                                Beyang was a software engineer at Palantir Technologies where he
+                                                Beyang was a software engineer at Palantir Technologies, where he
                                                 developed new data analysis software on a small, customer-facing team
                                                 working with Fortune 500 companies.
                                             </p>
@@ -230,6 +230,9 @@ export default class About extends React.Component<any, any> {
                                         </div>
                                     </div>
                                 </div>
+                                <a href="/company/team">
+                                    <button className="btn btn-primary">See all Sourcegraph team members</button>
+                                </a>
                             </div>
                         </div>
                         <div className="about__investors">


### PR DESCRIPTION
Several teammates have asked for our website to list all Sourcegraph teammates (not just me and Beyang as at https://about.sourcegraph.com/about).

I've started the list here with me and Beyang because we already had bios written.  

---

## Check your name off when you've added your section

Please add yourself using the template at the top of the newly added file. **⭐⭐ See [How to add yourself to the team members page from the pull request](https://www.youtube.com/watch?v=MBgURqD4HMM) for a quick video walkthrough on how to add yourself (if you aren't familiar with GitHub pull request editing).**

I will be responsible for ensuring all teammates have added their sections. I may merge before everyone has done so, and I'll follow up with other teammates to ensure they add their section.

(GitHub is partially down right now, so I can't autocomplete everyone's usernames, but I'll add the full list later.)

- [x] @sqs
- [x] @beyang
- [x] @christinaforney
- [x] @nicksnyder
- [ ] @dadlerj
- [x] @mercadon
- [x] @slimsag
- [x] @keegancsmith
- [x] cdf
- [ ] @mrnugget
- [ ] @tsenart
- [ ] phu
- [x] Eric F
- [x] @unknwon
- [ ] @attfarhan
- [x] @rvantonder
- [ ] @felixfbecker
- [ ] @eseliger 
- [x] @vanesa
- [ ] @ryan-blunden
- [x] Ryan S
- [ ] @kzh 
- [ ] @lguychard
- [x] Eric B-M
- [x] @uwedeportivo 
- [ ] @ggilmore
- [ ] Julia G
- [ ] @chrismwendt
- [ ] @hadrian-git 
- [ ] Aileen A
- [ ] Adam F 

@sourcegraph/team 