### PR TITLE
use February-through-January fiscal year

### DIFF
--- a/company/okrs/2019_q3.md
+++ b/company/okrs/2019_q3.md
@@ -1,10 +1,10 @@
-# 2019-Q3 OKRs
+# CY19-Q3 OKRs
 
 > NOTE: These OKRs were written before we adopted the current [OKR guidelines](index.md) for formatting and updating.
 
 1. CEO: Grow net new ARR consistently: reach $N net new ARR in Q3, grow SWAUs at existing companies
-   1. Sales: Update pricing model to enable higher value negotiations/contracts 
-   1. Sales: Reach at least [$N](https://docs.google.com/document/d/1RPdDawv2FtK5hjJQGpSsF82ubB6tgcutv3Bc0sEZVYA/edit#bookmark=id.15i9rk7jnr9k) net new ARR in Q3 
+   1. Sales: Update pricing model to enable higher value negotiations/contracts
+   1. Sales: Reach at least [$N](https://docs.google.com/document/d/1RPdDawv2FtK5hjJQGpSsF82ubB6tgcutv3Bc0sEZVYA/edit#bookmark=id.15i9rk7jnr9k) net new ARR in Q3
    1. Sales: Line up the following pipeline for Q4 with at least 80% chance of closure:
       1. At least 3 Tier 1 Deals
       1. At least 10 Tier 2 & 3 Deals

--- a/company/okrs/2019_q4.md
+++ b/company/okrs/2019_q4.md
@@ -1,4 +1,4 @@
-# 2019-Q4 OKRs
+# CY19-Q4 OKRs
 
 1. **CEO: Net new ARR**
    1. **Sales (Closing Deals): Reach [$N](https://docs.google.com/document/d/1clukaACTCjPLnmhEttJXcOwadxHEGYK24Znn0HUQGB0/edit#bookmark=kix.n8t17z6iyawc) net new ARR in Q4 by fully onboarding 2 new AEs who will close 4 Tier 1 deals (>=$100K ARR) and 11 non-Tier 1 deals.**

--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -1,4 +1,6 @@
-# 2020-Q1 OKRs
+# FY20-Q1 OKRs
+
+> These OKRs are for Q1 in [fiscal year 2020](../../handbook/communication/index.md#fiscal-year), which runs from 2020-02-01 to 2020-04-30. This is the first quarter we are using the new February-through-January fiscal year. Some OKRs have not yet been extended to include April; this sentence will be removed when all have been updated.
 
 ## CEO
 
@@ -13,7 +15,7 @@
 
 ## Sales and marketing (WIP)
 
-> NOTE: Sales and Marketing OKRs are being finalized in "[OKRs FY2020-Q1](https://docs.google.com/document/d/1OHrg23CXxgk2oKqKeClAiwBgEKKwFdSjKrrfUoldJKs/edit)" and will be posted here soon.
+> NOTE: Sales and Marketing OKRs are being finalized in "[OKRs FY20-Q1](https://docs.google.com/document/d/1OHrg23CXxgk2oKqKeClAiwBgEKKwFdSjKrrfUoldJKs/edit)" and will be posted here soon.
 
 ## Product
 

--- a/company/okrs/index.md
+++ b/company/okrs/index.md
@@ -4,9 +4,9 @@
 
 Our OKRs are public:
 
-- [2020-Q1 (active)](2020_q1.md)
-- [2019-Q4](2019_q4.md)
-- [2019-Q3](2019_q3.md)
+- [FY20-Q1 (active)](2020_q1.md)
+- [CY19-Q4](2019_q4.md)
+- [CY19-Q3](2019_q3.md)
 
 ## What are OKRs?
 
@@ -74,7 +74,7 @@ Each OKR has the following format:
 
 ### Sensitive information
 
-Do not include any specific financial numbers, customer names, or any other sensitive information in the public OKR document. Instead, use placeholders (such as `N` and `M` for 2 numbers or `C1` and `C2` for 2 customers) and document their meanings in the linked `OKRs YYYY-QN` Google Doc's `Key for sensitive information` section.
+Do not include any specific financial numbers, customer names, or any other sensitive information in the public OKR document. Instead, use placeholders (such as `N` and `M` for 2 numbers or `C1` and `C2` for 2 customers) and document their meanings in the linked `OKRs FYYY-QN` Google Doc's `Key for sensitive information` section.
 
 ### Changing OKRs mid-quarter
 

--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -98,4 +98,9 @@ Most meetings at Sourcegraph are video calls. We prefer [Zoom](https://zoom.us) 
 ## Writing
 
 1. Always use [ISO dates](https://en.wikipedia.org/wiki/ISO_8601#Calendar_dates) in all writing and legal documents because other formats [lead to online confusion](http://xkcd.com/1179/). Use `yyyy-mm-dd`, for example 2020-04-13, and never 04-13-2020, 13-04-2020, 2020/04/13, nor April 13, 2020. Even if you use an unambiguous alternative format, it is still harder to search for a date, sort on a date, and for other team members to know we use the ISO standard. For months use `yyyy-mm`, so 2020-01 for January 2020.
-
+1. Prefix the year with `FY` (e.g., `FY20` for fiscal year 2020) when referring to fiscal year, which starts on February 1 and ends January 31. {#fiscal-year} We use this instead of calendar years (`CY`) because Q4 ending during the December holidays makes the quarters less even and predictable.
+  - FY__ is fiscal year 20__ (e.g., `FY20` is fiscal year 2020, which means 2020-02-01 through 2021-01-31)
+  - FY__-Q1 (e.g., `FY20-Q1`) is February 1 through April 30
+  - FY__-Q2 is May 1 through July 31
+  - FY__-Q3 is August 1 through October 31
+  - FY__-Q4 is November 1 through January 31


### PR DESCRIPTION
- Explain why on communication page
- Update OKRs and titles

Most SaaS companies make this switch at around our size. It mainly affects sales/marketing, but we'd also extend the current dev/product/ops OKRs through April 30 so that all OKRs aligned to fiscal quarters. I will review each existing OKR and talk with the team to extend it to account for the additional month of April.

Pros:
- Quarters are more even and predictable (Q4 ending during the holidays causes unpredictability).

Cons:
- Require some getting used to
- Need to remember to prefix years with FY (fiscal year, as in `FY20-Q3`) or CY (calendar year) to avoid confusion