### PR TITLE
confirm new team members are in our GitHub org

### DIFF
--- a/handbook/people-ops/from-graphbook/onboarding_remote_non_us.md
+++ b/handbook/people-ops/from-graphbook/onboarding_remote_non_us.md
@@ -52,7 +52,7 @@ The following are the to-do's necessary to prep for a new teammate's onboarding 
 
 - [ ] Have Officengine send them an Expensify invite.
 
-- [ ] Have Officengine send them a Veem invite for international payments. 
+- [ ] Have Officengine send them a Veem invite for international payments.
 
 - [ ] Send JamfNow enrollment instructions.
 
@@ -75,6 +75,8 @@ Welcome! We're excited to have you get started, so here is a list of the account
 - [ ] **[Slack](https://slack.com/)**: Access our team communication tool.
 
 - [ ] **[GitHub](https://github.com/sourcegraph/Graphbook)**: Access the Graphbook (employee handbook).
+
+- [ ] Confirm that the new team member is a member of our GitHub organization (which requires having/creating a GitHub account and accepting the invitation to the `sourcegraph` organization). To check, visit https://github.com/sourcegraph/about/issues/new, press **Assignees** on the right, and confirm the team member is in the list.
 
 - [ ] **[Jamf Now](https://sourcegraph.jamfcloud.com)**: Enroll your device in our MDM (ask Noemi for your access code).
 

--- a/handbook/people-ops/from-graphbook/onboarding_remote_us.md
+++ b/handbook/people-ops/from-graphbook/onboarding_remote_us.md
@@ -74,6 +74,8 @@ Welcome! We're excited to have you get started, so here is a list of the account
 
 - [ ] **[GitHub](https://github.com/sourcegraph/Graphbook)**: Access the Graphbook (employee handbook).
 
+- [ ] Confirm that the new team member is a member of our GitHub organization (which requires having/creating a GitHub account and accepting the invitation to the `sourcegraph` organization). To check, visit https://github.com/sourcegraph/about/issues/new, press **Assignees** on the right, and confirm the team member is in the list.
+
 - [ ] **[Jamf Now](https://sourcegraph.jamfcloud.com)**: Enroll your device in our MDM (ask Noemi for your access code).
 
 - [ ] **[Lattice](https://sourcegraph.latticehq.com/)**: Access our teammate feedback cycles (takes place every quarter– Noemi will send out details).

--- a/handbook/people-ops/from-graphbook/onboarding_san_francisco.md
+++ b/handbook/people-ops/from-graphbook/onboarding_san_francisco.md
@@ -54,7 +54,7 @@ The following are the to-do's necessary to prep for a new teammate's onboarding 
 
 - [ ] Have Officengine send them an Expensify invite.
 
-- [ ] Send GrubHub for Work invite. 
+- [ ] Send GrubHub for Work invite.
 
 # New teammate to-do's: First day
 
@@ -75,6 +75,8 @@ Welcome! We're excited to have you get started, so here is a list of the account
 - [ ] **[Slack](https://slack.com/)**: Access our team communication tool.
 
 - [ ] **[GitHub](https://github.com/sourcegraph/Graphbook)**: Access the Graphbook (employee handbook).
+
+- [ ] Confirm that the new team member is a member of our GitHub organization (which requires having/creating a GitHub account and accepting the invitation to the `sourcegraph` organization). To check, visit https://github.com/sourcegraph/about/issues/new, press **Assignees** on the right, and confirm the team member is in the list.
 
 - [ ] **[Jamf Now](https://sourcegraph.jamfcloud.com)**: Enroll your device in our MDM (ask Noemi for your access code).
 


### PR DESCRIPTION
I added this to all of the onboarding checklists (which we plan to consolidate into a single checklist) to ensure it's not accidentally forgotten in the consolidation.

The purpose of this is to avoid confusion like at https://sourcegraph.slack.com/archives/CQ44Y7F4G/p1580913355019700 where a new team member had not yet accepted the GitHub invite.