### PR TITLE
Add X-Frame-Options = "DENY"

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -8,6 +8,11 @@ command = "curl -sSL -o /tmp/docsite https://github.com/sourcegraph/docsite/rele
   YARN_VERSION = "1.15.2"
   YARN_FLAGS = "--no-ignore-optional"
 
+[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Frame-Options = "DENY"
+
 [[redirects]]
   from = "/assets/*"
   to = "https://about-docsite.sourcegraph.com/assets/:splat"


### PR DESCRIPTION
X-Frame-Options prevents our static site from being embedded in iframes on other sites.

https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/X-Frame-Options

[Docs for Netlify config file](https://docs.netlify.com/routing/headers/#syntax-for-the-netlify-configuration-file).