### PR TITLE
Update MQL definition

### DIFF
--- a/handbook/marketing/index.md
+++ b/handbook/marketing/index.md
@@ -35,9 +35,7 @@ An inquiry is a person who has requested information from Sourcegraph for the fi
 
 A marketing qualified lead (MQL) is any of:
 
-- A person who fills out a demo request form
-- A person who fills out a free trial form
-- A person who fills out a form requesting to speak with a Sourcegraph representative
+- A person who fills out a demo request form AND self-reports an engineering team of >100 or has a title containing `Director`, `Manager`, `VP`, `Vice President`, `Senior`, `Sr`, 	`Head`, `Lead`, `CTO` or `Chief Technnology Offier`
 - A person who sets up a new Sourcegraph instance
 
 


### PR DESCRIPTION
This MQL definition did not represent what's happening in HubSpot, so I'm proposing only having new instances and demo requests in MQL qualification.

This also means we will stop excluding personal email domains (gmail, hotmail, etc) from becoming MQLs. 