### PR TITLE
broaden MQL defn to include people who register for our events

### DIFF
--- a/handbook/marketing/index.md
+++ b/handbook/marketing/index.md
@@ -38,7 +38,7 @@ A marketing qualified lead (MQL) is any of:
 
 - A person who fills out a demo request form
 - A person who fills out a free trial form
-- A person who attends a Sourcegraph event (including online events)
+- A person who registers for a Sourcegraph event (including online events)
 - A person who fills out a form requesting to speak with a Sourcegraph representative
 - A person who sets up a new Sourcegraph instance
 

--- a/handbook/marketing/index.md
+++ b/handbook/marketing/index.md
@@ -38,6 +38,7 @@ A marketing qualified lead (MQL) is any of:
 
 - A person who fills out a demo request form
 - A person who fills out a free trial form
+- A person who attends a Sourcegraph event (including online events)
 - A person who fills out a form requesting to speak with a Sourcegraph representative
 - A person who sets up a new Sourcegraph instance
 


### PR DESCRIPTION
This broadens the definition of MQL to include people who attend a webinar. I think we were already operating with this definition, and the handbook was just wrong/outdated. (If MQL intentionally excludes this, that is fine, although I'm curious why.)

(Should it be even broader, including people who merely RSVP yes to a webinar but don't actually end up attending?)