### PR TITLE
Document tech stack

### DIFF
--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -1,5 +1,11 @@
 # Code intelligence team
 
-Vision statement: Code intelligence is as good or better than an IDE in the browser for all code hosts and all languages, including cross-repository definitions and references.
-
 [Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.dimwsc9ccmwq)
+
+## Vision statement
+
+Code intelligence is as good or better than an IDE in the browser for all code hosts and all languages, including cross-repository definitions and references.
+
+## Tech stack
+
+Go, TypeScript, Postgres and many other languages for supporting LSIF and LSP.

--- a/handbook/engineering/core-services/index.md
+++ b/handbook/engineering/core-services/index.md
@@ -1,5 +1,11 @@
 # Code services team
 
-Vision statement: Sourcegraph operations are fast (e.g. search), instances scale to 80k repositories, private code is secure and respects ACLs for every authorization provider, and the product settings are easy to set up and understand for our largest customers. Tech stack: Go, Postgres, Redis, Docker, Kubernetes, and others.
-
 [Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.fv5i7qi85bru)
+
+## Vision statement
+
+Sourcegraph operations are fast (e.g. search), instances scale to 80k repositories, private code is secure and respects ACLs for every authorization provider, and the product settings are easy to set up and understand for our largest customers. Tech stack: Go, Postgres, Redis, Docker, Kubernetes, and others.
+
+## Tech stack
+
+Go, Postgres, Redis, Docker, Kubernetes.

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -1,10 +1,14 @@
 # Distribution team
 
-Vision statement: Make Sourcegraph accessible to every developer and development team. Identify and satisfy long- and short-term needs of critical customers. ([Google Doc with more info](https://docs.google.com/document/d/1-RQTq1HnhvxiLWrHUssmSW3aSUqlIOfTtTg1wvKGtzc/edit?ts=5da61097#heading=h.frjbo9inynne))
-
 [Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.mi8zg2ql2uc6)
 
-- [How to set up a separate website maintained by Sourcegraph](separate_website.md)
+## Vision Statement
+
+Make Sourcegraph accessible to every developer and development team. Identify and satisfy long-term and short-term needs of critical customers. ([Google Doc with more info](https://docs.google.com/document/d/1-RQTq1HnhvxiLWrHUssmSW3aSUqlIOfTtTg1wvKGtzc/edit?ts=5da61097#heading=h.frjbo9inynne))
+
+## Tech stack
+
+Go, Docker, Kubernetes.
 
 ## Code host testing instances
 
@@ -39,3 +43,7 @@ Now you can switch between any added roles and your Sourcegraph AWS account usin
    - Name: `<NAME><TYPE>SharedAccessRole`, where `<NAME>` is the customer name and `<TYPE>` is `Replica` or `Managed`. (Examples: `AcmeCorpReplicaSharedAccessRole` or `AcmeCorpManagedSharedAccessRole`.)
    - Email: use any unused email address. (Example: `alice+acme-corp-replica-shared@sourcegraph.com`.)
 1. Move the account under the organization that you wish to allow this user to access https://console.aws.amazon.com/organizations/home?#/browse/ou-48vq-waaj46mo
+
+## Misc
+
+- [How to set up a separate website maintained by Sourcegraph](separate_website.md)

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -1,8 +1,14 @@
 # Web team
 
-Vision statement: Bring the power of Sourcegraph (e.g. search, code intelligence, automation) to all developers everywhere that they interact with code (e.g. command line, editors, web browser, code hosts).
-
 [Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.g2wq4qci7wj0)
+
+## Vision statement
+
+Bring the power of Sourcegraph (e.g. search, code intelligence, automation) to all developers everywhere that they interact with code (e.g. command line, editors, web browser, code hosts).
+
+## Tech stack
+
+TypeScript, React, RxJS, GraphQL, Go.
 
 ## Team syncs
 


### PR DESCRIPTION
Instead of inlining this information in the project roadmap, this information belongs in the handbook and I have added links to these team pages from the project roadmap.