### PR TITLE
Add a mission statement for Campaigns

### DIFF
--- a/handbook/engineering/campaigns.md
+++ b/handbook/engineering/campaigns.md
@@ -11,7 +11,7 @@ When I write an AWS Lambda function I want to focus on which requests it receive
 
 When I deploy a static site on Netlify I want to focus on my site — its content and design — and not think about where it's deployed, how to get new SSL certificates, how to install dependencies to run the static site generator on a server, how to preview the site in a pull request.
 
-**Campaigns allow users to focus on finding code that needs to be changed and changing it by running code**.
+**Find code that needs to be changed and change it by running code**.
 
 Campaign users don't have to worry about:
 

--- a/handbook/engineering/campaigns.md
+++ b/handbook/engineering/campaigns.md
@@ -5,12 +5,6 @@ Developer documentation: https://docs.sourcegraph.com/dev/campaigns_development
 
 ## Mission Statement
 
-Campaigns are to large-scale code changes what Netlify is to static site generation and AWS Lambda is to handling HTTP requests.
-
-When I write an AWS Lambda function I want to focus on which requests it receives and what response to send out. I don't want to worry about which server to run it on, how to scale it, secure it, add logging, keep track of its usage.
-
-When I deploy a static site on Netlify I want to focus on my site — its content and design — and not think about where it's deployed, how to get new SSL certificates, how to install dependencies to run the static site generator on a server, how to preview the site in a pull request.
-
 **Find code that needs to be changed and change it by running code**.
 
 Campaign users don't have to worry about:
@@ -22,3 +16,9 @@ Campaign users don't have to worry about:
 * Create pull requests from patches
 * Draft, keep track of and update a large number of pull requests
 * Re-running code when the base branch changes
+
+Campaigns are to large-scale code changes what Netlify is to static site generation and AWS Lambda is to handling HTTP requests.
+
+When I write an AWS Lambda function I want to focus on which requests it receives and what response to send out. I don't want to worry about which server to run it on, how to scale it, secure it, add logging, keep track of its usage.
+
+When I deploy a static site on Netlify I want to focus on my site — its content and design — and not think about where it's deployed, how to get new SSL certificates, how to install dependencies to run the static site generator on a server, how to preview the site in a pull request.

--- a/handbook/engineering/campaigns.md
+++ b/handbook/engineering/campaigns.md
@@ -7,7 +7,7 @@ Developer documentation: https://docs.sourcegraph.com/dev/campaigns_development
 
 **Find code that needs to be changed and change it by running code**.
 
-Campaign users don't have to worry about:
+Users can focus on the changes to their code because Campaigns solve the following problems for you: 
 
 * Finding the correct repositories in which to run code
 * Fetching the newest version of each repository
@@ -17,8 +17,10 @@ Campaign users don't have to worry about:
 * Draft, keep track of and update a large number of pull requests
 * Re-running code when the base branch changes
 
-Campaigns are to large-scale code changes what Netlify is to static site generation and AWS Lambda is to handling HTTP requests.
+Netlify and AWS Lambda solve difficult, repeatable problems for developers, removing overhead and enabling them to focus on the problems they are solving. In that regard, Campaigns are to large-scale code changes what Netlify is to static site generation and AWS Lambda is to handling HTTP requests.
 
 When I write an AWS Lambda function I want to focus on which requests it receives and what response to send out. I don't want to worry about which server to run it on, how to scale it, secure it, add logging, keep track of its usage.
 
 When I deploy a static site on Netlify I want to focus on my site — its content and design — and not think about where it's deployed, how to get new SSL certificates, how to install dependencies to run the static site generator on a server, how to preview the site in a pull request.
+
+When I create a campaign to make large-scale code changes I want to _focus on the specific change I want to make across all of the code at my organization_. I don't want to worry about all of the overhead associated with execution, code hosts, and management of all things listed above. 

--- a/handbook/engineering/campaigns.md
+++ b/handbook/engineering/campaigns.md
@@ -1,0 +1,23 @@
+# Campaigns
+
+User-facing documentation: https://docs.sourcegraph.com/user/campaigns
+Developer documentation: https://docs.sourcegraph.com/dev/campaigns_development
+
+## Mission Statement
+
+Campaigns are to large-scale code changes what Netlify is to static site generation and AWS Lambda is to handling HTTP requests.
+
+When I write an AWS Lambda function I want to focus on which requests it receives and what response to send out. I don't want to worry about which server to run it on, how to scale it, secure it, add logging, keep track of its usage.
+
+When I deploy a static site on Netlify I want to focus on my site — its content and design — and not think about where it's deployed, how to get new SSL certificates, how to install dependencies to run the static site generator on a server, how to preview the site in a pull request.
+
+**Campaigns allow users to focus on finding code that needs to be changed and changing it by running code**.
+
+Campaign users don't have to worry about:
+
+* Finding the correct repositories in which to run code
+* Fetching the newest version of each repository
+* Running code in each repository
+* Turn the result into patches
+* Create pull requests from patches
+* Draft, keep track of and update a large number of pull requests

--- a/handbook/engineering/campaigns.md
+++ b/handbook/engineering/campaigns.md
@@ -21,3 +21,4 @@ Campaign users don't have to worry about:
 * Turn the result into patches
 * Create pull requests from patches
 * Draft, keep track of and update a large number of pull requests
+* Re-running code when the base branch changes

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -18,6 +18,7 @@
 - [Prometheus](prometheus.md)
 - [Adding ping data](adding_ping_data.md)
 - [Adding buildkite secrets](adding_buildkite_secrets.md)
+- [Campaigns](campaigns.md)
 
 ## [Roles and responsibilities](roles.md)
 


### PR DESCRIPTION
In the past couple of weeks I've been thinking about Campaigns, what it is and isn't, where it should go and what we, as engineers, can do to support that.

Call it an engineering vision or a mission statement, I'm not set on a name, and it's still rough and I want to polish it (with everybody's input, of course).

I do think it's valuable to have something like this in place, because it helps us make priority decisions, especially from an engineering perspective. Ever since I came up with these analogies (see PR) for myself, it got a lot easier for me to decide what to work on and what not.

---

I just put this in `index.md` because I couldn't find a better place to put it, but I'm happy to move it.