### PR TITLE
Add "conciously invest in tooling" as Core Services principle

### DIFF
--- a/handbook/engineering/core-services/index.md
+++ b/handbook/engineering/core-services/index.md
@@ -13,6 +13,10 @@ Go, Postgres, Redis, Docker, Kubernetes.
 - [Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.fv5i7qi85bru)
 - [Tracking Issues](https://github.com/sourcegraph/sourcegraph/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Ateam%2Fcore-services+label%3Atracking)
 
+## Principles
+
+* We consciously invest time in our codebase, tooling, and testing processes.
+
 ## Processes
 
 ### Weekly check-ins


### PR DESCRIPTION
This is a follow-up to our [Core Services retrospective last week](https://docs.google.com/document/d/1Bk0c6vf5g5yqjk-xoBIw3xVb_Rs44YX4aiZwOLkS5X0/edit?ts=5e99ea72).

Since we didn't have a place for this already, I've added the
"Principles" header.

The problem is that this is now, of course, a non-exhaustive list and
might make the wrong impression.

What do you think?