### PR TITLE
release: suggest to list commits with checkbox in reversed order

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -14,7 +14,7 @@ Arguments:
 
 - [ ] TODO: Add PR or commit links here.
     ```
-    git log v$MAJOR.$MINOR.$(($PATCH-1))...$MAJOR.$MINOR --pretty=format:'- %H %s'
+    git log v$MAJOR.$MINOR.$(($PATCH-1))...$MAJOR.$MINOR --pretty=format:'- [ ] %H %s'
     ```
 
 ## Release sourcegraph/server

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -47,7 +47,7 @@ Arguments:
 
 In [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph):
 
-- [ ] Wait for Renovate to open a PR to update the image tags and merge that PR ([example](https://github.com/sourcegraph/deploy-sourcegraph/pull/199)).
+- [ ] Wait for Renovate to open a PR to update the image tags and merge that PR ([example](https://github.com/sourcegraph/deploy-sourcegraph/pull/199) and Renovate could merge it automatically).
 - [ ] Cherry-pick the image tag update commits from `master` onto `$MAJOR.$MINOR` branch. Then push the release tag:
     ```
     git checkout $MAJOR.$MINOR

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -33,13 +33,13 @@ Arguments:
 - [ ] Wait for the final Docker images to be available at https://hub.docker.com/r/sourcegraph/server/tags.
 - [ ] Run the old and new images at least three times to make sure it starts:
     ```
-    # 1. Answer NO to delete /tmp/sourcegraph with the old image
+    # 1. Answer YES to delete /tmp/sourcegraph with the old image
     IMAGE=sourcegraph/server:$MAJOR.$MINOR ./dev/run-server-image.sh
     
-    # 2. Answer YES to delete /tmp/sourcegraph with the new image
+    # 2. Answer NO to delete /tmp/sourcegraph with the new image
     IMAGE=sourcegraph/server:$MAJOR.$MINOR.$PATCH ./dev/run-server-image.sh
     
-    # 3. Answer NO to delete /tmp/sourcegraph with the new image
+    # 3. Answer YES to delete /tmp/sourcegraph with the new image
     IMAGE=sourcegraph/server:$MAJOR.$MINOR.$PATCH ./dev/run-server-image.sh
     ```
 

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -31,8 +31,15 @@ Arguments:
     git tag -a 'v$MAJOR.$MINOR.$PATCH' -m 'v$MAJOR.$MINOR.$PATCH' && git push origin 'v$MAJOR.$MINOR.$PATCH'
     ```
 - [ ] Wait for the final Docker images to be available at https://hub.docker.com/r/sourcegraph/server/tags.
-- [ ] Run the image at least once to make sure it starts:
+- [ ] Run the old and new images at least three times to make sure it starts:
     ```
+    # 1. Answer NO to delete /tmp/sourcegraph with the old image
+    IMAGE=sourcegraph/server:$MAJOR.$MINOR ./dev/run-server-image.sh
+    
+    # 2. Answer YES to delete /tmp/sourcegraph with the new image
+    IMAGE=sourcegraph/server:$MAJOR.$MINOR.$PATCH ./dev/run-server-image.sh
+    
+    # 3. Answer NO to delete /tmp/sourcegraph with the new image
     IMAGE=sourcegraph/server:$MAJOR.$MINOR.$PATCH ./dev/run-server-image.sh
     ```
 

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -14,7 +14,7 @@ Arguments:
 
 - [ ] TODO: Add PR or commit links here.
     ```
-    git log v$MAJOR.$MINOR.$(($PATCH-1))...$MAJOR.$MINOR --pretty=format:'- [ ] %H %s'
+    git log v$MAJOR.$MINOR.$(($PATCH-1))...$MAJOR.$MINOR --pretty=format:'- [ ] %H %s' --reverse
     ```
 
 ## Release sourcegraph/server

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -31,6 +31,10 @@ Arguments:
     git tag -a 'v$MAJOR.$MINOR.$PATCH' -m 'v$MAJOR.$MINOR.$PATCH' && git push origin 'v$MAJOR.$MINOR.$PATCH'
     ```
 - [ ] Wait for the final Docker images to be available at https://hub.docker.com/r/sourcegraph/server/tags.
+- [ ] Run the image at least once to make sure it starts:
+    ```
+    IMAGE=sourcegraph/server:$MAJOR.$MINOR.$PATCH ./dev/run-server-image.sh
+    ```
 
 ## Release Kubernetes deployment
 

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -19,7 +19,7 @@ Arguments:
 
 ## Release sourcegraph/server
 
-- [ ] Push the branch `$MAJOR.$MINOR` with your cherry-picked commit(s) and make sure CI passes.
+- [ ] Push the branch [`$MAJOR.$MINOR`](https://github.com/sourcegraph/sourcegraph/tree/$MAJOR.$MINOR) with your cherry-picked commit(s) and make sure CI passes.
 - [ ] Push a release candidate tag:
     ```
     git checkout '$MAJOR.$MINOR'


### PR DESCRIPTION
The output will have checkbox style on GitHub.com, also list commits in reverse order to respect the order of cherry-pick (oldest to newest).

Minors:
- A link to the branch page for the patch release.
- Suggest to run the Docker image at least three times.