### PR TITLE
Fix rendering of table

### DIFF
--- a/handbook/engineering/commit_messages.md
+++ b/handbook/engineering/commit_messages.md
@@ -19,10 +19,10 @@ The subject line should be concise and easy to visually scan in a list of commit
 3. Do not end the subject line with punctuation.
 4. Use the [imperative mood](https://chris.beams.io/posts/git-commit/#imperative) in the subject line.
 
-   | Prefer | Instead of |
-   |--------|------------|
-   | Fix bug in XYZ | Fixed a bug in XYZ |
-   | Change behavior of X | Changing behavior of X |
+| Prefer | Instead of |
+|--------|------------|
+| Fix bug in XYZ | Fixed a bug in XYZ |
+| Change behavior of X | Changing behavior of X |
 
 Example:
 


### PR DESCRIPTION
This fixes the rendering of a table in the "Commit message guidelines" page.

Before:
<img width="845" alt="Screenshot 2020-04-16 at 12 11 03" src="https://user-images.githubusercontent.com/2102036/79431388-72465a00-7fdb-11ea-9c08-952ff1ecf263.png">

After:
<img width="627" alt="Screenshot 2020-04-16 at 12 11 16" src="https://user-images.githubusercontent.com/2102036/79431421-7ecab280-7fdb-11ea-97e8-41eb911ee94d.png">
