### PR TITLE
Update pull request section

### DIFF
--- a/handbook/engineering/go_style_guide.md
+++ b/handbook/engineering/go_style_guide.md
@@ -18,15 +18,6 @@ that pointer may be `nil`. When the pointer is nil, the function does its defaul
 If the options struct should not be nil, either make the argument the value instead of a
 pointer or document it.
 
-## Pull requests
-
-When you have a PR that adds one new constant or other kind of declaration in a list that
-gofmt will automatically reindent, and if it changes the indentation, just add it in another
-block (separated with newlines). That way code reviewers don't have to wonder if you changed
-anything else in the block, and other people who might be working on the same code don't have
-to worry about lots of merge conflicts. Then immediately after/before merging, you can delete
-the extraneous newlines and add it in its proper place.
-
 ## Group code blocks logically
 
 Declare your variables close to where they are actually used.

--- a/handbook/engineering/go_style_guide.md
+++ b/handbook/engineering/go_style_guide.md
@@ -20,7 +20,7 @@ pointer or document it.
 
 ## Pull requests
 
-Avoid unnecessary whitespace changes unless they are made by formatting tools (e.g. `prittier`, `gofmt`).
+Avoid unnecessary formatting changes that are unrelated to your change. If you find code that isn't formatted correctly, fix the formatting in a separate PR by running the appropriate formatter (e.g. `prettier`, `gofmt`).
 
 ## Group code blocks logically
 

--- a/handbook/engineering/go_style_guide.md
+++ b/handbook/engineering/go_style_guide.md
@@ -18,6 +18,10 @@ that pointer may be `nil`. When the pointer is nil, the function does its defaul
 If the options struct should not be nil, either make the argument the value instead of a
 pointer or document it.
 
+## Pull requests
+
+Avoid unnecessary whitespace changes unless they are made by formatting tools (e.g. `prittier`, `gofmt`).
+
 ## Group code blocks logically
 
 Declare your variables close to where they are actually used.


### PR DESCRIPTION
The strategy is not needed anymore by using GitHub's "Hide whitespace changes" setting.

Example file on a PR:

https://github.com/sourcegraph/sourcegraph/pull/7180/files?utf8=%E2%9C%93&diff=unified&w=1#diff-2598a72c0a155ecbd26dcb9486d00d16

![Screen Shot 2019-12-13 at 2 03 27 PM](https://user-images.githubusercontent.com/2946214/70824955-57f03b80-1db1-11ea-9fa7-cb7a7e329f45.png)

vs.

https://github.com/sourcegraph/sourcegraph/pull/7180/files?utf8=%E2%9C%93&diff=unified#diff-2598a72c0a155ecbd26dcb9486d00d16

![Screen Shot 2019-12-13 at 2 03 53 PM](https://user-images.githubusercontent.com/2946214/70824978-68081b00-1db1-11ea-8842-fc330416fa38.png)


Notice the `&w=1`.