### PR TITLE
define IARR, new/expansion IARR

### DIFF
--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -5,7 +5,7 @@
 ## CEO
 
 1. **CEO: Grow ARR consistently**
-   1. [$N][N] net new ARR
+   1. [$N][N] IARR
    1. Sales leadership owns revenue targets and hiring plan
    1. Sales, engineering, and product have a working process for prioritization and delivery
 1. **CEO: Aspirational, efficient all-remote team**

--- a/company/okrs/index.md
+++ b/company/okrs/index.md
@@ -66,11 +66,11 @@ Each OKR has the following format:
    - If a key result has a complex definition (more than a few words), link to a handbook page with the precise definition instead of inlining it in the OKR list.
    - Key results can be links to issues or [RFCs](../../handbook/communication/rfcs/index.md).
    - Examples:
-     - Good (quantitative): `$M net new ARR`, `100% of monthly releases ship on time`
+     - Good (quantitative): `$M IARR`, `100% of monthly releases ship on time`
      - Good (human judgment): `Support LSIF-based code intel in targeted languages (Go, JavaScript/TypeScript, Python, Java, C#, and C/C++)` because quantitatively defining this has proven to be unproductive
      - Bad: `Create an effective pitch for Fortune 500 prospects` because "effective" is not defined and different people are likely to have a wide variety of opinions about what it means
 1. The `=> Outcome.` part is only added/updated after the quarter starts.
-1. Top-level CEO OKRs may just be short phrases (such as `Net new ARR`) instead of listing out key results when those key results would be redundant with the sub-OKRs.
+1. Top-level CEO OKRs may just be short phrases (such as `IARR`) instead of listing out key results when those key results would be redundant with the sub-OKRs.
 
 ### Sensitive information
 

--- a/handbook/sales/index.md
+++ b/handbook/sales/index.md
@@ -31,6 +31,20 @@ The Sales team represents us and our values to customers, bringing back dollars 
 
 Annual Recurring Revenue (ARR) is the dollar value of contracted recurring revenue in a (normalized) one-year period.
 
+### IARR
+
+Incremental [ARR](#arr) (IARR) is the change in ARR from one period to another.
+
+### New IARR
+
+New [IARR](#iarr) is IARR from *new customers* (i.e., organizations that were **not** existing customers at the beginning of the period). See also [expansion IARR](#expansion-iarr).
+
+### Expansion IARR
+
+Expansion [IARR](#iarr) is IARR from *existing customers* (i.e., organizations that were already customers at the beginning of the period).
+
+If within a single period a new customer signs a contract which then grows in ARR before the end of the period, the total ending ARR is all considered [new IARR](#new-iarr), not expansion IARR. For example, if Acme Corp signs a $100k contract on February 3 and then the contract expands to $200k on March 5, all $200k would be considered new IARR for Q1.
+
 ### Customer
 
 A customer is an organization with a Sourcegraph subscription contract that has not ended.
@@ -163,8 +177,4 @@ Categorize any outbound emails into the ‘Manual Outbound Workflow’, which se
 
 Maintaining [Server Installers to Company List](https://docs.google.com/spreadsheets/d/1Y2Z23-2uAjgIEITqmR_tC368OLLbuz12dKjEl4CMINA/edit?usp=sharing) and [Server to Company List](https://docs.google.com/spreadsheets/d/1wo_KQIcGrNGCWYKa6iHJ7MImJ_aI7GN12E-T21Es8TU/edit?usp=sharing) spreadsheets for every new company on a trial and new customers.
 
-<<<<<<< HEAD
 These are used as join tables in Looker, and are important to connect instance data to a specific customer.
-=======
-These are used as join tables in Looker, and are important to connect instance data to a specific customer.  
->>>>>>> How to create a license key

--- a/handbook/sales/onboarding/index.md
+++ b/handbook/sales/onboarding/index.md
@@ -58,7 +58,7 @@ Welcome to Sourcegraph! As a member of the sales team, you represent us and our 
   - HubSpot overview
   - Current customers and pipeline/goals overview
      - [Q4 model](https://docs.google.com/spreadsheets/d/1Ao3Nqw6gH3yAuZtICV3xo35kKKnI9oKXnvPuTQ0Fh9c/edit#gid=665660264)
-     - [Past quarterly net new ARR](https://docs.google.com/presentation/d/1I2nhK_2uz0o8jiBqajzdTPHcy9Hnl9n1LROo1ZlJW-Q/edit#slide=id.g41cb4d21db_0_0)
+     - [Past quarterly IARR](https://docs.google.com/presentation/d/1I2nhK_2uz0o8jiBqajzdTPHcy9Hnl9n1LROo1ZlJW-Q/edit#slide=id.g41cb4d21db_0_0)
   - Value props and pitches for various [personas](../../product/personas.md)
   - FAQ and common objections
 


### PR DESCRIPTION
I propose we use IARR (defined in this change) instead of "net new ARR" as we have been saying. This is to avoid confusion; "new ARR" can be interpreted as "incremental ARR" or "new logo ARR", which are 2 very different things. Now that we are distinguishing between new and expansion ARR much more than in the past, this confusion is more likely to occur.

Note (for the curious): GitLab uses the terms "new IACV" and "growth IACV" (https://about.gitlab.com/handbook/sales/#annual-contract-value-acv). We use the term "expansion" instead of "growth". If anyone has a preference for "growth" instead, speak up.