### PR TITLE
Update security policy

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,7 +18,6 @@
 /blogposts @sourcegraph/marketing
 /website @sourcegraph/marketing
 /docs @sourcegraph/marketing
-/docs/security.md @sourcegraph/security
 
 /handbook/product @christinaforney
 /handbook/design @imtommyroberts 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -18,6 +18,7 @@
 /blogposts @sourcegraph/marketing
 /website @sourcegraph/marketing
 /docs @sourcegraph/marketing
+/docs/security.md @sourcegraph/security
 
 /handbook/product @christinaforney
 /handbook/design @imtommyroberts 
@@ -27,5 +28,6 @@
 /handbook/engineering/code-intelligence @sourcegraph/code-intel
 /handbook/engineering/core-services @sourcegraph/core-services
 /handbook/engineering/distribution @sourcegraph/distribution
+/handbook/engineering/security @sourcegraph/security
 /handbook/engineering/web @sourcegraph/web
 /handbook/marketing @sourcegraph/marketing

--- a/docs/security.md
+++ b/docs/security.md
@@ -87,16 +87,14 @@ calendar reminders, or (subscribe to the Sourcegraph newsletter)[https://about.s
 
 If you think that you have found a security issue, please email us at <a href="mailto:security@sourcegraph.com">security@sourcegraph.com</a>. We will reply to reports within 1 business day to acknowledge that we received them and will strive to send you regular updates on our progress until the issue is resolved. You may request an update by replying to the existing email thread. We will read, but may not respond to low quality or spammy reports (e.g. those produced by automated tooling).
 
-We provide monetary rewards, up to $10,000 USD, for security vulnerability reports. The actual reward amount is determined based on the number of customers<sup>*</sup> impacted, the difficulty of exploiting the vulnerability, and the severity of the consequences (e.g. service disruption, data leakage, reputational damage to Sourcegraph) of a successful exploit.
-
-\* A **customer** is defined as a paid user of Sourcegraph. Please note that there are currently no paying customers on sourcegraph.com because sourcegraph.com only hosts public code and is free to use. As such, an issue that impacts all **users** on sourcegraph.com doesn't necessarily impact any **customers**.
+We provide monetary rewards, up to $10,000 USD, for security vulnerability reports. The actual reward amount is determined based on the number of customers impacted, the difficulty of exploiting the vulnerability, and the severity of the consequences (e.g. service disruption, data leakage, reputational damage to Sourcegraph) of a successful exploit.
 
 We will send payment to a valid PayPal account after the issue is confirmed fixed or 90 days from the original report, whichever happens first. We will ask you for the name and country associated with your PayPal account.
 
 We may choose to not issue a reward if any of the following apply:
 
 1. You engage in disruptive behavior on sourcegraph.com itself (e.g. spamming our system with requests, fake accounts, denial of service). Sourcegraph is [open source software](https://github.com/sourcegraph/sourcegraph), so you can [install a copy yourself](https://docs.sourcegraph.com/#quickstart-guide) and test against that instead.
-1. You publicly disclose a vulnerability before we have fixed it.
+1. You publicly disclose a vulnerability before we confirm that it is OK to do so. We want to give our customers time to upgrade to a patched version before public disclosure.
 1. You spam us with duplicate and/or low quality vulnerability reports (e.g. copy/pasting generic issues from automatic scanning tools).
 1. You are a current or former teammate at Sourcegraph (e.g. employee, contractor, intern).
 1. You are friends or family with a current or former teammate at Sourcegraph.

--- a/docs/security.md
+++ b/docs/security.md
@@ -10,7 +10,7 @@ We don't stop at keeping your code safe. When your team's developers use Sourceg
 
 If you have specific questions or concerns, contact us at <a href="mailto:security@sourcegraph.com">security@sourcegraph.com</a>.
 
-If you think you have discovered a security vulnerability in our product, please follow our instructions on [how to report a security vulnerability](#how-to-report-a-security-vulnerability).
+If you think you have discovered a security vulnerability in our product, please follow our instructions on [how to report a security vulnerability](https://about.sourcegraph.com/handbook/engineering/security#how-to-report-a-security-vulnerability).
 
 ## Sourcegraph on-premise
 
@@ -82,19 +82,3 @@ Customers are encouraged to update to the latest release of Sourcegraph every mo
 ensure that their Sourcegraph instance has the latest security-related updates. New releases are
 (published on the 20th of every month)[https://docs.sourcegraph.com/admin/updates], so customers that wish to stay up-to-date can set monthly
 calendar reminders, or (subscribe to the Sourcegraph newsletter)[https://about.sourcegraph.com/].
-
-## How to report a security vulnerability
-
-If you think that you have found a security issue, please email us at <a href="mailto:security@sourcegraph.com">security@sourcegraph.com</a>. We will reply to reports within 1 business day to acknowledge that we received them and will strive to send you regular updates on our progress until the issue is resolved. You may request an update by replying to the existing email thread. We will read, but may not respond to low quality or spammy reports (e.g. those produced by automated tooling).
-
-We provide monetary rewards, up to $10,000 USD, for security vulnerability reports. The actual reward amount is determined based on the number of customers impacted, the difficulty of exploiting the vulnerability, and the severity of the consequences (e.g. service disruption, data leakage, reputational damage to Sourcegraph) of a successful exploit.
-
-We will send payment to a valid PayPal account after the issue is confirmed fixed or 90 days from the original report, whichever happens first. We will ask you for the name and country associated with your PayPal account.
-
-We may choose to not issue a reward if any of the following apply:
-
-1. You engage in disruptive behavior on sourcegraph.com itself (e.g. spamming our system with requests, fake accounts, denial of service). Sourcegraph is [open source software](https://github.com/sourcegraph/sourcegraph), so you can [install a copy yourself](https://docs.sourcegraph.com/#quickstart-guide) and test against that instead.
-1. You publicly disclose a vulnerability before we confirm that it is OK to do so. We want to give our customers time to upgrade to a patched version before public disclosure.
-1. You spam us with duplicate and/or low quality vulnerability reports (e.g. copy/pasting generic issues from automatic scanning tools).
-1. You are a current or former teammate at Sourcegraph (e.g. employee, contractor, intern).
-1. You are friends or family with a current or former teammate at Sourcegraph.

--- a/handbook/engineering/security/index.md
+++ b/handbook/engineering/security/index.md
@@ -10,13 +10,27 @@ Make Sourcegraph secure by design.
 - #security channel Slack.
 - [@sourcegraph/security](https://github.com/orgs/sourcegraph/teams/security) on GitHub.
 
-## How to report a security vulnerability to us
+## How to report a security vulnerability
 
-[Follow these instructions](https://about.sourcegraph.com/security#how-to-report-a-security-vulnerability).
+If you think that you have found a security issue, please email us at <a href="mailto:security@sourcegraph.com">security@sourcegraph.com</a>. We will reply to reports within 1 business day to acknowledge that we received them and will strive to send you regular updates on our progress until the issue is resolved. You may request an update by replying to the existing email thread. We will read, but may not respond to low quality or spammy reports (e.g. those produced by automated tooling).
+
+### Bounties
+
+We provide monetary rewards, up to $10,000 USD, for security vulnerability reports. The actual reward amount is determined based on the number of customers impacted, the difficulty of exploiting the vulnerability, and the severity of the consequences (e.g. service disruption, data leakage, reputational damage to Sourcegraph) of a successful exploit.
+
+We will send payment to a valid PayPal account after the issue is confirmed fixed or 90 days from the original report, whichever happens first. We will ask you for the name and country associated with your PayPal account.
+
+We may choose to not issue a reward if any of the following apply:
+
+1. You engage in disruptive behavior on sourcegraph.com itself (e.g. spamming our system with requests, fake accounts, denial of service). Sourcegraph is [open source software](https://github.com/sourcegraph/sourcegraph), so you can [install a copy yourself](https://docs.sourcegraph.com/#quickstart-guide) and test against that instead.
+1. You publicly disclose a vulnerability before we confirm that it is OK to do so. We want to give our customers time to upgrade to a patched version before public disclosure.
+1. You spam us with duplicate and/or low quality vulnerability reports (e.g. copy/pasting generic issues from automatic scanning tools).
+1. You are a current or former teammate at Sourcegraph (e.g. employee, contractor, intern).
+1. You are friends or family with a current or former teammate at Sourcegraph.
 
 ## How we respond to security vulnerability reports
 
-When we receive [a report of a security vulnerability](https://about.sourcegraph.com/security#how-to-report-a-security-vulnerability), a member of our security team determines if a reported vulnerability should be investigated by an engineer.
+When we receive [a report of a security vulnerability](#how-to-report-a-security-vulnerability), a member of our security team determines if a reported vulnerability should be investigated by an engineer.
 
 - If so, a member of our security team will [file a vulnerability report in sourcegraph/security-issues](https://github.com/sourcegraph/security-issues/issues/new/choose) and follow the checklist in the issue template.
 


### PR DESCRIPTION
Remove distinction for sourcegraph.com since we are prioritizing working on it this year.

Clarify that we wait until our customers have a chance to upgrade.

Move "how to report a security vulnerability" content to handbook since that is an engineering process. This separates the marketing content of how our product deals with security and how we respond to security incidents. The former already links to the latter.