### PR TITLE
Update cheatsheet command for port-forward Jaeger

### DIFF
--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -203,7 +203,7 @@ These example commands are for the `dot-com` cluster where the Sourcegraph appli
 <tr>
   <td>Get access to Jaeger locally.</td>
   <td>
-	<code>kubectl port-forward svc/jaeger-query 16686</code>
+	<code>kubectl port-forward --namespace=prod svc/jaeger-query 16686</code>
   </td>
 </tr>
 


### PR DESCRIPTION
Sometimes `--namespace prod` is required.