### PR TITLE
Redirects for the ABCs book

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -74,3 +74,5 @@
 /product/code-search-navigation /product/code-discovery 301!
 /product/automation /product/code-change-management 301!
 /product/server /product 301!
+/abc /resources/abcs-book
+/resources/our-abcs-childrens-book-download https://cdn2.hubspot.net/hubfs/2762526/CTA%20assets/sourcegraph-abc-book.pdf


### PR DESCRIPTION
All links on the site to download the book point to `/resources/our-abcs-childrens-book-download` which then redirects to the actual PDF download link.

This is so we can alter the download link if needed.