### PR TITLE
Prevent accidental check-offs of non-cherry-pick'd commits

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -10,7 +10,7 @@ Arguments:
 
 # $MAJOR.$MINOR.$PATCH Patch Release
 
-**Attention developers:** Add pending changes to this checklist, cherry-pick the relevant commits onto branch `$MAJOR.$MINOR`, and then check off the item:
+**Attention developers:** Add pending changes to this checklist, cherry-pick the relevant commits onto branch `$MAJOR.$MINOR`. **Only check off items if the relevant PR/commits have been cherry-picked into the branch**:
 
 - [ ] TODO: Add PR or commit links here
 


### PR DESCRIPTION
This happened by accident in https://github.com/sourcegraph/sourcegraph/issues/5519 and this change would've hopefully prevented it 😃