### PR TITLE
Remove automation team documentation

### DIFF
--- a/handbook/engineering/automation/index.md
+++ b/handbook/engineering/automation/index.md
@@ -1,7 +1,0 @@
-# Automation project
-
-Automation is a project that contains members from the [web team](../web/index.md) and [core services team](../core-services/index.md).
-
-Vision statement: Developers can automate any large-scale code change across all code hosts, confidently manage campaigns with thousands of changesets, are proactively notified about campaigns they should run that would improve code quality, and consider the notifications high signal-to-noise.
-
-[Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.ek2cvljm0wh7)

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -26,7 +26,6 @@ Each Sourcegraph engineer works on a team that has long-term ownership of a part
 - [Core services team](core-services/index.md)
 - [Distribution team](distribution/index.md)
 - [Web team](web/index.md)
-- [Automation project](automation/index.md)
 
 ## Repositories
 

--- a/handbook/people-ops/travel.md
+++ b/handbook/people-ops/travel.md
@@ -22,15 +22,12 @@ The first category of travel is company-wide events. Sourcegraph holds two compa
 
 Each team is allocated USD $4K per year per teammate for team events (minimum two members of the team). This is designed to allow each team to hold at least one event every six months (in addition to the company-wide events above). This budget can be used for travel (airfare, trains, etc.), lodging (hotels, rental homes, etc.), events, meals and entertainment, and more. Teams are expected to use discretion about what events are appropriate for team outings, and should contact @sourcegraph/people-ops with any questions.
 
-If one individual is a member of both a product team and a project team (e.g. a member of both Core services and Automation), the total budget per person would stay the same at USD $4K, and the individual (and their teams) would have to figure out how to split it.
-
-Today, “teams” includes both permanent product teams and project-specific teams (this is subject to change, and should be confirmed with your manager):
+If one individual is a member of multiple teams, the total budget per person would stay the same at USD $4K, and the individual (and their teams) would have to figure out how to split it.
 
 - Dev: Web
 - Dev: Core services
 - Dev: Distribution
 - Dev: Code intelligence
-- Dev: Automation
 - DevRel, Marketing, and Growth
 - Sales
 


### PR DESCRIPTION
The automation project team is no longer necessary as approved in RFC 90.
3.12 is a transitional release cycle where some artifacts of the automation team may remain, but the transition will be complete by 3.13.