### PR TITLE
Add Continuous Releasability Contract

### DIFF
--- a/handbook/engineering/continuous_releasability.md
+++ b/handbook/engineering/continuous_releasability.md
@@ -1,3 +1,5 @@
+# Continuous releasability
+
 We practice **continuous releasability**. This is a variant of [continous
 delivery](https://en.wikipedia.org/wiki/Continuous_delivery) adapted to a monthly release cadence
 that serves the needs of customers running their own Sourcegraph instances.

--- a/handbook/engineering/continuous_releasability.md
+++ b/handbook/engineering/continuous_releasability.md
@@ -4,7 +4,7 @@ We practice **continuous releasability**. This is a variant of [continous
 delivery](https://en.wikipedia.org/wiki/Continuous_delivery) adapted to a monthly release cadence
 that serves the needs of customers running their own Sourcegraph instances.
 
-### Continuous Releasability Contract
+## Continuous Releasability Contract
 
 * `master` branch is always releasable
 * Every new feature includes a feature flag

--- a/handbook/engineering/continuous_releasability.md
+++ b/handbook/engineering/continuous_releasability.md
@@ -44,7 +44,7 @@ Feature flags achieve 2 things:
   Releasability Contract. E.g., if we discover a critical bug in a new feature 1 day before release,
   we can immediately disable it to make the release deadline.
 
-### Exceptions
+## Exceptions
 
 In some cases, it may be prohibitively expensive to preserve releasability. For example, a major
 change made the indexed search backend horizontally scalable. Maintaining strict releasability of

--- a/handbook/engineering/continuous_releasability.md
+++ b/handbook/engineering/continuous_releasability.md
@@ -28,7 +28,7 @@ that the revision can be released to customers. In particular,
 * **Up-to-date Regression test suite**: Every key workflow has a regression test.
   * This means adding/updating regression tests when you add/update workflows.
 
-**A feature flag is required for every new feature**
+### A feature flag is required for every new feature
 
 The preferred feature flag mechanism is the
 [`experimentalFeatures`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2b90ec5006f6879193d9a0fd2d2493bc6e061004/-/blob/schema/site.schema.json#L47:6)

--- a/handbook/engineering/continuous_releasability.md
+++ b/handbook/engineering/continuous_releasability.md
@@ -1,0 +1,62 @@
+We practice **continuous releasability**. This is a variant of [continous
+delivery](https://en.wikipedia.org/wiki/Continuous_delivery) adapted to a monthly release cadence
+that serves the needs of customers running their own Sourcegraph instances.
+
+### Continuous Releasability Contract
+
+* `master` branch is always releasable
+* Every new feature includes a feature flag
+
+**`master` is always releasable**
+
+Every change merged into `master` must preserve the releasability of `master`. *Releasable* means
+that the revision can be released to customers. In particular,
+
+* **Up-to-date changelog and docs**: The changelog and documentation reflect the current feature set.
+  * Docs must be updated as soon as a feature is merged and enabled.
+  * You can merge a feature without yet updating the docs if it is behind a disabled feature flag.
+* **QA**: Every feature has been QA'd by an appropriate set of users in an appropriate environment.
+  * Simple bug fixes should be tested at the very least by the author.
+  * Simple features should be tested by someone other than the author.
+  * Complex or scale-sensitive changes should be tested by multiple people on one of the dogfood instances.
+* **No regressions**: The regression test suite passes.
+  * The regression test suite is not run in CI, because it is time-consuming and somewhat flaky.
+  * The author should manually run the regression test suite before merging, *unless* they are
+    certain the change does not break the regression test suite AND introduces no new behavior.
+* **Up-to-date Regression test suite**: Every key workflow has a regression test.
+  * This means adding/updating regression tests when you add/update workflows.
+
+**A feature flag is required for every new feature**
+
+The preferred feature flag mechanism is the
+[`experimentalFeatures`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@2b90ec5006f6879193d9a0fd2d2493bc6e061004/-/blob/schema/site.schema.json#L47:6)
+field of site config.
+
+Feature flags achieve 2 things:
+
+* They allow us to maintain the Continuous Releasability Contract while still merging big features
+  into `master` (disabled behind the feature flag) before they are fully tested. This is useful if a
+  feature needs to be deployed to a dogfood instance or beta-tested before being deemed
+  release-ready.
+* They give us a quick mechanism to disable features if a feature inadvertently breaks the
+  Releasability Contract. E.g., if we discover a critical bug in a new feature 1 day before release,
+  we can immediately disable it to make the release deadline.
+
+### Exceptions
+
+In some cases, it may be prohibitively expensive to preserve releasability. For example, a major
+change made the indexed search backend horizontally scalable. Maintaining strict releasability of
+`master` would have required spinning up the new backend alongside the old one with a feature flag
+to toggle between the old and new backends. It was far easier to switch over and fix any bugs
+immediately after.
+
+Such cases are exceptional and the conditions under which they are allowable will change as the team
+and codebase grows. If maintaining the Continuous Releasability Contract is too expensive for a
+given feature, notify the Release Captain and together come up with a QA and rollout plan. Try to
+minimize the period of time during which the Releasability Contract is broken. Here are some rules
+of thumb:
+
+* Do as much QA and testing as possible before merging into `master`.
+* Have a plan for quickly testing and fixing any issues that arise immediately after merging into
+  `master`.
+* Make the change as much in advance of the release date as possible.

--- a/handbook/engineering/continuous_releasability.md
+++ b/handbook/engineering/continuous_releasability.md
@@ -9,7 +9,7 @@ that serves the needs of customers running their own Sourcegraph instances.
 * `master` branch is always releasable
 * Every new feature includes a feature flag
 
-**`master` is always releasable**
+### `master` is always releasable
 
 Every change merged into `master` must preserve the releasability of `master`. *Releasable* means
 that the revision can be released to customers. In particular,

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -5,6 +5,7 @@
   - [How we use RFCs](../communication/rfcs/index.md)
 - [Code reviews](code_reviews.md)
 - [Go style guide](go_style_guide.md)
+- [Continuous releasability](continuous_releasability.md)
 - [Commit message guidelines](commit_messages.md)
 - [Incidents](incidents.md)
 - [Releases](releases/index.md)


### PR DESCRIPTION
This adds a page to the handbook defining a *Continuous Releasability Contract*, which holds that (1) `master` should always be releasable to customers and (2) we use feature flags for every new feature.

One side effect of abiding by the Releasability Contract is that end-of-cycle QA should become a formality, rather than a period during which we expect to catch a non-zero number of release-blocking issues. In order for this to happen, certain teams may have to do a more thorough QA pass *before* merging/enabling new features in `master` than they have in the past.

I believe this is just a written statement of our existing policy w.r.t to PRs and the state of `master` branch. However, since that policy was not written down and our team has grown since we decided on it, I am not sure that every teammate is aware of it. I'd therefore like everyone on the engineering team to sign off on this.

Initial reviewers, please add your teammates as reviewers after you approve this PR.

Original discussion in [RFC 86](https://docs.google.com/document/d/1mbnLHBhEPT2c8ttoxQaQRstivW0JIbKHKtjg-ZRr5WM/edit). This is in service of OKR `1.vi.c.a` ("Major/minor and patch releases take 1 hour (including general QA but excluding customer-specific testing")