### PR TITLE
1-1s with Nick

### DIFF
--- a/company/team/index.md
+++ b/company/team/index.md
@@ -1,5 +1,7 @@
 # Sourcegraph team
 
+This page contains brief bios of our team. Teammates may also have a personal documentation page in this directory that is named according to their Sourcegraph email address (e.g. you@sourcegraph.com -> you.md).
+
 <!--
 
 To add yourself to this page, copy the following template, paste it at the end of this file, and make it about yourself!
@@ -64,7 +66,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 ## Eric Brody-Moore
 
-- Growth & Business Operations 
+- Growth & Business Operations
 - San Francisco, CA 🇺🇸
 - [ericbm@sourcegraph.com](mailto:ericbm@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/ericbm/), [ebrodymoore](https://github.com/ebrodymoore)
 - Eric splits his weekends eating his way through the Bay Area and getting out of town to explore the west coast nature, snowboard or golf. Prior to Sourcegraph, Eric was the first hire at Drift Marketplace, where he built the finance and analytics functions, and Deloitte Consulting’s strategy and operations practice. Eric graduated with a BS in Finance from the University of Washington.
@@ -108,13 +110,14 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 - VP Engineering
 - Belmont, CA, USA 🇺🇸
-- [nick@sourcegraph.com](mailto:nick@sourcegraph.com), [@nickdsnyder](https://twitter.com/nickdsnyder), [LinkedIn](https://www.linkedin.com/in/nickdsnyder/)
-- Nick is a career software engineer turned people manager. He started writing code in CS 101 at Vanderbilt and loved it so much that he graduated 4 years later with a M.S. in Computer Science and a B.S. in Computer Science (major), Math (major), and Economics (minor). Since then, Nick has had the privilege to work at multiple startups (AdMob, Maybe) and big companies (Google, LinkedIn), and he appreciates the perspectives that those experiences have given him. Nick has a wife, a daughter, and a son, and likes to sail on the SF Bay as often as his calendar permits. 
+- [nick@sourcegraph.com](mailto:nick@sourcegraph.com), [@nickdsnyder](https://twitter.com/nickdsnyder), [LinkedIn](https://www.linkedin.com/in/nickdsnyder/), [personal docs](nick.md)
+- Nick is a career software engineer turned people manager. He started writing code in CS 101 at Vanderbilt and loved it so much that he graduated 4 years later with a M.S. in Computer Science and a B.S. in Computer Science (major), Math (major), and Economics (minor). Since then, Nick has had the privilege to work at multiple startups (AdMob, Maybe) and big companies (Google, LinkedIn), and he appreciates the perspectives that those experiences have given him. Nick has a wife, a daughter, and a son, and likes to sail on the SF Bay as often as his calendar permits.
 
 ## Christopher Flournoy
+
 - San Francisco, CA, USA 🇺🇸
 - [christopher@sourcegraph.com](mailto:christopher@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/chrisflournoy/)
-- Chris enjoys new adventures, traveling with his wife, wine-tasting and spending time with friends and family. Depending on the season, you'll either find him skiing or attending professional sporting events.  Prior to Sourcegraph, Chris helped expand BetterCloud's sales presence out west, and has held various sales roles within software companies. Chris attended Temple University where he earned a BS in Business Administration. 
+- Chris enjoys new adventures, traveling with his wife, wine-tasting and spending time with friends and family. Depending on the season, you'll either find him skiing or attending professional sporting events. Prior to Sourcegraph, Chris helped expand BetterCloud's sales presence out west, and has held various sales roles within software companies. Chris attended Temple University where he earned a BS in Business Administration.
 
 ## Thorsten Ball
 
@@ -125,7 +128,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 ## Loïc Guychard
 
-- Software engineer, manager 
+- Software engineer, manager
 - Brest, Brittany, France 🇫🇷
 - [loic@sourcegraph.com](mailto:loic@sourcegraph.com), [lguychard](https://github.com/lguychard), [LinkedIn](https://www.linkedin.com/in/lo%C3%AFc-guychard-749b8152/)
 - Loïc loves oceanside living and long bike rides. He started his career as a linguist, before transitioning to software engineering while working at Dashlane.
@@ -141,7 +144,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 - Head of Marketing
 - Hillsborough, CA, USA 🇺🇸
-- [adam@sourcegraph.com](mailto:adam@sourcegraph.com),  [LinkedIn](https://www.linkedin.com/in/adamfrankl)
+- [adam@sourcegraph.com](mailto:adam@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/adamfrankl)
 - Adam has spent most of his career marketing technology to developers. He has co-founded or led marketing at 16 VC-backed startups, raning from developer tools to game technology to developer tools. He is a US Army veteran, and has been practising yoga for over 20 years.
 
 ## Ryan Blunden

--- a/company/team/nick.md
+++ b/company/team/nick.md
@@ -8,7 +8,7 @@ This is how I run [1-1s](../../handbook/leadership/1-1.md) with my direct report
 
 - 1-1s are 25 minutes weekly.
 - 1-1s start 5 minutes after the hour or half hour (e.g. 9:05, 9:35).
-- 5 minutes before the 1-1 starts (e.g. 9:00, 9:30), I will write a private list of the most important things I want to discuss in priority order. Direct reports should do the same.
+- 5 minutes before the 1-1 starts (e.g. 9:00, 9:30), I will write a list of the most important things I want to discuss in priority order. Direct reports should do the same.
 - Agenda:
   - Say hello and chit-chat about personal lives (<5 minutes).
   - Paste each persons agenda items into the [shared Google Doc](../../handbook/leadership/1-1.md#google-doc).

--- a/company/team/nick.md
+++ b/company/team/nick.md
@@ -11,7 +11,7 @@ This is how I run [1-1s](../../handbook/leadership/1-1.md) with my direct report
 - 5 minutes before the 1-1 starts (e.g. 9:00, 9:30), I will write a list of the most important things I want to discuss in priority order. Direct reports should do the same.
 - Agenda:
   - Say hello and chit-chat about personal lives (<5 minutes).
-  - Paste each persons agenda items into the [shared Google Doc](../../handbook/leadership/1-1.md#google-doc).
+  - Ensure each person's agenda items are in the [shared Google Doc](../../handbook/leadership/1-1.md#google-doc).
   - Talk about agenda items that are on both lists first, then the items on our individual lists.
   - We will end on time, even if we haven't covered all agenda items, and even if neither of us have a meeting immediately after.
     - If an agenda item hasn't been discussed, it is the responsibility of the person who added that agenda item to decide what to do with it (e.g. start a Slack conversation, discuss in next 1-1, take no action because it wasn't important)

--- a/company/team/nick.md
+++ b/company/team/nick.md
@@ -1,0 +1,32 @@
+# Nick Snyder
+
+## 1-1s
+
+_I will be experimenting with a modified 1-1 format, as documented below. The goal is to have more frequent, but shorter 1-1s so longer discussions are short circuited and discussed async._
+
+This is how I run [1-1s](../../handbook/leadership/1-1.md) with my direct reports.
+
+- 1-1s are 25 minutes weekly.
+- 1-1s start 5 minutes after the hour or half hour (e.g. 9:05, 9:35).
+- 5 minutes before the 1-1 starts (e.g. 9:00, 9:30), I will write a private list of the most important things I want to discuss in priority order. Direct reports should do the same.
+- Agenda:
+  - Say hello and chit-chat about personal lives (<5 minutes).
+  - Paste each persons agenda items into the [shared Google Doc](../../handbook/leadership/1-1.md#google-doc).
+  - Talk about agenda items that are on both lists first, then the items on our individual lists.
+  - We will end of time, even if we haven't covered all agenda items, and even if neither of us have a meeting immediately after.
+    - If an agenda item hasn't been discussed, it is the responsibility of the person who added that agenda item to decide what to do with it (e.g. start a Slack conversation, discuss in next 1-1, take no action because it wasn't important)
+
+The first three 1-1s I have with a direct report are a little different because I want to spend time getting to know you.
+
+1. Tell me about your life starting from grade school.
+2. What do you want to do at the pinnacle of your career?
+3. I will reflect back things I heard and tell you about how I think I can help you achieve your goals and be successful at Sourcegraph.
+
+## Skip level 1-1s
+
+A skip level 1-1 is between me and someone who I indirectly manage (e.g. the person reports to a person that I manage).
+
+If you would like to have a skip level 1-1 with me:
+
+1. Find a time on my calendar that is open and send me a calendar invite.
+2. Include as much context as is relevant so that I can prepare for the 1-1 if necessary.

--- a/company/team/nick.md
+++ b/company/team/nick.md
@@ -13,7 +13,7 @@ This is how I run [1-1s](../../handbook/leadership/1-1.md) with my direct report
   - Say hello and chit-chat about personal lives (<5 minutes).
   - Paste each persons agenda items into the [shared Google Doc](../../handbook/leadership/1-1.md#google-doc).
   - Talk about agenda items that are on both lists first, then the items on our individual lists.
-  - We will end of time, even if we haven't covered all agenda items, and even if neither of us have a meeting immediately after.
+  - We will end on time, even if we haven't covered all agenda items, and even if neither of us have a meeting immediately after.
     - If an agenda item hasn't been discussed, it is the responsibility of the person who added that agenda item to decide what to do with it (e.g. start a Slack conversation, discuss in next 1-1, take no action because it wasn't important)
 
 The first three 1-1s I have with a direct report are a little different because I want to spend time getting to know you.

--- a/handbook/leadership/1-1.md
+++ b/handbook/leadership/1-1.md
@@ -13,7 +13,7 @@ The purpose of 1-1s is to:
 
 1. In most cases, 1-1s should be weekly recurring 25-minute meetings.
    - When a new teammate joins, they [set up the 1-1 calendar event](../people-ops/onboarding/index.md#for-all-new-teammates).
-1. Create a Google Doc shared with only the manager and the direct report to keep notes from the current meeting and a list of topics to discuss next time (which can be added to throughout the week).
+1. Create a Google Doc shared with only the manager and the direct report to keep notes from the current meeting and a list of topics to discuss next time (which can be added to throughout the week). {#google-doc}
    - At the top of the doc, put the relevant OKRs for the direct report so they remain top of mind. {#okrs-in-notes-doc}
 1. Use a consistent agenda ([GitLab's suggested 1-1 agenda](https://about.gitlab.com/handbook/leadership/1-1/suggested-agenda-format/)).
 1. Both people should be contributing to the 1-1 agenda (things to talk about). If either person is not contributing much, that is an indication of a larger problem that you need to solve.


### PR DESCRIPTION
This PR documents that individuals on the team can have personal documentation pages, which I think is a good option to have for when individuals want to document their own processes and APIs.

For example, I want to document how I do (or want to do) 1-1s, but I don't necessarily want to document that this is how everyone should do 1-1s (especially since I haven't tried this format myself).

(this PR also fixes some formatting issues)