### PR TITLE
add HubSpot and email logging step to sales onboarding

### DIFF
--- a/handbook/sales/onboarding/index.md
+++ b/handbook/sales/onboarding/index.md
@@ -23,6 +23,8 @@ Welcome to Sourcegraph! As a member of the sales team, you represent us and our 
   - [General onboarding steps](../../people-ops/onboarding/index.md#for-all-new-teammates)
   - [Sourcegraph handbook](../../index.md) intro
   - GitHub account setup and tutorial
+  - HubSpot account setup
+    - Ensure emails are logged in HubSpot
 - [CEO](../../ceo/index.md)
   - Vision
   - [Values](../../../company/values.md)

--- a/handbook/sales/onboarding/index.md
+++ b/handbook/sales/onboarding/index.md
@@ -2,6 +2,8 @@
 
 Welcome to Sourcegraph! As a member of the sales team, you represent us and our values to customers, and you bring back dollars and feedback to help us grow.
 
+See also [Sales onboarding logistics](https://docs.google.com/document/d/1un9fFPCBtcyWQSJtorUz20zI5LJGMTpdmmTomE9ndEM/edit).
+
 ## Week 1
 
 - Get familiar with the internal tools we use


### PR DESCRIPTION
To avoid problems like https://sourcegraph.slack.com/archives/C0B2RU51Q/p1581598734414000?thread_ts=1581542364.391200&cid=C0B2RU51Q.