### PR TITLE
Fix typos across sourcegraph/about repo

### DIFF
--- a/blogposts/announcing-sourcegraph-3.8.md
+++ b/blogposts/announcing-sourcegraph-3.8.md
@@ -121,7 +121,7 @@ You can now toggle the browser extension on and off without having to fully disa
 
 #### Changed
 
-- A `hardTTL` setting was added to the [Bitbucket Server `authorization` config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration). This setting specifies a duration after which a user's cached permissions must be updated before any user action is authorized. This contrasts with the already existing `ttl` setting which defines a duration after which a user's cached permissions will get updated in the background, but the previously cached (and now stale) permissions are used to authorize any user action occuring before the update concludes. If your previous `ttl` value is larger than the default of the new `hardTTL` setting (i.e. **3 days**), you must change the `ttl` to be smaller or, `hardTTL` to be larger.
+- A `hardTTL` setting was added to the [Bitbucket Server `authorization` config](https://docs.sourcegraph.com/admin/external_service/bitbucketserver#configuration). This setting specifies a duration after which a user's cached permissions must be updated before any user action is authorized. This contrasts with the already existing `ttl` setting which defines a duration after which a user's cached permissions will get updated in the background, but the previously cached (and now stale) permissions are used to authorize any user action occurring before the update concludes. If your previous `ttl` value is larger than the default of the new `hardTTL` setting (i.e. **3 days**), you must change the `ttl` to be smaller or, `hardTTL` to be larger.
 - Sourcegraph now receives [pings](https://docs.sourcegraph.com/admin/pings) on which extensions are activated from Sourcegraph.com.
 
 #### Removed

--- a/blogposts/lsif-indexer.md
+++ b/blogposts/lsif-indexer.md
@@ -80,7 +80,7 @@ Tree hierarchy of scopes for Listing 1.
 We need to:
 
 - maintain the scope hierarchy
-- for each identifier occurence
+- for each identifier occurrence
 	- if it is a definition, add it to the active scope
 	- if it is a reference, look in the scope hierarchy for its definition starting at the active scope and going up its parent link
 
@@ -211,9 +211,9 @@ The only additional vertices not described yet are the ones labelled "$event". T
 
 ## Generating
 
-We are finally ready to generate the LSIF data. The code is in [dumper.go](https://github.com/sourcegraph/lsif-jsonnet/blob/master/dumper/dumper.go). We proceed in a top-down fashion. We start with the project and the listener for the main Jsonnet file. We emit the project node and delimiter marker for start of project and then call the method for emiting a document. This, in turn, emits a document node and start of document marker. It then emits declarations which create those subgraphs from above by also iterating through their reference lists. We also recursively call document emit methods for each import passing in the corresponding import listener created from parsing the import file. We finish by returning from these methods, creating stop markers as we unwind.
+We are finally ready to generate the LSIF data. The code is in [dumper.go](https://github.com/sourcegraph/lsif-jsonnet/blob/master/dumper/dumper.go). We proceed in a top-down fashion. We start with the project and the listener for the main Jsonnet file. We emit the project node and delimiter marker for start of project and then call the method for emitting a document. This, in turn, emits a document node and start of document marker. It then emits declarations which create those subgraphs from above by also iterating through their reference lists. We also recursively call document emit methods for each import passing in the corresponding import listener created from parsing the import file. We finish by returning from these methods, creating stop markers as we unwind.
 
-The actual emiting is done by [protocol.go](https://github.com/sourcegraph/lsif-jsonnet/blob/master/protocol/protocol.go), which has utility methods to create the appropriate vertices, edges and JSON lines.
+The actual emitting is done by [protocol.go](https://github.com/sourcegraph/lsif-jsonnet/blob/master/protocol/protocol.go), which has utility methods to create the appropriate vertices, edges and JSON lines.
 
 ## Testing and validating LSIF output
 

--- a/blogposts/strange-loop-2019-a-robot-poet-goes-for-a-walk-in-the-park.md
+++ b/blogposts/strange-loop-2019-a-robot-poet-goes-for-a-walk-in-the-park.md
@@ -43,7 +43,7 @@ you walked through Fort Mason Park.
 
 Lazer-Walker went over the agenda for the talk:
 
-1. Site-specfic theatre - Immersive theater, narrative installation, and “joyful, emergent behaviors”
+1. Site-specific theatre - Immersive theater, narrative installation, and “joyful, emergent behaviors”
 2. Actual act of generating art like this
 3. Digital/Physical hybrids
 

--- a/blogposts/strange-loop-2019-assistive-augmentation-lip-reading-with-ai.md
+++ b/blogposts/strange-loop-2019-assistive-augmentation-lip-reading-with-ai.md
@@ -135,7 +135,7 @@ We’d need a larger training set with annotated data in order to improve this -
 - Q: What did you use for the facial recognition?
 - A: A piece of open source software from (name I missed) that ran in a JuPyter Notebook.
 
-- Q: Are you trying to get puncutation, inflections, etc. into the model?
+- Q: Are you trying to get punctuation, inflections, etc. into the model?
 - A: Yes, I’m trying to. For instance, commas, “...”, question marks, etc. were tokenized in the hopes the system would find them, but it usually didn’t. In part this is because there isn’t a lip movement that corresponds to that particular symbol.
 
 - Q: What’s the current program runtime?

--- a/blogposts/strange-loop-2019-beyond-alt-text-trends-in-online-accessibility.md
+++ b/blogposts/strange-loop-2019-beyond-alt-text-trends-in-online-accessibility.md
@@ -93,7 +93,7 @@ The 11 stands for the 11 characters inbetween "a" and "y" (a***********y)
 
 ### Technical Specifications
 
-  **Accessibile Rich Internet Applications (ARIA)** is a tool at your disposal to meet WCAG standards (aria-hidden and aria-labeledby as examples), however, this should not be your first tool of choice. Using HTML elements to their semantic specifications is what you should be doing first. As an example, don't use "<div class="button"...>" as divs are not focusable by default. A much better method would be to use a button and then apply a style.
+  **Accessible Rich Internet Applications (ARIA)** is a tool at your disposal to meet WCAG standards (aria-hidden and aria-labeledby as examples), however, this should not be your first tool of choice. Using HTML elements to their semantic specifications is what you should be doing first. As an example, don't use "<div class="button"...>" as divs are not focusable by default. A much better method would be to use a button and then apply a style.
 
 ### So why do we care about accessibility, a history lesson
 
@@ -101,9 +101,9 @@ Our physical spaces come with a lot of affordances which exist to help people wi
 
 However, we **all** use and take these for granted. These public affordances didn't always exist. In fact, most of this didn't exist even in the 1960's.
 
-A strong [disability rights movement](https://en.wikipedia.org/wiki/Disability_rights_movement) took place in the 60's and 70's, thanks to [Ed Roberts](https://en.wikipedia.org/wiki/Ed_Roberts_(activist)), that really changed the way we percieve and value people with disabilities.
+A strong [disability rights movement](https://en.wikipedia.org/wiki/Disability_rights_movement) took place in the 60's and 70's, thanks to [Ed Roberts](https://en.wikipedia.org/wiki/Ed_Roberts_(activist)), that really changed the way we perceive and value people with disabilities.
 
-Although this major shift in public opinion occurred several decades ago, we can still see renovations and retrofits occuring to public spaces. The Toronto subway stations are a prime example. The stations were built in the 60's and are today retrofitting elevators, a very slow and expensive process.
+Although this major shift in public opinion occurred several decades ago, we can still see renovations and retrofits occurring to public spaces. The Toronto subway stations are a prime example. The stations were built in the 60's and are today retrofitting elevators, a very slow and expensive process.
 
 ![Presentation slide showing a wheelchair at a curb with a 5 inch drop. No curb cut present.](/blog/strange-loop-2019/beyond-alt-text-1.png)
 This is a standard curb with an approx 5 inch drop for this wheelchair.
@@ -159,7 +159,7 @@ So where do you start with accessibility? Your keyboard.
 
 ### Low Vision
 
-- **Magnification:** Use a relative font unit like rems or ems to accomodate screen magnification.
+- **Magnification:** Use a relative font unit like rems or ems to accommodate screen magnification.
 - **Color Contrast:** Colors should meet [WCAG AA requirements to color contrast](https://webaim.org/resources/contrastchecker/) which benefits all users as another digital curb-cut.
 - **High Contrast Themes:** these themes allow users with low vision to use your site with less difficulty. However, this comes with its own hiccups for CSS implemented background images.
 
@@ -187,7 +187,7 @@ Always test for accessability. Reach out to local accessibility communities for 
 
 ### SHARE YOUR KNOWLEDGE
 
-Document your accessibility improvements as much as possible to ensure accessibility is consistent throughtout all aspects of a project and are clearly understood by all team members.
+Document your accessibility improvements as much as possible to ensure accessibility is consistent throughout all aspects of a project and are clearly understood by all team members.
 
 A great example of this is [eBay's accessibility documentation](http://ebay.github.io/mindpatterns/).
 

--- a/blogposts/strange-loop-2019-complexities-of-color-in-computing.md
+++ b/blogposts/strange-loop-2019-complexities-of-color-in-computing.md
@@ -67,7 +67,7 @@ Pixels create color by combining red, green, and blue,against a black background
 There’s a couple more computer colorspaces that come up, including sRGB, which is the standardized RGB created in 1996, hexadecimal which is a way of representing rgb, CYMK which stands for cyan, yellow, magenta black and which is a color-subtractive method of measuring color, and hsl which stands for hue/saturation/light. For the purposes of this talk we’re going to focus on rgb, since it’s based on the physics of the eye, but also reveals a lot of limitations and interesting cliffs on our understanding--say, for example, in comparing the distance in two colors
 
 
-A Euclidian distance formula could theoretically calculate the differences between colors.
+A Euclidean distance formula could theoretically calculate the differences between colors.
 
 ```
 Color 1 = ( R ₁ , G ₁ , B ₁  )
@@ -150,7 +150,7 @@ Most studies agree that the dress phenomenon has something to do with the assump
 ## Q & A
 (Audience) Have you seen research that links color perception and language?
 
-(Ellen) It's been years since I've looked at that research, but if I remember correctly, if people don't have the word for a color they are less likely to percieve it. 
+(Ellen) It's been years since I've looked at that research, but if I remember correctly, if people don't have the word for a color they are less likely to perceive it. 
 
 (Audience) Have you seen any attempts out of Hong Kong to disrupt facial recognition?
 

--- a/blogposts/strange-loop-2019-digital-and-social-resilience-through-the-nyc-mesh.md
+++ b/blogposts/strange-loop-2019-digital-and-social-resilience-through-the-nyc-mesh.md
@@ -229,7 +229,7 @@ have been actively engaged in other projects.
 
 Photos of new members, happy volunteers. They historically have little to no
 training and are exciting about where they're connecting to and building a
-sence of community.
+sense of community.
 
 
 # Where are we?
@@ -275,7 +275,7 @@ volunteers over time. Interest has spiked since the repeal of net neutrality.
 
 We still have problems, though!  We haven't figured out how to structure
 ourselves as a distributed organization. We're not sure how to secure funding.
-We don't know how we're oging to be able to hire employees, and pay people for
+We don't know how we're going to be able to hire employees, and pay people for
 their work. We're also still really bad at reaching consensus.
 
 We're hoping that once we reach 1000 nodes, we might be able to pay some people

--- a/blogposts/strange-loop-2019-enhancing-angklung-music-rehearsals-with-modern-tech.md
+++ b/blogposts/strange-loop-2019-enhancing-angklung-music-rehearsals-with-modern-tech.md
@@ -37,7 +37,7 @@ Trapsilo comes from Bandung, Indonesia. Bandung is the 3rd largest city in Indon
 
 ![Map of Bandung, Indonesia](/blog/strange-loop-2019/angklung/Bandung-Indonesia_map.png)
 
-Trapsilo has played Angklung for over 10 years and has played in Italy, Greece, Maylasia and Singapore and has also conducted several concerts and performances.
+Trapsilo has played Angklung for over 10 years and has played in Italy, Greece, Malaysia and Singapore and has also conducted several concerts and performances.
 
 He has been programming far longer than he has been playing Angklung. Naturally he thought of programming ways to solve the problems his groups had when doing performances.
 

--- a/blogposts/strange-loop-2019-explainable-ai-the-apex-of-human-and-machine-learning.md
+++ b/blogposts/strange-loop-2019-explainable-ai-the-apex-of-human-and-machine-learning.md
@@ -91,7 +91,7 @@ Baxter talks about the Rectangle Game and another experiment teaching image cate
 
 ![](/blog/strange-loop-2019/pedagogy.jpg)
 
-We did have some success in transfering some knowledge that was machine knowledge in to humans.
+We did have some success in transferring some knowledge that was machine knowledge in to humans.
 
 The problem with this is that its's is recursive maths and teaching is harder than learning.
 

--- a/blogposts/strange-loop-2019-federated-learning-private-distributed-ml.md
+++ b/blogposts/strange-loop-2019-federated-learning-private-distributed-ml.md
@@ -39,7 +39,7 @@ issues like privacy. In his view, federated learning combines areas like distrib
 
 ### Machine Learning
 
-ML is the field of algorithms that infer rules connecting data to answers, given data & the right answers. It differs from classical programming by infering the rules instead of explictly being provided with a set of rules.
+ML is the field of algorithms that infer rules connecting data to answers, given data & the right answers. It differs from classical programming by infering the rules instead of explicitly being provided with a set of rules.
 
 The most common machine learning workflow involves moving data from different sources to one location. This gives rise to the issue of privacy. If you use products built by various large tech companies, you invariably end up handing over your private data to them which they use to train their models.
 

--- a/blogposts/strange-loop-2019-from-video-games-to-fashion-a-machine-learning-journey.md
+++ b/blogposts/strange-loop-2019-from-video-games-to-fashion-a-machine-learning-journey.md
@@ -31,7 +31,7 @@ Gaming is a rapidly growing industry. Players generate extremely rich datasets t
 ---
 ![From Video Games to Fashion: a Machine Learning Journey, title slide](blog/strange-loop-2019/strange-loop-perianez-title.jpg)
 
-Dr. África Periáñez has traced a career from scientist to data scientist, including a stint as a CEO along the way, but her focus for the last few years has been probabilistic forecasting.  Having recently made a dramatic shift between industries--from video games to fashion--Periáñez noted that this was one of the most difficult talks for her to prepare. While she has continued in the practice of predictive forecasting, her work is now in a completely new context. Earlier in her career Periáñez worked with academia and atomspheric data sets at CERN and the German weather service. She then moved into the field of video games, where she spent 2015-2019 analyzing and predicting player behavior. 
+Dr. África Periáñez has traced a career from scientist to data scientist, including a stint as a CEO along the way, but her focus for the last few years has been probabilistic forecasting.  Having recently made a dramatic shift between industries--from video games to fashion--Periáñez noted that this was one of the most difficult talks for her to prepare. While she has continued in the practice of predictive forecasting, her work is now in a completely new context. Earlier in her career Periáñez worked with academia and atmospheric data sets at CERN and the German weather service. She then moved into the field of video games, where she spent 2015-2019 analyzing and predicting player behavior. 
 
 ![career shifts 2005-2019](blog/strange-loop-2019/strange-loop-perianez-careers.jpg)
 

--- a/blogposts/strange-loop-2019-how-computers-misunderstand-the-world.md
+++ b/blogposts/strange-loop-2019-how-computers-misunderstand-the-world.md
@@ -89,13 +89,13 @@ As of 2017, there were zero tenured women faculty members in the Harvard math de
 
 ### Bias Manifested
 
-Unconcious bias manifests in technology in a variety of ways.
+Unconscious bias manifests in technology in a variety of ways.
 
 1. **Wide-spread harassment in computer science and mathematics**: news headlines and movements to speak out openly about the experiences many today still have
 2. **Bias in word embedding**: critical to how Google figures out what you're looking for when you search occupations associated with he and she {photo of _extreme she_ and _extreme he_ occupations}; these are the embeddings that feed the algorithms which increasingly make decisions on our behalf; biases at creation were not noticed because of unconscious bias 
 3. **Bias in tech features and functions**: Environmentally racist soap dispenser ([YouTube video][3]) light skin man can get it to work; dark skin man can't get it to work; white paper towel works just fine; Meredith's take: "_I do not believe the people who made the dispenser tech sat down to make a racist soap dispenser. What I do believe is that the technology was developed by a bunch of people with light skin who said 'oh hey it works!' and then sent it out into the world and now people can't wash their hands._"
 4. **Positive Asymmetry**: concep t of how we as humans like to focus more on what's happy than what iss problematic; it is a group dynamic and we need to recognize this type of behavior happens; while uncomfortable to do so, it is worth pushing past; if we don't push past the discomfort, we end up with Machine Bias
-5. **Algorithms are NOT Neutral**: {photo with article heading with two petty theft arrests and future crime risks score mis-match between a white man and a black woman} unconscious bias is embedded into the "future crime" model through the training data used to create the model; facial recognition algorithms work better for light skin men vs darker skin women and regularly mis-gender/mis-identify women and dark skinned people; book reference: _ALGORITHMS OF OPRESSION_
+5. **Algorithms are NOT Neutral**: {photo with article heading with two petty theft arrests and future crime risks score mis-match between a white man and a black woman} unconscious bias is embedded into the "future crime" model through the training data used to create the model; facial recognition algorithms work better for light skin men vs darker skin women and regularly mis-gender/mis-identify women and dark skinned people; book reference: _ALGORITHMS OF OPPRESSION_
 6. **Bias Magnified**: the unconscious bias in the soap dispenser is magnified in facial recognition; same tech in the soap dispensers and used in facial recognition are in self-driving cars; image recognition algorithms are really, really _fragile_; Are they going to recognize people with darker skin? What about people with disabilities?
 
 ### Better Informed

--- a/blogposts/strange-loop-2019-how-not-to-read-the-room-creating-wearables-with-ml.md
+++ b/blogposts/strange-loop-2019-how-not-to-read-the-room-creating-wearables-with-ml.md
@@ -87,6 +87,6 @@ All of this code is available on: [tiny.cc/ml-necklace](tiny.cc/ml-necklace)
 
 Her final hardware challenge was a bit more unexpected. Moving the harness from the manequin to her body, she found bad connections and shorting (soldering is hard!), and the fit wasn't exactly right. She had also hoped to fit all the electronics in a fanny pack, but needed to end up using a larger wearable bag. She also discovered a new user requirement - a way to turn off the lights completely when not in use. She added a long-press button to toggle on/off manually.
 
-All-in-all, Stephanie described this project as a hard build - about 8 months, on and off. It was exhausting. She took several month-long breaks due to burnout, especially becasue of things like power issues.
+All-in-all, Stephanie described this project as a hard build - about 8 months, on and off. It was exhausting. She took several month-long breaks due to burnout, especially because of things like power issues.
 
 But the end result is compelling! Audience members approaching Stephanie after the talk to ask questions served as a fantastic demo of how the neckalce performs in the real world.

--- a/blogposts/strange-loop-2019-how-to-fix-ai-solutions-to-ml-bias-and-why-they-don-t-matter.md
+++ b/blogposts/strange-loop-2019-how-to-fix-ai-solutions-to-ml-bias-and-why-they-don-t-matter.md
@@ -44,7 +44,7 @@ Majority of the talk focuses on technical mitigations for bias in data and will 
 
 ## 1. The Problem
 
-Joyce tells a story from 1961 about a man called Clyde Ross who tried to buy a home in North Lawndale, Chicago. He was a veteran who after WW II had worked for 14 years before he and his wife tried to buy a house. Unfortunately, he gets into a predatory agreement where he pays his mortgage to his seller, but Ross doesn’t get any equity. And if he misses a single payment, he forfeits the property itself. He tried to leave and get new housing but discovered he could not because of redlining.  Redlining specifically affected people of color. Joyce tells another story from 2018 where Rachelle Faroud tried to but a house in Western Philadlephia again and again and was denied despite improving her social standing.
+Joyce tells a story from 1961 about a man called Clyde Ross who tried to buy a home in North Lawndale, Chicago. He was a veteran who after WW II had worked for 14 years before he and his wife tried to buy a house. Unfortunately, he gets into a predatory agreement where he pays his mortgage to his seller, but Ross doesn’t get any equity. And if he misses a single payment, he forfeits the property itself. He tried to leave and get new housing but discovered he could not because of redlining.  Redlining specifically affected people of color. Joyce tells another story from 2018 where Rachelle Faroud tried to but a house in Western Philadelphia again and again and was denied despite improving her social standing.
 
 In 1968 the Fair Housing Act was passed to protect people from discrimination such as what Clyde Ross went through.
 

--- a/blogposts/strange-loop-2019-recreating-forgotten-programming-languages-for-art.md
+++ b/blogposts/strange-loop-2019-recreating-forgotten-programming-languages-for-art.md
@@ -159,7 +159,7 @@ Line printers print line by line with a very limited character set.
 Example of a drum of a line printer.
 Really fast and really loud.
 
-These graphcis were made with a language called "ART 1", made by Katherine Nash and Richard Williams at
+These graphics were made with a language called "ART 1", made by Katherine Nash and Richard Williams at
 University of New Mexico. The graphics are made by printing 2 blocks of simple characters on top of each other.
 They were EBCDIC characters, these days we have something similar with ASCII.
 

--- a/blogposts/strange-loop-2019-uptime-15364-days-the-computers-of-voyager.md
+++ b/blogposts/strange-loop-2019-uptime-15364-days-the-computers-of-voyager.md
@@ -86,7 +86,7 @@ The National Air and Space museum has a engineering prototype of Voyager that's 
 
 ## Post-Launch
 
-Post-launch there was an issue with the control transmission and the primary reciever on Voyager 1 failed after an automated failover attempt. There's a short in a capacitor on the secondary receiver so it although it works it's somewhat tempermental.
+Post-launch there was an issue with the control transmission and the primary receiver on Voyager 1 failed after an automated failover attempt. There's a short in a capacitor on the secondary receiver so it although it works it's somewhat tempermental.
 They managed to get more funding to get to Uranus and Neptune. They added a data compression algorithm to deal with the transmission rate decreasing due to signal attenuation. They switched the probe to use both processors, one to deal with the compression.
 Power available has been decreasing slowly, the thermocouples are degrading and about half of the Plutonium has been used up. NASA has been turning off and cycling the systems to conserve power. We expect Voyager to last maybe another 5 years. After it ceases operation it'll still continue out into the galaxy, carrying the Voyager golden record. 
 

--- a/company/remote/index.md
+++ b/company/remote/index.md
@@ -21,7 +21,7 @@ All-remote teams like ours rely heavily on written communication. Nothing else w
   - The speaker's non-verbal cues (e.g., tone, facial expression, posture) modulate how the listener perceives the words being said.
     - Without this context that people are used to, written communication can feel cold and negative by default, unless the writer makes a conscious effort to lead with positivity (e.g., "Great!", "Thanks!", "I agree!"). This becomes less of a risk if the speaker and listener already have a good working relationship.
   - The speaker can adapt their message based on the listener's non-verbal cues (e.g., if the listener looks confused then the speaker can ask what is confusing and clarify the confusion before moving on).
-    - Written communication is most effective when the writer thinks about what questions readers will have and preemptively anwsers those questions in the original communication.
+    - Written communication is most effective when the writer thinks about what questions readers will have and preemptively answers those questions in the original communication.
 
 All-remote teams can't rely as much on the spontaneous interactions and conversations that might happen in an office (e.g., in a break room, in the hallway, at lunch). These kinds of interactions are valuable for building interpersonal relationships, so all-remote teams need to explicitly make space for these things to happen.
 

--- a/handbook/design/design-execution.md
+++ b/handbook/design/design-execution.md
@@ -6,7 +6,7 @@ Design execution documents are where design projects live, tracking the process 
 
 A design execution document is a place where design is executed. Research will be organised, and discussion concerning design artifacts can take place and be documented here.
 
-The [template](https://docs.google.com/document/d/12qT1U_ogBBY1ED6XlG-3MnbeOzCuYrnvoU7inpUMtPM/edit#) for design execution documents is loose, to accomodate varying design needs, and changes to process. 
+The [template](https://docs.google.com/document/d/12qT1U_ogBBY1ED6XlG-3MnbeOzCuYrnvoU7inpUMtPM/edit#) for design execution documents is loose, to accommodate varying design needs, and changes to process. 
 
 All DE documents should serve 3 goals:
 

--- a/handbook/engineering/code_reviews.md
+++ b/handbook/engineering/code_reviews.md
@@ -63,7 +63,7 @@ If we see that there are too many [PRs being merged without approval](https://gi
 
 ## What makes an effective Pull Request (PR)?
 
-An effective PR minimizes the amount of effort that is required for the reviewer to understand your change so that they can provide high quality feedback in a timely manner. [Futher reading](https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests).
+An effective PR minimizes the amount of effort that is required for the reviewer to understand your change so that they can provide high quality feedback in a timely manner. [Further reading](https://www.atlassian.com/blog/git/written-unwritten-guide-pull-requests).
 
 Do:
 

--- a/handbook/engineering/continuous_releasability.md
+++ b/handbook/engineering/continuous_releasability.md
@@ -1,6 +1,6 @@
 # Continuous releasability
 
-We practice **continuous releasability**. This is a variant of [continous
+We practice **continuous releasability**. This is a variant of [continuous
 delivery](https://en.wikipedia.org/wiki/Continuous_delivery) adapted to a monthly release cadence
 that serves the needs of customers running their own Sourcegraph instances.
 

--- a/handbook/engineering/github-notifications/index.md
+++ b/handbook/engineering/github-notifications/index.md
@@ -1,6 +1,6 @@
 # GitHub notifications
 
-It is important to configure your notifications correctly so that you receive and read notifications that are important (e.g. someone makes a comment on one of your PRs, someone adds you as a reviewer to a PR) without being overwhemled by notifications that don't involve you. This document describes some options.
+It is important to configure your notifications correctly so that you receive and read notifications that are important (e.g. someone makes a comment on one of your PRs, someone adds you as a reviewer to a PR) without being overwhelmed by notifications that don't involve you. This document describes some options.
 
 GitHub notification settings are configured here: https://github.com/settings/notifications.
 
@@ -25,7 +25,7 @@ This option will send you the firehose of notifications for all of the repositor
 1. So that you can search your email to find conversations that are not involved in.
 2. So that if you are added to an existing conversation in a PR or issue, you will have the complete conversation in your email already.
 
-If you enable email notifications for watched repositories then you will want to setup some email filters (otherwise your email inbox will be overwhelemed and important things will get buried). You should _not_ attempt to read every issue and PR that doesn't involve you.
+If you enable email notifications for watched repositories then you will want to setup some email filters (otherwise your email inbox will be overwhelmed and important things will get buried). You should _not_ attempt to read every issue and PR that doesn't involve you.
 
 ### Gmail filters
 

--- a/handbook/engineering/product_documentation.md
+++ b/handbook/engineering/product_documentation.md
@@ -6,7 +6,7 @@ These guidelines are for contributing documentation to the [sourcegraph reposito
 
 Whenever a feature is changed, updated, introduced, or deprecated, the pull request introducing these changes must be accompanied by the documentation (either updating existing ones or creating new ones).
 
-The developer who made the code change is also [responsible](../../handbook/engineering/roles.md#software-enginer) for writing the initial documentation for new features and updating the documentation for changes to existing features. At the pace Sourcegraph evolves, this is the only way to keep the docs up to date.
+The developer who made the code change is also [responsible](../../handbook/engineering/roles.md#software-engineer) for writing the initial documentation for new features and updating the documentation for changes to existing features. At the pace Sourcegraph evolves, this is the only way to keep the docs up to date.
 
 It's the [responsibility of the Product Manager](../../handbook/product/roles.md#product-manager) to ensure all features are shipped with documentation (i.e., that nothing slips through), whether is a small or big change.
 

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -1,10 +1,10 @@
 # Roles on the Engineering team
 
-This page lists the roles on the Engineering team and some of the responsibilites for each of the roles.
+This page lists the roles on the Engineering team and some of the responsibilities for each of the roles.
 
 ## Software Engineer
 
-Sofware Engineers are individual contributors who build software to satisfy the needs of the business.
+Software Engineers are individual contributors who build software to satisfy the needs of the business.
 
 ### Responsibilities
 

--- a/handbook/marketing/index.md
+++ b/handbook/marketing/index.md
@@ -41,7 +41,7 @@ An inquiry is a person who has requested information from Sourcegraph for the fi
 
 A marketing qualified lead (MQL) is any of:
 
-- A person who fills out a demo request form AND self-reports an engineering team of >100 or has a title containing `Director`, `Manager`, `VP`, `Vice President`, `Senior`, `Sr`, 	`Head`, `Lead`, `CTO` or `Chief Technnology Offier`
+- A person who fills out a demo request form AND self-reports an engineering team of >100 or has a title containing `Director`, `Manager`, `VP`, `Vice President`, `Senior`, `Sr`, 	`Head`, `Lead`, `CTO` or `Chief Technology Offier`
 - A person who sets up a new Sourcegraph instance with a business email (personal email domains and .edu addresses do not qualify)
 
 ### [SQL](../sales/index.md#lead) (sales-qualified lead)

--- a/handbook/people-ops/from-graphbook/glossary.md
+++ b/handbook/people-ops/from-graphbook/glossary.md
@@ -39,7 +39,7 @@ A service like GitHub, GitLab, or Bitbucket which provides storage and remote ac
 ### Version Control
 A system that tracks changes to a document or project over time in an orderly and systematic way.
 
-This is similar to how a Google Doc allows you to review a document’s history (see what changes occured, who made which changes, etc.) Version control provides the ability to “time travel” and restore previous versions of the document in case something went wrong with one of the changes. 
+This is similar to how a Google Doc allows you to review a document’s history (see what changes occurred, who made which changes, etc.) Version control provides the ability to “time travel” and restore previous versions of the document in case something went wrong with one of the changes. 
 
 ### Git
 A version control system, developed for the maintenance of code with particularly strong support or simultaneous efforts by many developers.

--- a/handbook/sales/index.md
+++ b/handbook/sales/index.md
@@ -139,7 +139,7 @@ Different customers and deals have different needs from our sales team. We segme
 
 This page describes how we use HubSpot to maintain high data quality. This allows us to increase the effectiveness of all Sourcegraph teams through accurate insights.
 
-Account Executives are responisble for maintaining HubSpot as a [source of truth](https://about.sourcegraph.com/handbook/communication#sources-of-truth). The data is synced between HubSpot and Looker every weekend so this data must be updated (at least) by end of day Friday.
+Account Executives are responsible for maintaining HubSpot as a [source of truth](https://about.sourcegraph.com/handbook/communication#sources-of-truth). The data is synced between HubSpot and Looker every weekend so this data must be updated (at least) by end of day Friday.
 
 ### Associating contacts to deals
 


### PR DESCRIPTION
:writing_hand: **Fix typos across sourcegraph/about repo**

**Files that have typos**

```
about/blogposts/announcing-sourcegraph-3.8.md:124:541: "occuring" is a misspelling of "occurring"
about/blogposts/lsif-indexer.md:83:22: "occurence" is a misspelling of "occurrence"
about/blogposts/lsif-indexer.md:214:350: "emiting" is a misspelling of "emitting"
about/blogposts/lsif-indexer.md:216:11: "emiting" is a misspelling of "emitting"
about/blogposts/strange-loop-2019-a-robot-poet-goes-for-a-walk-in-the-park.md:46:8: "specfic" is a misspelling of "specific"
about/blogposts/strange-loop-2019-assistive-augmentation-lip-reading-with-ai.md:138:27: "puncutation" is a misspelling of "punctuation"
about/blogposts/strange-loop-2019-beyond-alt-text-trends-in-online-accessibility.md:96:4: "Accessibile" is a misspelling of "Accessible"
about/blogposts/strange-loop-2019-beyond-alt-text-trends-in-online-accessibility.md:104:237: "percieve" is a misspelling of "perceive"
about/blogposts/strange-loop-2019-beyond-alt-text-trends-in-online-accessibility.md:106:117: "occuring" is a misspelling of "occurring"
about/blogposts/strange-loop-2019-beyond-alt-text-trends-in-online-accessibility.md:162:66: "accomodate" is a misspelling of "accommodate"
about/blogposts/strange-loop-2019-beyond-alt-text-trends-in-online-accessibility.md:190:99: "throughtout" is a misspelling of "throughout"
about/blogposts/strange-loop-2019-complexities-of-color-in-computing.md:70:2: "Euclidian" is a misspelling of "Euclidean"
about/blogposts/strange-loop-2019-complexities-of-color-in-computing.md:153:155: "percieve" is a misspelling of "perceive"
about/blogposts/strange-loop-2019-digital-and-social-resilience-through-the-nyc-mesh.md:232:0: "sence" is a misspelling of "sense"
about/blogposts/strange-loop-2019-digital-and-social-resilience-through-the-nyc-mesh.md:278:24: "oging" is a misspelling of "going"
about/blogposts/strange-loop-2019-enhancing-angklung-music-rehearsals-with-modern-tech.md:40:80: "Maylasia" is a misspelling of "Malaysia"
about/blogposts/strange-loop-2019-explainable-ai-the-apex-of-human-and-machine-learning.md:94:28: "transfering" is a misspelling of "transferring"
about/blogposts/strange-loop-2019-federated-learning-private-distributed-ml.md:42:178: "explictly" is a misspelling of "explicitly"
about/blogposts/strange-loop-2019-from-video-games-to-fashion-a-machine-learning-journey.md:34:533: "atomspheric" is a misspelling of "atmospheric"
about/blogposts/strange-loop-2019-how-not-to-read-the-room-creating-wearables-with-ml.md:90:172: "becasue" is a misspelling of "because"
about/blogposts/strange-loop-2019-how-computers-misunderstand-the-world.md:92:0: "Unconcious" is a misspelling of "Unconscious"
about/blogposts/strange-loop-2019-how-computers-misunderstand-the-world.md:98:463: "OPRESSION" is a misspelling of "OPPRESSION"
about/blogposts/strange-loop-2019-how-to-fix-ai-solutions-to-ml-bias-and-why-they-don-t-matter.md:47:637: "Philadlephia" is a misspelling of "Philadelphia"
about/blogposts/strange-loop-2019-recreating-forgotten-programming-languages-for-art.md:162:6: "graphcis" is a misspelling of "graphics"
about/blogposts/strange-loop-2019-uptime-15364-days-the-computers-of-voyager.md:89:77: "reciever" is a misspelling of "receiver"
about/company/remote/index.md:24:125: "anwsers" is a misspelling of "answers"
about/handbook/design/design-execution.md:9:146: "accomodate" is a misspelling of "accommodate"
about/handbook/engineering/continuous_releasability.md:3:64: "continous" is a misspelling of "continuous"
about/handbook/engineering/code_reviews.md:66:175: "Futher" is a misspelling of "Further"
about/handbook/engineering/github-notifications/index.md:3:224: "overwhemled" is a misspelling of "overwhelmed"
about/handbook/engineering/github-notifications/index.md:28:142: "overwhelemed" is a misspelling of "overwhelmed"
about/handbook/engineering/product_documentation.md:9:106: "enginer" is a misspelling of "engineer"
about/handbook/engineering/roles.md:3:66: "responsibilites" is a misspelling of "responsibilities"
about/handbook/engineering/roles.md:7:0: "Sofware" is a misspelling of "Software"
about/handbook/marketing/index.md:44:212: "Technnology" is a misspelling of "Technology"
about/handbook/people-ops/from-graphbook/glossary.md:42:98: "occured" is a misspelling of "occurred"
about/handbook/sales/index.md:142:23: "responisble" is a misspelling of "responsible"
```

**PS:** I use [**client9/misspell**](https://github.com/client9/misspell) to scan typos :heart: 

Making the world a better place :innocent: