### PR TITLE
Press releases no longer in blog, list auto-generated on news page

### DIFF
--- a/blogposts/press-release-our-abcs-childrens-book.md
+++ b/blogposts/press-release-our-abcs-childrens-book.md
@@ -1,9 +1,9 @@
 ---
-title: "Press release: Sourcegraph Releases Free Digital Children's Book Titled 'Our ABCs: Always Be Coding'"
+title: "Sourcegraph Releases Free Digital Children's Book Titled 'Our ABCs: Always Be Coding'"
 author: Sourcegraph
 publishDate: 2020-04-23T00:00
-tags: ["blog", "press release"]
-slug: press-release-our-abcs-childrens-book
+tags: [press-release]
+slug: our-abcs-childrens-book
 heroImage: https://info.sourcegraph.com/hubfs/CTA%20images/abc-book-cover.png
 published: true
 ---

--- a/blogposts/press-release-sourcegraph-announces-new-gitlab-native-integration.md
+++ b/blogposts/press-release-sourcegraph-announces-new-gitlab-native-integration.md
@@ -1,9 +1,9 @@
 ---
-title: 'Press release: Sourcegraph Announces New GitLab Native Integration, Universal Code Search Engine, and Amazing Company Momentum'
+title: 'Sourcegraph Announces New GitLab Native Integration, Universal Code Search Engine, and Amazing Company Momentum'
 author: Sourcegraph
 publishDate: 2019-11-12T10:00-07:00
-tags: [blog]
-slug: press-release-sourcegraph-announces-new-gitlab-native-integration
+tags: [press-release]
+slug: sourcegraph-announces-new-gitlab-native-integration
 heroImage: https://about.sourcegraph.com/sourcegraph-mark.png
 published: true
 ---

--- a/blogposts/press-release-sourcegraph-secures-series-b.md
+++ b/blogposts/press-release-sourcegraph-secures-series-b.md
@@ -1,9 +1,9 @@
 ---
-title: 'Press release: Sourcegraph Secures $23 Million Series B Round for Universal Code Search'
+title: 'Sourcegraph Secures $23 Million Series B Round for Universal Code Search'
 author: Sourcegraph
 publishDate: 2020-03-03T00:00
-tags: ['blog','press release']
-slug: press-release-sourcegraph-secures-series-b
+tags: [press-release]
+slug: sourcegraph-secures-series-b
 heroImage: https://about.sourcegraph.com/sourcegraph-mark.png
 published: true
 ---

