### PR TITLE
Fix landing page overflowing

### DIFF
--- a/website/src/components/product/GitLabIntegrationSection.tsx
+++ b/website/src/components/product/GitLabIntegrationSection.tsx
@@ -3,7 +3,7 @@ import * as React from 'react'
 import { RequestDemoAction } from '../../css/components/actions/RequestDemoAction'
 
 export const GitLabIntegrationSection: React.FunctionComponent<{ className?: string }> = ({ className = '' }) => (
-    <div id="gitlab-integration" className="gitlab-integration-section py-5 row justify-content-center ">
+    <div id="gitlab-integration" className="gitlab-integration-section py-5 container-fluid justify-content-center d-flex">
         <div className="row justify-content-center container">
             <h2 className="text-center display-4 mb-2">
                 <div className="gitlab-integration-section__new-badge">New</div>


### PR DESCRIPTION
a row not finding it's parent container is pushing it's limits :) this should fix it

<img width="897" alt="Screen Shot 2019-12-19 at 11 54 40 PM" src="https://user-images.githubusercontent.com/19534377/71216534-06691480-22bb-11ea-9f60-218bd054c899.png">
