### PR TITLE
Document how to trigger Docker image builds for specific branches

### DIFF
--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -162,3 +162,25 @@ These example commands are for the `dot-com` cluster where the Sourcegraph appli
 ## Backups
 
 Snapshots of all Kubernetes resources are taken periodically and pushed to https://github.com/sourcegraph/kube-backup/.
+
+## Building Docker images for a specific branch
+
+If you need to build Docker images on Buildkite for testing purposes, e.g. you
+have a PR with a fix and want to deploy that fix to a test instance, you can
+push the branch to the special `docker-images-patch` and
+`docker-images-patch-notest` branches.
+
+Example: you want to build a new Docker image for `frontend` and `gitserver`
+based on the branch `my_fix`.
+
+```
+git push origin my_fix:docker-images-patch-notest/frontend
+git push origin my_fix:docker-images-patch-notest/gitserver
+```
+
+This will trigger two builds on Buildkite for these branches:
+
+* https://buildkite.com/sourcegraph/sourcegraph/builds?branch=docker-images-patch-notest%2Ffrontend
+* https://buildkite.com/sourcegraph/sourcegraph/builds?branch=docker-images-patch-notest%2Fgitserver
+
+And the end of the build you can find the name of the newly built Docker image.


### PR DESCRIPTION
I was looking for instructions on how to do this again today but couldn't find anything, so here's my attempt to add them.

Problem: I don't know if they still work. My build failed https://buildkite.com/sourcegraph/sourcegraph/builds/56652#05c7ad40-57a0-4daa-9352-3634331adf35 **but pushed the image up**.

Tagging @ggilmore and @keegancsmith here because you two might know what changed.