### PR TITLE
releases: fix broken variable expansion + simplify commands

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -41,7 +41,7 @@ In [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph):
     git cherry-pick <commit0> <commit1> ... # all relevant commits from the master branch
     git push $MAJOR.$MINOR
     git tag v$MAJOR.$MINOR.$PATCH
-    git push v$MAJOR.$MINOR.$PATCH
+    git push origin v$MAJOR.$MINOR.$PATCH
     ```
 
 ## Update the docs

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -19,13 +19,13 @@ Arguments:
 - [ ] Push the branch `$MAJOR.$MINOR` with your cherry-picked commit(s) and make sure CI passes.
 - [ ] Push a release candidate tag:
     ```
-    VERSION=$MAJOR.$MINOR git checkout "$VERSION"
-    VERSION='v$MAJOR.$MINOR.$PATCH-rc.1' bash -c 'git tag -a "$VERSION" -m "$VERSION" && git push origin "$VERSION"'
+    git checkout '$MAJOR.$MINOR'
+    git tag -a 'v$MAJOR.$MINOR.$PATCH-rc.1' -m 'v$MAJOR.$MINOR.$PATCH-rc.1' && git push origin 'v$MAJOR.$MINOR.$PATCH-rc.1'
     ```
 - [ ] If CI passes, push the release tag:
     ```
-    VERSION=$MAJOR.$MINOR git checkout "$VERSION"
-    VERSION='v$MAJOR.$MINOR.$PATCH' bash -c 'git tag -a "$VERSION" -m "$VERSION" && git push origin "$VERSION"'
+    git checkout '$MAJOR.$MINOR'
+    git tag -a 'v$MAJOR.$MINOR.$PATCH' -m 'v$MAJOR.$MINOR.$PATCH' && git push origin 'v$MAJOR.$MINOR.$PATCH'
     ```
 - [ ] Wait for the final Docker images to be available at https://hub.docker.com/r/sourcegraph/server/tags.
 


### PR DESCRIPTION
The `git checkout` commands didn't work in Bash as-is, and since this is not hand-written anymore it seems fine to not use variables at all.