### PR TITLE
Add Q1 web OKR around onboarding improvements

### DIFF
--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -75,6 +75,7 @@
    1. Search mode usage is tracked in [pings](https://docs.sourcegraph.com/admin/pings).
 1. **Identify the pain points in our onboarding**
    1. Run 5 user tests to gather feedback on our user onboarding
+   1. Improve in-app documentation for site admin onboarding steps
 
 ### Core services
 

--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -73,6 +73,8 @@
    1. Search daily, weekly, monthly active users are tracked in [pings](https://docs.sourcegraph.com/admin/pings).
    1. Search filter usage is tracked in [pings](https://docs.sourcegraph.com/admin/pings).
    1. Search mode usage is tracked in [pings](https://docs.sourcegraph.com/admin/pings).
+1. **Identify the pain points in our onboarding**
+   1. Run N user tests to gather feedback on our user onboarding
 
 ### Core services
 

--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -74,7 +74,7 @@
    1. Search filter usage is tracked in [pings](https://docs.sourcegraph.com/admin/pings).
    1. Search mode usage is tracked in [pings](https://docs.sourcegraph.com/admin/pings).
 1. **Identify the pain points in our onboarding**
-   1. Run N user tests to gather feedback on our user onboarding
+   1. Run 5 user tests to gather feedback on our user onboarding
 
 ### Core services
 

--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -73,7 +73,7 @@
    1. Search daily, weekly, monthly active users are tracked in [pings](https://docs.sourcegraph.com/admin/pings).
    1. Search filter usage is tracked in [pings](https://docs.sourcegraph.com/admin/pings).
    1. Search mode usage is tracked in [pings](https://docs.sourcegraph.com/admin/pings).
-1. **Identify the pain points in our onboarding**
+1. **Identify and start addressing pain points in our onboarding**
    1. Run 5 user tests to gather feedback on our user onboarding
    1. Improve in-app documentation for site admin onboarding steps
 


### PR DESCRIPTION
We've discussed in the web sync adding an additional Q1 OKR (given that Q1 got "extended") to reflect our focus around onboarding improvements.

Opening this PR to discuss & agree on what this OKR would look like (and eventually merge it 🙂).