### PR TITLE
Document eng team slide format for company meetings

### DIFF
--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -21,7 +21,7 @@
   - Each engineering team owns a slide that _summarizes_ relevant progress to the rest of the company in the last week.
     - The engineering manager for each team is ultimately responsible for their team's slide, but they may delegate this responsibility to other teammates on any given week.
     - The slide should contain short bullet points for each team project that has been completed, started, or is still in progress since the last update. Usually these bullet points are items on the roadmap. Ongoing work items should be marked with the [monthly release](../engineering/releases/index.md) that they are expected to be included in (if applicable).
-    - The slide should communicate how team's progress contribute to their [quarterly OKRs](../../company/okrs/index.md), usually by inlining the teams objectivs as top level bullet points and nesting project bullet points under the relevant objective.
+    - The slide should communicate how the team's progress contributes to their [quarterly OKRs](../../company/okrs/index.md), usually by inlining the teams objectives as top-level bullet points and nesting project bullet points under the relevant objective.
     - The speaker notes on the slide should be exactly what the presenter is going to say (so anyone who can't attend company meeting can quickly catch up).
     - [Here is an example of a good team slide](https://docs.google.com/presentation/d/1pIoUFHpKI7jLK-F-H6z_aFke_aDZDbXZKuJff6Kf_nc/edit#slide=id.g4d25168c6a_0_55)
 1. Other announcements

--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -18,6 +18,12 @@
 1. Hiring
 1. Sales and marketing
 1. Product and development updates
+  - Each engineering team owns a slide that _summarizes_ relevant progress to the rest of the company in the last week.
+    - The engineering manager for each team is ultimately responsible for their team's slide, but they may delegate this responsibility to other teammates on any given week.
+    - The slide should contain short bullet points for each team project that has been completed, started, or is still in progress since the last update. Usually these bullet points are items on the roadmap. Communciate if ongoing work items are on-track for the next [monthly release](../engineering/releases/index.md).
+    - The slide should communicate how team's progress contribute to their [quarterly OKRs](../../company/okrs/index.md).
+    - The speaker notes on the slide should be exactly what the presenter is going to say (so anyone who can't attend company meeting can quickly catch up).
+    - [Here is an example of a good team slide](https://docs.google.com/presentation/d/1pIoUFHpKI7jLK-F-H6z_aFke_aDZDbXZKuJff6Kf_nc/edit#slide=id.g4d25168c6a_0_55)
 1. Other announcements
    - Also share these announcements in #general.
 1. Q&A (questions and answers about anything company-wide)

--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -20,8 +20,8 @@
 1. Product and development updates
   - Each engineering team owns a slide that _summarizes_ relevant progress to the rest of the company in the last week.
     - The engineering manager for each team is ultimately responsible for their team's slide, but they may delegate this responsibility to other teammates on any given week.
-    - The slide should contain short bullet points for each team project that has been completed, started, or is still in progress since the last update. Usually these bullet points are items on the roadmap. Communciate if ongoing work items are on-track for the next [monthly release](../engineering/releases/index.md).
-    - The slide should communicate how team's progress contribute to their [quarterly OKRs](../../company/okrs/index.md).
+    - The slide should contain short bullet points for each team project that has been completed, started, or is still in progress since the last update. Usually these bullet points are items on the roadmap. Ongoing work items should be marked with the [monthly release](../engineering/releases/index.md) that they are expected to be included in (if applicable).
+    - The slide should communicate how team's progress contribute to their [quarterly OKRs](../../company/okrs/index.md), usually by inlining the teams objectivs as top level bullet points and nesting project bullet points under the relevant objective.
     - The speaker notes on the slide should be exactly what the presenter is going to say (so anyone who can't attend company meeting can quickly catch up).
     - [Here is an example of a good team slide](https://docs.google.com/presentation/d/1pIoUFHpKI7jLK-F-H6z_aFke_aDZDbXZKuJff6Kf_nc/edit#slide=id.g4d25168c6a_0_55)
 1. Other announcements

--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -18,7 +18,7 @@
 1. Hiring
 1. Sales and marketing
 1. Product and development updates
-  - Each engineering team owns a slide that _summarizes_ relevant progress to the rest of the company in the last week.
+  - Each engineering team owns a slide that _summarizes_ relevant progress  in the last week to the rest of the company.
     - The engineering manager for each team is ultimately responsible for their team's slide, but they may delegate this responsibility to other teammates on any given week.
     - The slide should contain short bullet points for each team project that has been completed, started, or is still in progress since the last update. Usually these bullet points are items on the roadmap. Ongoing work items should be marked with the [monthly release](../engineering/releases/index.md) that they are expected to be included in (if applicable).
     - The slide should communicate how the team's progress contributes to their [quarterly OKRs](../../company/okrs/index.md), usually by inlining the teams objectives as top-level bullet points and nesting project bullet points under the relevant objective.


### PR DESCRIPTION
@sqs asked for this to be documented in the handbook: https://sourcegraph.slack.com/archives/CHXHX7XAS/p1580149639028200?thread_ts=1580149260.027200&cid=CHXHX7XAS

@creachadair would this documentation have answered your question?

@chrismwendt @beyang @tsenart @lguychard does this documentation make sense to you and is it consistent with what we have been doing in practice?