### PR TITLE
Add jargon file

### DIFF
--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -26,6 +26,8 @@ The following places are not sources of truth. Treat documents and conversations
 - Zoom recordings
 - All other Google Docs/Sheets/Slides
 
+The [jargon file](jargon.md) is an incomplete list of terms that may be used in a context that creates confusion for other members of the team. This list should be helpful during onboarding, and during cross-team discussions (e.g. engineering and marketing).
+
 ## Meetings
 
 - [Company meeting](company_meeting.md) (Mondays 10:30-11:00am PST/PDT)

--- a/handbook/communication/jargon.md
+++ b/handbook/communication/jargon.md
@@ -1,0 +1,24 @@
+# Jargon file
+
+This page is a collection of terms and phrases (roughly categorized) which have a specific internal meaning. This list should be treated as a living document and should be updated when new terms come into use, when old terms are given a new or altered meaning, and when old terms are met with confusion (e.g during onboarding).
+
+Some terms in this document may only be useful for internal communication. For concepts which are also user-facing, the public description should be used over any alternate internal description.
+
+## General terminology
+
+This section contains terminology that was defined outside of and is not specific to Sourcegraph, but is used to describe Sourcegraph features and technology.
+
+### Code intelligence
+
+- **Language Servers** are a long-running program that performs semantic analysis over code and answers code intelligence queries (e.g. find definitions, find refrences, get hover text) from clients.
+- **Language Server Protocol (LSP)** is the RPC-based protocol used between Language Servers and clients.
+- **Language Server Index Format (LSIF)** is a specification by Microsoft that captures a subset of data returned by queries to a language server. It allows queries to be answered without running a language server.
+
+## Sourcegraph-specific
+
+This section contains terminology that is defined within Sourcegraph or is specific to a Soucegraph feature or technology.
+
+### Code intelligence
+
+- **Precise code intelligence** (find definitions, find references, get hover text) is provided by semantic analysis over source code (currently LSIF or LSP). Answers provided by code intelligence can assumed to be correct.
+- **Search-based code intelligence** (find definitions, find references, get hover text) is provided by the basic code intelligence extension and is powered by code search. It uses heuristics (file extensions, import parsing) to prune the result set of obviously incorrect search results. This type of code intelligence can have many false positive results. This type of code intelligence used to be referred to internally as _basic_ or _fuzzy code intelligence_.


### PR DESCRIPTION
We should have a place that defines some common terms that are either unknown during onboarding or unknown when members of different teams are communicating.