### PR TITLE
update MQL definition

### DIFF
--- a/handbook/marketing/index.md
+++ b/handbook/marketing/index.md
@@ -41,12 +41,8 @@ An inquiry is a person who has requested information from Sourcegraph for the fi
 
 A marketing qualified lead (MQL) is any of:
 
-- A person who fills out a demo request form
-- A person who fills out a free trial form
-- A person who registers for a Sourcegraph event (including online events)
-- A person who fills out a form requesting to speak with a Sourcegraph representative
-- A person who sets up a new Sourcegraph instance
-
+- A person who fills out a demo request form AND self-reports an engineering team of >100 or has a title containing `Director`, `Manager`, `VP`, `Vice President`, `Senior`, `Sr`, 	`Head`, `Lead`, `CTO` or `Chief Technnology Offier`
+- A person who sets up a new Sourcegraph instance with a business email (personal email domains and .edu addresses do not qualify)
 
 ### [SQL](../sales/index.md#lead) (sales-qualified lead)
 


### PR DESCRIPTION
Updating these definitions to match HubSpot workflows. The deleted bullets don't automatically qualify a lead as an MQL