### PR TITLE
release publishing: cherry pick version substitution into release branch

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -65,5 +65,6 @@ In [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph):
   ```
   yarn run release release:publish $MAJOR.$MINOR.$PATCH
   ```
+- [ ] Cherry pick the release-publishing PR from sourcegraph/sourcegraph@master into the release branch.  
 - [ ] Create a new section for the patch version in the changelog. Verify that all changes that have been cherry picked onto the release branch have been moved to this section of the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/master/CHANGELOG.md) on `master`.
 - [ ] Post a reply in the #dev-announce thread to say that the release is complete.

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -110,6 +110,7 @@ Cut a new release candidate daily if necessary:
 ## $RELEASE_DATE by 10am: Release
 
 - [ ] Merge the release-publishing PRs created previously.
+- [ ] Cherry pick the release-publishing PR from sourcegraph/sourcegraph@master into the release branch.
 - [ ] Merge the blog post ([example](https://github.com/sourcegraph/about/pull/83)).
 
 ### Post-release


### PR DESCRIPTION
we have docs @ 3.15 or docs @3.14 etc

they also need the same version substitution, otherwise they have the versions from master when the branch was cut (so the previous version)

related to https://github.com/sourcegraph/sourcegraph/pull/10065