### PR TITLE
describe free tier user limit based on accounts, not active users

### DIFF
--- a/website/src/components/PricingFreeTierPopover.tsx
+++ b/website/src/components/PricingFreeTierPopover.tsx
@@ -10,7 +10,7 @@ const PricingFreeTierPopoverBody: React.FunctionComponent<any> = () => (
             <li className="nav-item mb-1">Editor and code host integrations</li>
             <li className="nav-item mb-1">Sourcegraph extensions</li>
             <li className="nav-item mb-1">Single sign-on (SSO)</li>
-            <li className="nav-item mb-1">10 monthly active user limit</li>
+            <li className="nav-item mb-1">10-user limit</li>
             <li className="nav-item">Community support</li>
         </ul>
     </div>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -58,7 +58,7 @@ export default ((props: any) => (
                                     },
                                     { name: 'Single sign-on (SSO)', id: 'admin' },
                                     { name: 'Community support', id: 'support' },
-                                    { name: '10 monthly active user limit', id: 'deployment' },
+                                    { name: '10-user limit', id: 'deployment' },
                                 ]}
                                 buttonLabel="Install now"
                                 buttonHref="https://docs.sourcegraph.com#quickstart-guide"


### PR DESCRIPTION
This simplifies the user limit and reflects how it's actually implemented (it counts user accounts, not monthly active users).