### PR TITLE
Remove heading above video and added id field for content section component

### DIFF
--- a/website/src/components/content/ContentSection.tsx
+++ b/website/src/components/content/ContentSection.tsx
@@ -12,11 +12,12 @@ const COLORS = {
 }
 
 export const ContentSection: React.FunctionComponent<{
+    id?: string
     color?: keyof typeof COLORS
     className?: string
     children: React.ReactNode
-}> = ({ color = 'black', className = '', children }) => (
-    <div className={COLORS[color]}>
+}> = ({ id = '', color = 'black', className = '', children }) => (
+    <div id={id} className={COLORS[color]}>
         <section className={`content-section container ${className}`}>{children}</section>
     </div>
 )

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -182,10 +182,7 @@ export default ((props: any) => (
             <div className="bg-white text-dark">
                 <CustomerLogosSection className="py-5" />
             </div>
-            <ContentSection color="black" className="py-6">
-                <h2 id="demo" className="text-center display-4 pb-4">
-                    See why developers rely on Sourcegraph daily
-                </h2>
+            <ContentSection id="demo" color="black" className="py-6">
                 <Vimeo id={353422112} muted={true} autoplay={true} loop={true} />
             </ContentSection>
                         <div className="bg-white text-dark py-4">


### PR DESCRIPTION
The heading above the video looks weird but by removing it, I needed to add an id to `ContentSection` component so the video part of the page could be linked to.

<img width="1245" alt="Screen Shot 2020-03-04 at 11 06 11 AM" src="https://user-images.githubusercontent.com/133014/75834605-2f07a180-5e08-11ea-8335-b2a11a2e95ce.png">
