### PR TITLE
Use handbook references in opsgenie guide

### DIFF
--- a/handbook/engineering/on_call/index.md
+++ b/handbook/engineering/on_call/index.md
@@ -8,7 +8,7 @@ We have an ops on-call rotation managed through [OpsGenie](https://opsgenie.com)
 1.  Acknowledge pages promptly. If you do not acknowledge within 10 minutes, someone else will get paged.
 1.  Identify the issue and collect information that might be useful for preventing the problem in the future (e.g. if a disk was full, what was it full with?).
     - This frequently involves running kubectl commands against our production cluster.
-    - Make sure you have [setup access to kubernetes](https://about.sourcegraph.com/handbook/engineering/deployments#how-to-setup-access-to-kubernetes) and know [how to perform operations](https://about.sourcegraph.com/handbook/engineering/on_call#playbook) like: looking at logs for a service, restarting a service, getting a command shell in a running pod (e.g. to look at what is on disk).
+    - Make sure you have [setup access to kubernetes](https://about.sourcegraph.com/handbook/engineering/deployments#how-to-setup-access-to-kubernetes) and know [how to perform operations](https://about.sourcegraph.com/handbook/engineering/deployments#kubectl-cheatsheet) like: looking at logs for a service, restarting a service, getting a command shell in a running pod (e.g. to look at what is on disk).
 1.  Take steps to resolve the issue (e.g. if a disk was full, delete any data that is safe to delete to resolve the immediate issue) if you can.
     - Don't mark pages as "resolved". Wait for the underlying alert to auto resolve.
     - If you have unsuccessfully attempted to figure out how to resolve a page, the page hasn't auto resolved (many do), and the issue appears important (e.g. impacts users), then get help from someone else. Prefer to contact people who you know are already awake/working.

--- a/handbook/engineering/on_call/index.md
+++ b/handbook/engineering/on_call/index.md
@@ -8,7 +8,7 @@ We have an ops on-call rotation managed through [OpsGenie](https://opsgenie.com)
 1.  Acknowledge pages promptly. If you do not acknowledge within 10 minutes, someone else will get paged.
 1.  Identify the issue and collect information that might be useful for preventing the problem in the future (e.g. if a disk was full, what was it full with?).
     - This frequently involves running kubectl commands against our production cluster.
-    - Make sure you have [setup access to kubernetes](https://github.com/sourcegraph/infrastructure/blob/master/kubernetes/README.md#how-to-set-up-access-to-kubernetes) and know [how to perform operations](https://github.com/sourcegraph/infrastructure/blob/master/kubernetes/README.md#command-cheatsheet) like: looking at logs for a service, restarting a service, getting a command shell in a running pod (e.g. to look at what is on disk).
+    - Make sure you have [setup access to kubernetes](https://about.sourcegraph.com/handbook/engineering/deployments#how-to-setup-access-to-kubernetes) and know [how to perform operations](https://about.sourcegraph.com/handbook/engineering/on_call#playbook) like: looking at logs for a service, restarting a service, getting a command shell in a running pod (e.g. to look at what is on disk).
 1.  Take steps to resolve the issue (e.g. if a disk was full, delete any data that is safe to delete to resolve the immediate issue) if you can.
     - Don't mark pages as "resolved". Wait for the underlying alert to auto resolve.
     - If you have unsuccessfully attempted to figure out how to resolve a page, the page hasn't auto resolved (many do), and the issue appears important (e.g. impacts users), then get help from someone else. Prefer to contact people who you know are already awake/working.


### PR DESCRIPTION
Previous links are outdated, these sections live in the handbook now.