### PR TITLE
How to prioritize and other product updates

### DIFF
--- a/handbook/product/delivery_plans.md
+++ b/handbook/product/delivery_plans.md
@@ -1,0 +1,55 @@
+# Delivery plans
+
+Every customer-facing piece of work at Sourcegraph has a **delivery plan**, which describes how we deliver the work to customers. Delivery plans have 3 purposes:
+
+- They let us ship things to customers more quickly without blocking on any other team member or to relay context. Usually, this means developers notify customers directly and can get immediate feedback on their work.
+- They are an easily verifiable check during planning that all work ties directly to a customer need that is understood by the developers working on the feature.
+- They give developers more direct contact with customers (which is motivating and educational).
+
+Delivery plans live in the [sourcegraph/customer issue tracker](https://github.com/sourcegraph/customer/issues), which is visible only to Sourcegraph team members.
+
+## Format
+
+There is no strict format for delivery plans. (This may change as we use them more.)
+
+We anticipate most delivery plans will:
+
+- Have a series of steps that the developer can follow on their own without blocking on any other team member (e.g., sales or distribution). Usually this will be an email or Slack message to send to 1 or 2 specific customers with docs links, screenshots, and/or example links.
+  - Have clear ownership for each step (usually a single developer or group of developers)
+- Have hypotheses to help us learn more quickly. There are 2 kinds of hypotheses. These help us learn quickly if we've misjudged the importance or ease of a feature.
+  - Example hypothesis 1: Testing whether a feature is actually important to a customer. The hypothesis is of the form `Within X days, Alice ____` (e.g., "Within 3 days, Alice replies to the email and uses the feature").
+  - Example hypothesis 2: Testing whether a feature works as expected. The hypothesis is of the form `Alice is able to ____` (e.g., "Alice is able to perform an interactive-mode search").
+- Be written together by team members on Product/Sales/Engineering/Marketing (depending on the feature).
+  - It is not the developer's responsibility in general to know what the delivery plan should be or to write it themselves. That information is crucial context that usually comes from Product or Sales.
+
+## Process
+
+1. The delivery plan for each feature is created during planning (along with the tracking issue and prioritization discussions).
+1. When a developer's work is ready, they *immediately* start following the delivery plan.
+
+   - They do not check in with sales/product/marketing (e.g., "hey, feature XYZ is ready, can you ping the customer?" or "can you check the delivery plan to make sure it's still up to date before I send this email?") before doing so. This enforces that the delivery plan is written comprehensively beforehand and is kept up to date by sales/product/marketing if customer circumstances change. We are an all-remote company and need to avoid synchronous processes.
+
+1. When steps in the delivery plan are executed (such as emailing a customer), comment on the delivery plan issue.
+1. When the hypotheses have results, comment on the issue.
+1. When the delivery plan is finished and all hypotheses have results, close the issue.
+
+See [RFC 97: Delivery plans for getting customer feedback/usage sooner](https://docs.google.com/document/d/1cZ7JIVuRWrF2MxwDdH36SC7zOyT2qJf9AMUd9Wc9_aY/edit#) (where this idea was originally proposed) for more background.
+
+## Example delivery plan (for the code statistics feature)
+
+When this feature is deployed to Sourcegraph.com, enable it in global settings. Then email alice@example.com and cc bob@sourcegraph.com with subject `Code statistics on Acme Corp's Sourcegraph instance` and the following body.
+
+> Hi Alice,
+>
+> I'm Carol, an engineer on the Sourcegraph team. Bob (cc'd) mentioned you are interested in seeing language statistics computed across multiple repositories and for specific queries. We just shipped this feature, and it will be available on Acme Corp's Sourcegraph instance next time you upgrade.
+>
+> Docs at https://docs.sourcegraph.com/user/search#statistics. Try it on Acme Corp's public code at https://sourcegraph.com/stats?q=repo%3A%2Facme-corp%2F%28foo%7Cbar%29.
+>
+> [Attach screenshot of the Sourcegraph.com page pie chart]
+>
+> Would you like us to ask David to upgrade Acme Corp's Sourcegraph instance sooner so you can start using this?
+>
+> Thanks,
+> Bob
+
+We expect a reply in 3 days (or else we'll follow up nicely once). We expect Alice to ask David to upgrade sooner so they can try this out, and we expect Alice to use this within 2 days of it being available on their instance.

--- a/handbook/product/index.md
+++ b/handbook/product/index.md
@@ -23,6 +23,7 @@ See job descriptions and responsibilities of roles on the Product team:
 - [Planning](planning.md) - how we do planning and the artifacts we use to plan.
 - [Delivery plans](delivery_plans.md) - how validate the things we build solve user problems.
 - [Prioritizing](prioritizing.md) - how we prioritize work, and how to get things prioritized.
+- [Tracking user feedback](user_feedback.md) - sources of feedback and how we keep track of that feedback.
 
 ## Release early, release often
 

--- a/handbook/product/index.md
+++ b/handbook/product/index.md
@@ -6,81 +6,23 @@ The Product team strives to make the following true:
 - Each teammate has the customer and product context needed (about customer problems, likely future priorities, possible solutions, etc.) to perform their work effectively.
 - The product vision and roadmap are communicated well to teammates and everyone outside Sourcegraph.
 
-## [Sourcegraph workflow](../../workflow/index.md)
-
-The [Sourcegraph workflow](../../workflow/index.md) describes how our product fits into the developer workflow.
-
 ## [Roles](roles.md)
 
 See job descriptions and responsibilities of roles on the Product team:
 
-- [Product Manager](roles.md#product-manager)
+- [Product Manager](roles.md#product-manager) ([We're hiring!](https://github.com/sourcegraph/careers/blob/master/job-descriptions/product-manager.md))
+- [UX Designer](roles.md#product-designer) ([We're hiring!](https://github.com/sourcegraph/careers/blob/master/job-descriptions/ux-designer.md))
 
-## [Personas](personas.md)
+## Resources
 
-See "[Personas](personas.md)".
+- The [Sourcegraph workflow](../../workflow/index.md) describes how our product fits into the developer workflow.
+- [Personas](personas.md)
 
-## Delivery plans
+## Product planning
 
-Every customer-facing piece of work at Sourcegraph has a **delivery plan**, which describes how we deliver the work to customers. Delivery plans have 3 purposes:
-
-- They let us ship things to customers more quickly without blocking on any other team member or to relay context. Usually, this means developers notify customers directly and can get immediate feedback on their work.
-- They are an easily verifiable check during planning that all work ties directly to a customer need that is understood by the developers working on the feature.
-- They give developers more direct contact with customers (which is motivating and educational).
-
-Delivery plans live in the [sourcegraph/customer issue tracker](https://github.com/sourcegraph/customer/issues), which is visible only to Sourcegraph team members.
-
-### Format
-
-There is no strict format for delivery plans. (This may change as we use them more.)
-
-We anticipate most delivery plans will:
-
-- Have a series of steps that the developer can follow on their own without blocking on any other team member (e.g., sales or distribution). Usually this will be an email or Slack message to send to 1 or 2 specific customers with docs links, screenshots, and/or example links.
-  - Have clear ownership for each step (usually a single developer or group of developers)
-- Have hypotheses to help us learn more quickly. There are 2 kinds of hypotheses. These help us learn quickly if we've misjudged the importance or ease of a feature.
-  - Example hypothesis 1: Testing whether a feature is actually important to a customer. The hypothesis is of the form `Within X days, Alice ____` (e.g., "Within 3 days, Alice replies to the email and uses the feature").
-  - Example hypothesis 2: Testing whether a feature works as expected. The hypothesis is of the form `Alice is able to ____` (e.g., "Alice is able to perform an interactive-mode search").
-- Be written together by team members on Product/Sales/Engineering/Marketing (depending on the feature).
-  - It is not the developer's responsibility in general to know what the delivery plan should be or to write it themselves. That information is crucial context that usually comes from Product or Sales.
-
-### Process
-
-1. The delivery plan for each feature is created during planning (along with the tracking issue and prioritization discussions).
-1. When a developer's work is ready, they *immediately* start following the delivery plan.
-  - They do not check in with sales/product/marketing (e.g., "hey, feature XYZ is ready, can you ping the customer?" or "can you check the delivery plan to make sure it's still up to date before I send this email?") before doing so. This enforces that the delivery plan is written comprehensively beforehand and is kept up to date by sales/product/marketing if customer circumstances change. We are an all-remote company and need to avoid synchronous processes.
-1. When steps in the delivery plan are executed (such as emailing a customer), comment on the delivery plan issue.
-1. When the hypotheses have results, comment on the issue.
-1. When the delivery plan is finished and all hypotheses have results, close the issue.
-
-See [RFC 97: Delivery plans for getting customer feedback/usage sooner](https://docs.google.com/document/d/1cZ7JIVuRWrF2MxwDdH36SC7zOyT2qJf9AMUd9Wc9_aY/edit#) (where this idea was originally proposed) for more background.
-
-### Example delivery plan (for the code statistics feature)
-
-When this feature is deployed to Sourcegraph.com, enable it in global settings. Then email alice@example.com and cc bob@sourcegraph.com with subject `Code statistics on Acme Corp's Sourcegraph instance` and the following body.
-
-> Hi Alice,
->
-> I'm Carol, an engineer on the Sourcegraph team. Bob (cc'd) mentioned you are interested in seeing language statistics computed across multiple repositories and for specific queries. We just shipped this feature, and it will be available on Acme Corp's Sourcegraph instance next time you upgrade.
->
-> Docs at https://docs.sourcegraph.com/user/search#statistics. Try it on Acme Corp's public code at https://sourcegraph.com/stats?q=repo%3A%2Facme-corp%2F%28foo%7Cbar%29.
->
-> [Attach screenshot of the Sourcegraph.com page pie chart]
->
-> Would you like us to ask David to upgrade Acme Corp's Sourcegraph instance sooner so you can start using this?
->
-> Thanks,
-> Bob
-
-We expect a reply in 3 days (or else we'll follow up nicely once). We expect Alice to ask David to upgrade sooner so they can try this out, and we expect Alice to use this within 2 days of it being available on their instance.
-
-## [Tracking user feedback](user_feedback.md)
-
-See "[Tracking user feedback](user_feedback.md)".
-
-## Product planning is continuous
-
-See "[Planning](planning.md)".
+- [Planning](planning.md) - how we do planning and the artifacts we use to plan.
+- [Delivery plans](delivery_plans.md) - how validate the things we build solve user problems.
+- [Prioritizing](prioritizing.md) - how we prioritize work, and how to get things prioritized.
 
 ## Release early, release often
 
@@ -89,7 +31,3 @@ Each project, no matter how long-running, needs to plan to ship _something_ in e
 The reason for this is to avoid going for too long without customer feedback (from customers trying it) or even technical/product feedback (from performing the diligent work of polishing it to be ready to release). Lacking these critical checks means we will end up building something that doesn't solve people's problems or that is over-built.
 
 When we have relaxed this in the past, the results have been bad and the overwhelming feedback from retrospectives has been to release regularly.
-
-## Saying "no"
-
-We receive tons of feature requests and bug reports, more than we can handle. This means we must frequently say "no" or prioritize things less urgently than some people would like. Our job is to find the most important things to work on.

--- a/handbook/product/planning.md
+++ b/handbook/product/planning.md
@@ -43,8 +43,10 @@ Tracking issues are GitHub issues that encapsulate the planned work for an itera
 
 Teams should aggressively prioritize work for the iteration so that expectations can be set accordingly with users waiting for features or bug fixes. If work is carried over for multiple iterations it is an indication that the priority of that item is not actually as high as believed, or that the team is trying to do too many things in an iteration. Engineering can lean on Product for help with prioritization.
 
-## Prioritizing bug fixes and small tasks
+### Delivery plans
 
-Bugs and issues from customers come up regularly and need to be prioritized. Many of these tasks are quick (< 1 day) and should be prioritized within the iteration. Larger tasks should be added to the project roadmap. Customer issues should include context about how important that customer is, and how important this particular issue is to the customer so that teams can effectively prioritize. The goal is not to have the engineering teams jump at every customer request, but to thoughtfully triage them when compared to the rest of the work they have slated. If there is any ambiguity in importance, the PM can be consulted to help make prioritization decisions.
+See [delivery plans](delivery_plans.md).
 
-Each team may decide how they would like to keep track of the backlog of issues, whether that is in a kanban board, google doc, etc. Similarly, teams can decide how they would like to allocate resources to this, whether it is having one person working down the backlog each week, or assigning a set of issues to be accomplished within an iteration.
+### Prioritizing
+
+See [prioritizing](prioritizing.md).

--- a/handbook/product/planning.md
+++ b/handbook/product/planning.md
@@ -43,10 +43,10 @@ Tracking issues are GitHub issues that encapsulate the planned work for an itera
 
 Teams should aggressively prioritize work for the iteration so that expectations can be set accordingly with users waiting for features or bug fixes. If work is carried over for multiple iterations it is an indication that the priority of that item is not actually as high as believed, or that the team is trying to do too many things in an iteration. Engineering can lean on Product for help with prioritization.
 
-### Delivery plans
+### [Delivery plans](delivery_plans.md)
 
 See [delivery plans](delivery_plans.md).
 
-### Prioritizing
+### [Prioritizing](prioritizing.md)
 
 See [prioritizing](prioritizing.md).

--- a/handbook/product/prioritizing.md
+++ b/handbook/product/prioritizing.md
@@ -1,0 +1,23 @@
+# Prioritizing
+
+## Saying "no"
+
+We receive tons of feature requests and bug reports, more than we can handle. This means we must frequently say "no" or prioritize things less urgently than some people would like. Our job is to find the most important things to work on.
+
+## How do I get something prioritized by our product team?
+
+- [Create a GitHub issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose).
+  - Include as much detail as possible about the issue.
+  - Provide context around urgency and priority.
+  - Link to the customer (if applicable) in HubSpot.
+  - Add the team label on the issue for the team that should be responsible for it.
+- Share with the team in any of the following ways:
+  - Post link to the issue in Slack and ask the team to prioritize the issue in the next team sync (or let them know it is a P0 that should be handled immediately).
+  - Send to the Product Manager to prioritize with the team.
+  - Add the item in suggestion mode to [the roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#) in your best guess at relative priority. The team or PM will accept or update the priority of the item.
+
+## Prioritizing bug fixes and small tasks
+
+Bugs and issues from customers come up regularly and need to be prioritized. Many of these tasks are quick (< 1 day) and should be prioritized within the iteration. Larger tasks should be added to the project roadmap. Customer issues should include context about how important that customer is, and how important this particular issue is to the customer so that teams can effectively prioritize. The goal is not to have the engineering teams jump at every customer request, but to thoughtfully triage them when compared to the rest of the work they have slated. If there is any ambiguity in importance, the PM can be consulted to help make prioritization decisions.
+
+Each team may decide how they would like to keep track of the backlog of issues, whether that is in a kanban board, google doc, etc. Similarly, teams can decide how they would like to allocate resources to this, whether it is having one person working down the backlog each week, or assigning a set of issues to be accomplished within an iteration.

--- a/handbook/product/roles.md
+++ b/handbook/product/roles.md
@@ -4,26 +4,31 @@ This page lists the roles and responsibilities of the Product team.
 
 ## Product Manager
 
-<!-- TODO(christinaforney): this was taken from the old docs -->
+[We're hiring!](https://github.com/sourcegraph/careers/blob/master/job-descriptions/product-manager.md)
 
-The product manager is responsible for prioritization, which means ensuring the following is true:
-
-> The issues for each release milestone are the most important things to work on.
-
-This is a broader sense of the term "prioritization" that means the product manager must do 3 things:
-
-- **Educate** teams so they can prioritize on their own.
-- **Plan** with each team the set of issues to work on for each release.
-- **Backstop:** triage unprioritized/misprioritized issues and file unfiled issues.
-
-The right mix of these 3 things depends on the team and what they're working on (and should be agreed on with the team). For example:
-
-- For some teams, the PM will educate and plan by meeting with the team once at the start of a release, and will have a very limited backstop role in between. The devs will be the first responders for triaging issues and will kick off the planning meeting with a well prioritized set of issues to work on.
-- For other teams, the PM will be the first to respond to and prioritize issues that are filed on the team.
-
-No matter the chosen mix, the PM is still responsible for prioritization. For example, if the PM doesn't effectively educate the devs so they can plan and triage well, then the PM needs to step up on planning and triage (as a backstop).
+You work with engineering, sales, marketing, and design to plan, ship, and grow usage and engagement in specific areas of our product. As an early member of our product team, you have significant product ownership and communicate directly with our users to drive continuous improvement.
 
 ### Responsibilities
 
-- TODO
+- Own an area of the product, and drive and inform its product roadmap.
+- Collaborate with engineers and designers to plan and build the solutions to customer problems.
+- Gather customer feedback to validate priorities, improve documentation, and define product requirements.
+- Be transparent in your internal and external communication. Sourcegraph is open source, so most discussions are public or in channels where you communicate directly with our customers.
 - Ensure our documentation is accurate and up-to-date for all features we ship.
+- Be a passionate advocate for a delightful user experience.
+
+## Product Designer
+
+[We're hiring!](https://github.com/sourcegraph/careers/blob/master/job-descriptions/ux-designer.md)
+
+You work collaboratively with product and engineering to create a highly functional and beautiful experience that delights a technical audience. You will help us build the design team and shape the design culture at Sourcegraph.
+
+### Responsibilities
+
+- Contribute to the overall strategy and decision-making about Sourcegraph’s features.
+- Drive continual progress towards a cohesive, delightful experience for a technical audience through iterative improvements.
+- Have the autonomy to facilitate conversations, solve problems, and execute the designs.
+- Pull together insights to propose a variety of solutions, then collaborate with product and engineering to determine the best solutions to problems.
+- Use prototyping and usability testing to inform and validate designs.
+- Collaborate directly with customers to inform strategy and design decisions.
+- Publish blog posts and give conference talks about your work at Sourcegraph.


### PR DESCRIPTION
- Moved delivery plans to own page
- Created prioritization page and moved relevant sections there
- Organized index page
- Updated roles page to include descriptions from existing job postings and to indicate that we're hiring!