### PR TITLE
clean up BizOps section

### DIFF
--- a/handbook/bizops/index.md
+++ b/handbook/bizops/index.md
@@ -1,8 +1,14 @@
-### Analytics
+# BizOps
+
+The BizOps (Business Operations) team is responsible for <!-- TODO(ericbm): add brief summary for other teammates who don't know what BizOps means -->.
+
+To reach us, mention `@ericbm` in #sales or #marketing. <!-- TODO(ericbm): or create a new channel, or whatever you prefer -->
+
+## Analytics
 
 This page describes Sourcegraph's analytics function, our data sources, and how to use our data tools.
 
-## How to submit a data request
+### How to submit a data request
 
 [Looker](https://sourcegraph.looker.com/) is a self-service tool so we encourage everyone to try finding answers within the tool. [Get started here](#using-looker) if you're not familiar with Looker, the team in the #analytics Slack channel are more than happy to answer any questions regarding Looker. 
 
@@ -14,7 +20,7 @@ This page describes Sourcegraph's analytics function, our data sources, and how 
 
 **Small asks and questions:** Post in the #analytics channel in Slack. 
 
-## Data sources
+### Data sources
 
 Here are the following sources we collect data from:
 
@@ -25,15 +31,15 @@ Here are the following sources we collect data from:
 * [Pings](https://docs.sourcegraph.com/admin/pings) from self-hosted Sourcegraph instances containing anonymous and aggregated information
 * [Custom tool to track events](https://github.com/sourcegraph/sourcegraph/issues/5486) on the Sourcegraph.com instance
 
-## Data tools
+### Data tools
 
 * [Looker](#using-looker): Business intelligence/data visualization tool
 * Google Cloud Platform: BigQuery is our data warehouse and the database Looker runs on top of
 * Google Sheets: There are a [number of spreadsheets](https://drive.google.com/drive/folders/1vOyhFO90FjHe-bwnHOZeljHLuhXL2BAv)that Looker queries (by way of BigQuery).
 
-### Using Looker
+## Using Looker
 
-## Sourcegraph quick links
+### Sourcegraph quick links
 
 [All Instances](https://sourcegraph.looker.com/looks/436)<br/>
 [Specific Instance Overview](https://sourcegraph.looker.com/dashboards/94?Unique%20Server%20ID=&Site%20ID=&filter_config=%7B%22Unique%20Server%20ID%22:%5B%7B%22type%22:%22%3D%22,%22values%22:%5B%7B%22constant%22:%22%22%7D,%7B%7D%5D,%22id%22:4%7D%5D,%22Site%20ID%22:%5B%7B%22type%22:%22%3D%22,%22values%22:%5B%7B%22constant%22:%22%22%7D,%7B%7D%5D,%22id%22:5%7D%5D%7D) (To select a specific company, fill the Unique Server ID field)<br/>
@@ -43,7 +49,7 @@ Folders:<br/>
 [Sales](https://sourcegraph.looker.com/folders/114)<br/>
 [Product Insights](https://sourcegraph.looker.com/folders/113)<br/>
 
-## Getting started with Looker
+### Getting started with Looker
 
 Looker enables us to explore and visualize Sourcegraph data sources. If you're a new user, here's where to get started.
 

--- a/handbook/index.md
+++ b/handbook/index.md
@@ -42,4 +42,4 @@ The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's pub
 
 ## BizOps
 
-- [Analytics](bizops/index.md)
+- [BizOps](bizops/index.md)

--- a/handbook/sales/index.md
+++ b/handbook/sales/index.md
@@ -135,14 +135,14 @@ Please keep the following information updated for deals. These are the the most 
 * Deal size
 * Number of engineers
 
-If a deal comes through a referral or introduction, tell [BizOps](@sourcegraph/bizops) so an adjustment can be made in the database to reflect this. 
+If a deal comes through a referral or introduction, tell [BizOps](../bizops/index.md) so an adjustment can be made in the database to reflect this. 
 
 ### When a deal is won
 1. Mark the ‘Deal Status’ as ‘Closed Won’
 1. Mark the column ‘End of contract’ with the last day of the contract. HubSpot will automatically create a renewal deal based on this date
 
 ### When a deal is lost
-1. Update the ‘Closed Lost Dropdown’ property to reflect the reason. If the reason doesn’t exist in the dropdown, you can talk to [BizOps](@sourcegrapgh/bizops) about adding one
+1. Update the ‘Closed Lost Dropdown’ property to reflect the reason. If the reason doesn’t exist in the dropdown, you can talk to [BizOps](../bizops/index.md) about adding one
 1. Expand upon the reason in the longform ‘Closed Lost Reason’ field. This supports [2019-Q4 OKR 1 v](https://about.sourcegraph.com/company/okrs/2019_q4) to identify the top 3 reasons potential customers don't sign. 
 
 ### Recording outbound activity


### PR DESCRIPTION
- Make the main BizOps handbook page consistent with the other main handbook pages for teams. It needs to explain what the team is.
- Fix links from the sales handbook pages for people to contact BizOps. Previously, these used incorrect URLs (which is a simple problem, https://github.com/sourcegraph/about/pull/365#issuecomment-558516775) and they referred to a GitHub team `@sourcegraph/bizops`. That is not a helpful way to tell people how to contact BizOps in general. It would only work for mentioning the BizOps team on GitHub issues/PRs (which is not the context in which the sales pages ask people to contact BizOps). I changed this to link to the main BizOps handbook page, which includes instructions on how to contact the BizOps team.
- Fix Markdown headers (see https://github.com/sourcegraph/about/pull/365/files#r350595870).

@ebrodymoore:

- [ ] There are 2 TODOs in this PR that you should address
- [ ] In general, we like to avoid acronyms/jargon ([I will document this in the handbook](https://github.com/sourcegraph/about/pull/394)). This would suggest calling the team "Business Ops" and the folder `business-ops`, not "BizOps" and `bizops`, respectively. If this is OK with you and doesn't change the meaning of the term in your opinion, please make this change. Otherwise, it is fine to leave it as-is.