### PR TITLE
company/okrs: Q1 OKR for core services permissions work

### DIFF
--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -84,7 +84,6 @@
 
 1. **Transparent and scalable code-host permissions syncing**
    1. 95th percentile latency of authorization on the read path (i.e. `authzFilter`) is below 10ms.
-   1. Permissions of GitLab, Bitbucket Server and GitHub are synced in the background instead of on demand on the read path.
    1. Admins can force the refresh of permissions of individual users.
    1. Admins can see the progress of permissions syncing in the admin UI.
    1. Admins can see when a repository or user's permissions were last updated and when they are scheduled to be updated again.

--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -82,6 +82,13 @@
    1. At least four customers are running structural searches and metrics to validate this KR are tracked in [pings](https://docs.sourcegraph.com/admin/pings).
    1. At least four customers are running AND/OR/NOT queries and metrics to validate this KR are tracked in [pings](https://docs.sourcegraph.com/admin/pings).
 
+1. **Transparent and scalable code-host permissions syncing**
+   1. 95th percentile latency of authorization on the read path (i.e. `authzFilter`) is below 10ms.
+   1. Permissions of GitLab, Bitbucket Server and GitHub are synced in the background instead of on demand on the read path.
+   1. Admins can force the refresh of permissions of individual users.
+   1. Admins can see the progress of permissions syncing in the admin UI.
+   1. Admins can see when a repository or user's permissions were last updated and when they are scheduled to be updated again.
+
 ### Campaigns
 
 _This OKR is a joint effort between [web](#web) and [core services](#core-servies)._


### PR DESCRIPTION
This commit adds an OKR for the work we're doing around permissions in
Q1 which wasn't originally planned when we put these OKRs together.