### PR TITLE
Drive more traffic to signup

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -109,7 +109,7 @@ export default class Header extends React.Component<HeaderProps, any> {
                                         </li>
                                         <li className="header__nav-item nav-item" role="presentation">
                                             <a
-                                                className="header__nav-link nav-link btn btn-primary mb-2"
+                                                className="header__nav-link nav-link btn btn-primary"
                                                 href="https://sourcegraph.com/sign-up"
                                                 title="For public code only on Sourcegraph.com"
                                             >

--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -109,7 +109,7 @@ export default class Header extends React.Component<HeaderProps, any> {
                                         </li>
                                         <li className="header__nav-item nav-item" role="presentation">
                                             <a
-                                                className="header__nav-link nav-link"
+                                                className="header__nav-link nav-link btn btn-primary mb-2"
                                                 href="https://sourcegraph.com/sign-up"
                                                 title="For public code only on Sourcegraph.com"
                                             >


### PR DESCRIPTION
This change is the result of testing a blue signup button in an A/B test which ran for one month.  Even though we did not have a significantly large sample size, I'm calling the Blue button winner of the AB test since it drove 75% more clicks to signup.  Note the blue-button was showing up only on the home page in this test.

![Screen Shot 2020-04-27 at 3 48 49 PM](https://user-images.githubusercontent.com/2164916/80428659-3ba3f580-889f-11ea-9918-407a8421659e.png)
