### PR TITLE
don't auto-run prettier on handbook markdown files

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "prettier.requireConfig": true
+}


### PR DESCRIPTION
We don't want to run prettier to standardize Markdown formatting on handbook Markdown files for the reasons discussed in https://github.com/sourcegraph/about/pull/429#discussion_r353997479.

Many teammates use the prettier VS Code editor extension, which runs on all Markdown files by default. That means their handbok edits include a lot of unrelated prettier edits.

The `prettier.requireConfig` VS Code setting to the rescue! It tells prettier not to run on the handbook files (because there is no explicit prettier config file that applies to them). HT @felixfbecker at https://github.com/sourcegraph/about/pull/429#discussion_r354010829