--- a/website/gatsby-node.js
+++ b/website/gatsby-node.js
@@ -42,7 +42,7 @@ exports.createPages = ({ actions, graphql }) => {
             const slug = node.fields.slug
             const absPath = node.fileAbsolutePath
             if (
-              (absPath.includes('/blogposts') || absPath.includes('/projects')) &&
+              (absPath.includes('/blogposts')) &&
               node.frontmatter.published === true
             ) {
               if (node.frontmatter.tags && node.frontmatter.tags.includes('blog')) {
@@ -53,7 +53,16 @@ exports.createPages = ({ actions, graphql }) => {
                     fileSlug: slug,
                   },
                 })
-              } else if (
+              } else if (node.frontmatter.tags && node.frontmatter.tags.includes('press-release')) {
+                createPage({
+                  path: `/press-releases/${slug}`,
+                  component: PostTemplate,
+                  context: {
+                    fileSlug: slug,
+                  },
+                })
+              }
+              else if (
                 node.frontmatter.tags &&
                 (node.frontmatter.tags.includes('gophercon') || node.frontmatter.tags.includes('dotGo'))
               ) {

--- a/website/src/components/NewsList.tsx
+++ b/website/src/components/NewsList.tsx
@@ -5,7 +5,7 @@ class News extends React.Component {
     public render(): JSX.Element {
         return (
             <div>
-                <h5>2020</h5>
+                <h3>2020</h3>
                 <div className="container-fluid">
                     {NewsData.y2020.map((newsDetail, index) => (
                         <div className="row mb-4 news__item">
@@ -25,7 +25,7 @@ class News extends React.Component {
                         </div>
                     ))}
                 </div>
-                <h5>2019</h5>
+                <h3>2019</h3>
                 <div className="container-fluid">
                     {NewsData.y2019.map((newsDetail, index) => (
                         <div className="row mb-4 news__item">

--- a/website/src/pages/blog.tsx
+++ b/website/src/pages/blog.tsx
@@ -12,6 +12,7 @@ export enum BLOGS {
     GraphQLSummit = 'graphql',
     StrangeLoop = 'strange-loop',
     Blog = 'blog',
+    PressReleases = 'press-releases'
 }
 
 export default class BlogList extends React.Component<any, any> {

--- a/website/src/pages/news.tsx
+++ b/website/src/pages/news.tsx
@@ -1,9 +1,15 @@
 import * as React from 'react'
-import Helmet from 'react-helmet'
-import { ContentSection } from '../components/content/ContentSection'
+import { Link } from 'gatsby'
+import { ContentPage } from '../components/content/ContentPage'
 import Layout from '../components/Layout'
 import News from '../components/NewsList'
 
+interface PressRelease {
+    title: string
+    image: string
+    publishDate: string
+    url: string
+}
 // tslint:disable-next-line: no-any
 export default class NewsPage extends React.Component<any, any> {
     // tslint:disable-next-line: no-any
@@ -14,97 +20,111 @@ export default class NewsPage extends React.Component<any, any> {
         }
     }
 
-    public componentDidMount(): void {
-        if (document) {
-            document.getElementsByTagName('body')[0].setAttribute('style', 'background-image:none')
-        }
-    }
-
     public render(): JSX.Element | null {
-        const desc = 'The latest Sourcegraph news and press releases.'
+        const pressReleases: PressRelease[] = this.props.data.allMarkdownRemark.edges
+            .filter((post: any) => post.node.frontmatter.published === true)
+            .map((item: any): PressRelease => {
+                return {
+                    title: item.node.frontmatter.title,
+                    image: item.node.frontmatter.heroImage,
+                    publishDate: item.node.frontmatter.publishDate,
+                    url: `/press-releases/${item.node.frontmatter.slug}`,
+                }
+            })
         return (
             <Layout location={this.props.location}>
+                <ContentPage
+                    title="Sourcegraph in the news"
+                    description="The latest Sourcegraph news and press releases"
                 >
-                <Helmet>
-                    <title>Sourcegraph - News</title>
-                    <meta name="twitter:title" content="Sourcegraph in the news" />
-                    <meta property="og:title" content="Sourcegraph in the news" />
-                    <meta name="twitter:site" content="@srcgraph" />
-                    <meta name="twitter:image" content="https://about.sourcegraph.com/favicon.png" />
-                    <meta name="twitter:card" content="summary" />
-                    <meta name="twitter:description" content={desc} />
-                    <meta property="og:description" content={desc} />
-                    <meta name="description" content={desc} />
-                </Helmet>
-                <div className="news bg-white text-dark">
-                    <section>
-                        <div>
-                            <ContentSection color="purple" className="hero-section text-center py-5">
-                                <h1>Sourcegraph in the news</h1>
-                                <p className="news__head-description">The latest news and press releases.</p>
-                            </ContentSection>
-                        </div>
-                    </section>
-                    <section>
-                        <div className="container">
-                            <div className="row">
-                                <div className="col mt-5 mb-5 ">
-                                    <h3>Press releases</h3>
-                                    <ul>
-                                        <li>
-                                            <a href="/blog/press-release-our-abcs-childrens-book/?ref=news">
-                                                Sourcegraph Releases Free Digital Children's Book Titled 'Our ABCs:
-                                                Always Be Coding'
-                                            </a>
-                                            <span className="news__date">April 23, 2020</span>
-                                        </li>
-                                        <li>
-                                            <a href="/blog/press-release-sourcegraph-secures-series-b/?ref=news">
-                                                Sourcegraph Secures $23 Million Series B Round for Universal Code Search
-                                            </a>
-                                            <span className="news__date">March 3, 2020</span>
-                                        </li>
-                                        <li>
-                                            <a href="/blog/press-release-sourcegraph-announces-new-gitlab-native-integration/?ref=news">
-                                                New GitLab Native Integration, Universal Code Search Engine, and Amazing
-                                                Company Momentum
-                                            </a>
-                                            <span className="news__date">November 12, 2019</span>
-                                        </li>
-                                    </ul>
+                    <div className="news bg-white text-dark">
+                        <section>
+                            <div className="container">
+                                <div className="row justify-content-start">
+                                    <div className="col-sm-10 col-lg-10">
+                                        <h2 className="py-4">Press releases</h2>
+                                        {pressReleases.map(({ title, image, publishDate, url }, i: number) => (
+                                            <div className="row mb-4 news__item">
+                                                <div className="col-sm-3 col-lg-2 text-center">
+                                                    <img
+                                                        className="news__image"
+                                                        src={image}
+                                                        style={{ maxWidth: '100px' }}
+                                                    />
+                                                </div>
+                                                <div className="col-sm-9 col-lg-10 align-self-center">
+                                                    <p>
+                                                        <Link to={url} rel="nofollow" key={i} className="d-block">
+                                                            {title}
+                                                        </Link>
+                                                        <span className="news__date ml-0">{publishDate}</span>
+                                                    </p>
+                                                </div>
+                                            </div>
+                                        ))}
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                        <div className="container">
-                            <div className="row justify-content-start">
-                                <div className="col-sm-10 col-lg-10">
-                                    <h3>News</h3>
-                                    <News></News>
+                            <div className="container">
+                                <div className="row justify-content-start">
+                                    <div className="col-sm-10 col-lg-10">
+                                        <h2>News</h2>
+                                        <News></News>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
 
-                        <div className="container">
-                            <div className="row justify-content-md-center">
-                                <div className="col mt-5">
-                                    <h3>Media contact</h3>
-                                    <p>
-                                        Tanya Carlsson
-                                        <br />
-                                        Offleash PR for Sourcegraph
-                                        <br />
-                                        <a href="mailto:tanya@offleashpr.com">tanya@offleashpr.com</a>
-                                        <br />
-                                        <a href="tel:+17075296139">+1 707-529-6139</a>
-                                        <br />
-                                        &nbsp;
-                                    </p>
+                            <div className="container">
+                                <div className="row justify-content-md-center">
+                                    <div className="col mt-5">
+                                        <h3>Media contact</h3>
+                                        <p>
+                                            Tanya Carlsson
+                                            <br />
+                                            Offleash PR for Sourcegraph
+                                            <br />
+                                            <a href="mailto:tanya@offleashpr.com">tanya@offleashpr.com</a>
+                                            <br />
+                                            <a href="tel:+17075296139">+1 707-529-6139</a>
+                                            <br />
+                                            &nbsp;
+                                        </p>
+                                    </div>
                                 </div>
                             </div>
-                        </div>
-                    </section>
-                </div>
+                        </section>
+                    </div>
+                </ContentPage>
             </Layout>
         )
     }
 }
+
+export const pageQuery = graphql`
+    query PressReleases {
+        allMarkdownRemark(
+            filter: { frontmatter: { tags: { in: "press-release" } } }
+            sort: { fields: [frontmatter___publishDate], order: DESC }
+        ) {
+            edges {
+                node {
+                    frontmatter {
+                        title
+                        heroImage
+                        author
+                        tags
+                        publishDate(formatString: "MMMM D, YYYY")
+                        slug
+                        description
+                        published
+                    }
+                    html
+                    excerpt(pruneLength: 300)
+                    fields {
+                        slug
+                    }
+                }
+            }
+        }
+    }
+`

--- a/website/src/templates/blogPostTemplate.tsx
+++ b/website/src/templates/blogPostTemplate.tsx
@@ -66,6 +66,8 @@ export default class BlogPostTemplate extends React.Component<any, any> {
                 break
             case BLOGS.StrangeLoop:
                 slug = `/${BLOGS.StrangeLoop}/${slug}`
+            case BLOGS.PressReleases:
+                slug = `/${BLOGS.PressReleases}/${slug}`
             default:
                 slug = `/${BLOGS.Blog}/${slug}`
         }

--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -76,3 +76,6 @@
 /product/server /product 301!
 /abc /resources/abcs-book
 /resources/our-abcs-childrens-book-download https://cdn2.hubspot.net/hubfs/2762526/CTA%20assets/sourcegraph-abc-book.pdf
+/blog/press-release-our-abcs-childrens-book /press-releases/our-abcs-childrens-book 301!
+/blog/press-release-sourcegraph-secures-series-b /press-releases/sourcegraph-secures-series-b 301!
+/blog/press-release-sourcegraph-announces-new-gitlab-native-integration /press-releases/sourcegraph-announces-new-gitlab-native-integration 301!


### PR DESCRIPTION
This PR improves how we handle press releases:

- List of links to press releases on the news page is now auto-generated
- Press releases do not show up in the list of blog posts because they now have their own tag (`press-release`)


News page: https://deploy-preview-821--sourcegraph.netlify.app/news/

I've also added redirects for the old press release blog post links:

- https://deploy-preview-821--sourcegraph.netlify.app/blog/press-release-our-abcs-childrens-book
- https://deploy-preview-821--sourcegraph.netlify.app/blog/press-release-sourcegraph-secures-series-b
- https://deploy-preview-821--sourcegraph.netlify.app/blog/press-release-sourcegraph-announces-new-gitlab-native-integration