### PR TITLE
handbook: update the code intel team index

### DIFF
--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -20,3 +20,18 @@ The Code Intelligence team builds tools and services that provide contextual inf
 
 Most of the Code Intelligence tools and infrastructure are implemented in Go and TypeScript. Precise code indexers are written in a variety of languages, as needed.  We use Postgres and SQLite for data storage.
 
+## Team documentation & planning
+
+- On GitHub, mention or assign issues to @sourcegraph/code-intel team.
+- On Slack, use the [#code-intel](https://app.slack.com/client/T02FSM7DL/CHXHX7XAS) channel.
+- On Google Drive, we use the [Code Intel](https://drive.google.com/drive/folders/1vKcW5EM4RBIuF8ZFvPM0G1FRwl_03RXK) directory.
+
+The Code Intelligence team holds a weekly sync meeting.  We use a Google doc for [agenda and meeting notes](https://docs.google.com/document/d/1R4gXavKwajVRplHSy1ECn_ZHMoQZIwiGKqWWb2SdbUE/edit). If you would like to add a topic to the agenda, please ping [the #code-intel channel in Slack]( https://app.slack.com/client/T02FSM7DL/CHXHX7XAS) to ensure we are prepared to address it.
+
+Prior to the weekly sync meeting, each team member should:
+
+1. Add any agenda items that should be discussed.
+2. Review any existing agenda items and be prepared to discuss them.
+3. Update the current release tracking issue with a summary of progress for the previous week and plans for the next week.
+
+We track most of our work using [issues on the Sourcegraph main repository](https://github.com/sourcegraph/sourcegraph/issues). If you have an issue that wants our attention, mention [the @sourcegraph/code-intel team](https://github.com/orgs/sourcegraph/teams/code-intel) or tag your issue with the [`team/code-intelligence` label](https://github.com/sourcegraph/sourcegraph/labels/team%2Fcode-intelligence).

--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -18,4 +18,5 @@ The Code Intelligence team builds tools and services that provide contextual inf
 
 ## Tech stack
 
-Go, TypeScript, Postgres and many other languages for supporting LSIF and LSP.
+Most of the Code Intelligence tools and infrastructure are implemented in Go and TypeScript. Precise code indexers are written in a variety of languages, as needed.  We use Postgres and SQLite for data storage.
+

--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -24,7 +24,7 @@ Most of the Code Intelligence tools and infrastructure are implemented in Go and
 
 Here are some key ways to contact us:
 
-- On GitHub, mention or assign issues to @sourcegraph/code-intel team.
+- On GitHub, mention or assign issues to the [@sourcegraph/code-intel](https://github.com/orgs/sourcegraph/teams/code-intel) team.
 - On Slack, use the [#code-intel](https://app.slack.com/client/T02FSM7DL/CHXHX7XAS) channel.
 - On Google Drive, we use the [Code Intel](https://drive.google.com/drive/folders/1vKcW5EM4RBIuF8ZFvPM0G1FRwl_03RXK) directory.
 

--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -2,9 +2,19 @@
 
 [Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.dimwsc9ccmwq)
 
-## Vision statement
+## Vision
 
 Code intelligence is as good or better than an IDE in the browser for all code hosts and all languages, including cross-repository definitions and references.
+
+## Direction
+
+The Code Intelligence team builds tools and services that provide contextual information around code, taking into account its lexical, syntactic, and semantic structure. This includes:
+
+- An API to provide fast, comprehensive, and accurate answers to important code navigation queries such as Go to Definition and Find References
+
+- A powerful and flexible language-agnostic model of dependency relationships across projects, repositories, and languages
+
+- Robust, extensible, and scalable infrastructure to index code across all languages, keep those indexes up-to-date, and efficiently resolve code intelligence queries against all indexed code.
 
 ## Tech stack
 

--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -22,6 +22,8 @@ Most of the Code Intelligence tools and infrastructure are implemented in Go and
 
 ## Team documentation & planning
 
+Here are some key ways to contact us:
+
 - On GitHub, mention or assign issues to @sourcegraph/code-intel team.
 - On Slack, use the [#code-intel](https://app.slack.com/client/T02FSM7DL/CHXHX7XAS) channel.
 - On Google Drive, we use the [Code Intel](https://drive.google.com/drive/folders/1vKcW5EM4RBIuF8ZFvPM0G1FRwl_03RXK) directory.


### PR DESCRIPTION
- Add a "Direction" section to the code intel index, to give a higher-level view of the team's purpose.
- Add a contacts & planning section, to give pointers to team documentation.
- Clarify the code intel tech stack (chiefly: Removes mention of LSP).

Please pay particular attention to the wording of the "Direction" section. I believe this is consistent with our previous discussions, but since we haven't previously written these points in the Handbook, I'd like to be sure we are in agreement.