### PR TITLE
Add X-Content-Type-Options = nosniff

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,7 @@ command = "curl -sSL -o /tmp/docsite https://github.com/sourcegraph/docsite/rele
   for = "/*"
   [headers.values]
     X-Frame-Options = "DENY"
+    X-Content-Type-Options = "nosniff"
 
 [[redirects]]
   from = "/assets/*"


### PR DESCRIPTION
Site security scanners expect this header to be set. about.sourcegraph.com only hosts static content so there was no vulnerability introduced by not setting this header. I checked that we do set this header on sourcegraph.com.