### PR TITLE
add spacing after h[4-6] headers before list

### DIFF
--- a/website/src/css/pages/_blog-post.scss
+++ b/website/src/css/pages/_blog-post.scss
@@ -47,7 +47,13 @@
         h2 + ul,
         h2 + ol,
         h3 + ul,
-        h3 + ol {
+        h3 + ol,
+        h4 + ul,
+        h4 + ol,
+        h5 + ul,
+        h5 + ol,
+        h6 + ul,
+        h6 + ol {
             margin-top: 1.4em;
         }
 


### PR DESCRIPTION
If you have an h1-3 header for a section containing a list, there is appropriate spacing between the header and the list. This fixes it so that there is also appropriate spacing for other headers (h4-6). This was likely an oversight.