### PR TITLE
handbook/testing: add permissions note for Percy

### DIFF
--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -6,6 +6,7 @@
   - [How we use RFCs](../communication/rfcs/index.md)
 - [Code reviews](code_reviews.md)
 - [Go style guide](go_style_guide.md)
+- [Testing](testing.md)
 - [Continuous releasability](continuous_releasability.md)
 - [Commit message guidelines](commit_messages.md)
 - [Incidents](incidents.md)

--- a/handbook/engineering/testing.md
+++ b/handbook/engineering/testing.md
@@ -6,3 +6,7 @@ This file documents how we test code at Sourcegraph.
 ## Percy
 
 We use [Percy](https://percy.io/) to detect visual changes in Sourcegraph features. You may need permissions to update screenshots if your feature introduces visual changes. Post a message in #dev-chat that you need access to Percy, and someone will add you to our organization (you will also receive an invitation via e-mail). Make sure you are logged in with your GitHub credentials.
+
+## Other
+
+[Documentation for running tests in sourcegraph/sourcegraph](https://sourcegraph.sgdev.org/sourcegraph/sourcegraph/-/blob/doc/dev/testing.md).

--- a/handbook/engineering/testing.md
+++ b/handbook/engineering/testing.md
@@ -3,6 +3,6 @@
 This file documents how we test code at Sourcegraph.
 
 
-### Percy
+## Percy
 
 We use [Percy](https://percy.io/) to detect visual changes in Sourcegraph features. You may need permissions to update screenshots if your feature introduces visual changes. Post a message in #dev-chat that you need access to Percy, and someone will add you to our organization (you will also receive an invitation via e-mail). Make sure you are logged in with your GitHub credentials.

--- a/handbook/engineering/testing.md
+++ b/handbook/engineering/testing.md
@@ -1,0 +1,9 @@
+# Testing
+
+This file documents how we test code at Sourcegraph. See [permissions](#permissions) for help on accessing our testing tools. 
+
+## Permissions
+
+### Percy
+
+We use [Percy](https://percy.io/) to detect visual changes in Sourcegraph features. You may need permissions to update screenshots if your feature changes these. Post a message in #dev-chat that you need access to Percy, and someone will add you to our organization (you will also receive an invitation via e-mail). Make sure you are logged in with your GitHub credentials.

--- a/handbook/engineering/testing.md
+++ b/handbook/engineering/testing.md
@@ -2,7 +2,6 @@
 
 This file documents how we test code at Sourcegraph.
 
-## Permissions
 
 ### Percy
 

--- a/handbook/engineering/testing.md
+++ b/handbook/engineering/testing.md
@@ -6,4 +6,4 @@ This file documents how we test code at Sourcegraph. See [permissions](#permissi
 
 ### Percy
 
-We use [Percy](https://percy.io/) to detect visual changes in Sourcegraph features. You may need permissions to update screenshots if your feature changes these. Post a message in #dev-chat that you need access to Percy, and someone will add you to our organization (you will also receive an invitation via e-mail). Make sure you are logged in with your GitHub credentials.
+We use [Percy](https://percy.io/) to detect visual changes in Sourcegraph features. You may need permissions to update screenshots if your feature introduces visual changes. Post a message in #dev-chat that you need access to Percy, and someone will add you to our organization (you will also receive an invitation via e-mail). Make sure you are logged in with your GitHub credentials.

--- a/handbook/engineering/testing.md
+++ b/handbook/engineering/testing.md
@@ -1,6 +1,6 @@
 # Testing
 
-This file documents how we test code at Sourcegraph. See [permissions](#permissions) for help on accessing our testing tools. 
+This file documents how we test code at Sourcegraph.
 
 ## Permissions
 


### PR DESCRIPTION
Looks like we don't have a dedicated section for Testing yet. I'm only adding the Percy/permissions part to this for now: we want https://about.sourcegraph.com/search?q=percy to have this info. [Slack reference](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1579300085026700?thread_ts=1579300004.026500&cid=CMMTWQQ49).
