### PR TITLE
Document Distribution recurring processes in handbook

### DIFF
--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -66,7 +66,7 @@
 ### Distribution
 
 1. **Resolve issues for major customers**
-   1. Ensure that no technical issue blocks a deal for any [tier 1 or tier 2 customer](https://sourcegraph.looker.com/dashboards/132). => 67%: We have not yet lost a deal due to a technical blocker that fell under the purview of Distribution.
+   1. Ensure that no technical issue blocks a deal for any [tier 1 or tier 2 customer](https://sourcegraph.looker.com/dashboards/132). => 100%: We have not yet lost a deal due to a technical blocker that fell under the purview of Distribution.
 1. **Improve developer productivity**
    1. Automate away release captain role and adopt continuous releases (no human in loop required by default). => 20%: We have reduced the end-of-cycle release time from 5 days to 3 days. However, the release captain role remains necessary and we have not adopted continuous releases.
 1. **Improve installation and site admin onboarding process**

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -1,58 +1,26 @@
 # Distribution team
 
-[Roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.mi8zg2ql2uc6)
+## Mission statement
 
-## Vision Statement
+Make Sourcegraph accessible to every developer and development team.
 
-Make Sourcegraph accessible to every developer and development team. Identify and satisfy long-term and short-term needs of critical customers. ([Google Doc with more info](https://docs.google.com/document/d/1-RQTq1HnhvxiLWrHUssmSW3aSUqlIOfTtTg1wvKGtzc/edit?ts=5da61097#heading=h.frjbo9inynne))
+## Team API
 
-## Contact
-
-- #distributioneers channel or @distribution in Slack.
-- [team/distribution](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/distribution) label in GitHub.
+- Slack: #distributioneers channel or @distribution
+- File issues: [team/distribution](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/distribution) label
+- What we're currently working on: [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+label%3Ateam%2Fdistribution+label%3Atracking+distribution)
 
 ## Tech stack
 
-Go, Docker, Kubernetes.
+Go, Docker, Kubernetes
 
-## Code host testing instances
+## Details
 
-We maintain a collection of code hosts for testing purposes.
-
-- GitHub Enterprise: https://ghe.sgdev.org ([credentials on 1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/bw4nttlfqve3rc6xqzbqq7l7pm))
-  - [Notes about ghe.sgdev.org](github_enterprise_testing_instance.md)
-- Bitbucket Server: https://bitbucket.sgdev.org ([credentials on 1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/6owvzrgxfva3hn5jxe2253qbwi))
-
-## Getting access to our Kubernetes clusters
-
-See [kubernetes/README.md in the infrastructure repository](https://github.com/sourcegraph/infrastructure/blob/master/kubernetes/README.md).
-
-## Customer environment replicas
-
-We maintain separate AWS accounts with Sourcegraph instances and other infrastructure that mimic various customers' environments for testing purposes. See "[Customer environment replicas and managed instances](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/003/ctqvj7zcmdiujmfh2mxzffdlym)" on 1Password for the list.
-
-### Accessing customer environment replicas
-
-To access these AWS accounts:
-
-1. Sign into AWS using your account (which must be under Sourcegraph's main AWS account).
-1. Visit https://signin.aws.amazon.com/switchrole.
-1. Enter the details from the instance below that you wish to access.
-
-Now you can switch between any added roles and your Sourcegraph AWS account using the menu in the top right of AWS.
-
-### Creating a new customer environment replica
-
-1. Visit our [organization accounts on AWS](https://console.aws.amazon.com/organizations/home?#/accounts).
-1. Create an account that will act as the access role shared by everyone on the team.
-   - Name: `<NAME><TYPE>SharedAccessRole`, where `<NAME>` is the customer name and `<TYPE>` is `Replica` or `Managed`. (Examples: `AcmeCorpReplicaSharedAccessRole` or `AcmeCorpManagedSharedAccessRole`.)
-   - Email: use any unused email address. (Example: `alice+acme-corp-replica-shared@sourcegraph.com`.)
-1. Move the account under the organization that you wish to allow this user to access https://console.aws.amazon.com/organizations/home?#/browse/ou-48vq-waaj46mo
-
-## Misc
-
-- [How to set up a separate website maintained by Sourcegraph](separate_website.md)
-- [How to replay a metrics dump from a customer](use_metrics_dump.md)
-- [How to simulate k8s admin security restrictions](k8s_admin_custom_policy.md)
-- [How to test the Gitlab native integration locally](gitlab_native_local.md)
-- [How to make updates to global settings and configuration on sourcegraph.com](update_sourcegraph_website.md)
+* [Recurring processes](./recurring_processes.md)
+* [Internal infrastructure](./internal_infrastructure.md)
+* Tutorials
+  * [How to set up a separate website maintained by Sourcegraph](separate_website.md)
+  * [How to replay a metrics dump from a customer](use_metrics_dump.md)
+  * [How to simulate k8s admin security restrictions](k8s_admin_custom_policy.md)
+  * [How to test the Gitlab native integration locally](gitlab_native_local.md)
+  * [How to make updates to global settings and configuration on sourcegraph.com](update_sourcegraph_website.md)

--- a/handbook/engineering/distribution/internal_infrastructure.md
+++ b/handbook/engineering/distribution/internal_infrastructure.md
@@ -1,0 +1,35 @@
+# Internal infrastructure
+
+## Code host testing instances
+
+We maintain a collection of code hosts for testing purposes.
+
+- GitHub Enterprise: https://ghe.sgdev.org ([credentials on 1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/bw4nttlfqve3rc6xqzbqq7l7pm))
+  - [Notes about ghe.sgdev.org](github_enterprise_testing_instance.md)
+- Bitbucket Server: https://bitbucket.sgdev.org ([credentials on 1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/6owvzrgxfva3hn5jxe2253qbwi))
+
+## Getting access to our Kubernetes clusters
+
+See [kubernetes/README.md in the infrastructure repository](https://github.com/sourcegraph/infrastructure/blob/master/kubernetes/README.md).
+
+## Customer environment replicas
+
+We maintain separate AWS accounts with Sourcegraph instances and other infrastructure that mimic various customers' environments for testing purposes. See "[Customer environment replicas and managed instances](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/003/ctqvj7zcmdiujmfh2mxzffdlym)" on 1Password for the list.
+
+### Accessing customer environment replicas
+
+To access these AWS accounts:
+
+1. Sign into AWS using your account (which must be under Sourcegraph's main AWS account).
+1. Visit https://signin.aws.amazon.com/switchrole.
+1. Enter the details from the instance below that you wish to access.
+
+Now you can switch between any added roles and your Sourcegraph AWS account using the menu in the top right of AWS.
+
+### Creating a new customer environment replica
+
+1. Visit our [organization accounts on AWS](https://console.aws.amazon.com/organizations/home?#/accounts).
+1. Create an account that will act as the access role shared by everyone on the team.
+   - Name: `<NAME><TYPE>SharedAccessRole`, where `<NAME>` is the customer name and `<TYPE>` is `Replica` or `Managed`. (Examples: `AcmeCorpReplicaSharedAccessRole` or `AcmeCorpManagedSharedAccessRole`.)
+   - Email: use any unused email address. (Example: `alice+acme-corp-replica-shared@sourcegraph.com`.)
+1. Move the account under the organization that you wish to allow this user to access https://console.aws.amazon.com/organizations/home?#/browse/ou-48vq-waaj46mo

--- a/handbook/engineering/distribution/recurring_processes.md
+++ b/handbook/engineering/distribution/recurring_processes.md
@@ -101,8 +101,8 @@ feasible set of work with clear lines of ownership.
   role you take in planning should depend on your read of the team at the start of planning. Common
   pitfalls are being too passive or too dictatorial. Too passive means we aren't necessarily working
   on the right things. Too dictatorial means people aren't bought into what we're working on. Avoid
-  both of these. Keep in mind that no one (not even you) has a monopoly on useful knowledge and
-  context, but also that you are the project lead for a reason.
+  both of these. Keep in mind that no one (including you) has a monopoly on useful knowledge and
+  context, but also that the project lead exists for a reason.
 
 ### Retrospective
 

--- a/handbook/engineering/distribution/recurring_processes.md
+++ b/handbook/engineering/distribution/recurring_processes.md
@@ -1,0 +1,146 @@
+# Recurring processes
+
+## Quarterly
+
+### OKRs
+
+Every quarter, we set OKRs to set our focus and align our goals with those of the company.
+
+**Input:** Existing issues and new ideas proposed by any member of the Sourcegraph organization.
+
+**Output:** OKRs and issues filed and assigned to Backlog milestone for each thing that is covered by
+the OKRs.
+
+**Process:** The [project lead](../roles.md#project-lead) drives OKR planning, and follows these steps:
+
+1. Gather context:
+   1. Last quarter's OKRs
+   1. Issue backlog
+   1. Any goals, proposals, or priorities not yet represented in the issue backlog. Write down your own and
+      solicit from teammates.
+1. Filter out any items that are not priorities this quarter, and group the remaining items into
+   themes.
+1. From the themes, define the objectives and key results.
+1. Propose these OKRs to the Distribution team for 1 round of feedback.
+1. Add these to the company OKRs document. Solicit feedback from VP Engineering. Respond to feedback
+   and iterate.
+
+#### Updating the OKRs mid-quarter
+
+This is generally discouraged, but may be necessary if real priorities shift (update objective) or a
+better way to measure emerges (update key results). Updates should be signed off by the VP of
+Engineering.
+
+## Monthly
+
+### Milestone planning
+
+Every (monthly) iteration, we determine what work we plan to do to bring us closer to accomplishing
+our quarterly OKRs.
+
+**Input:** Existing issues and new proposals in line with our OKRs.
+
+**Output:** A tracking issue that lists all engineering items of work we plan to accomplish this
+iteration.
+
+**Process:** The [project lead](../roles.md#project-lead) drives iteration planning, and follows
+these steps:
+
+**Proposal phase (day 1):** The idea here is to identify a superset of issues to be prioritized for
+this milestone, rather than to identify the exact set of issues. The pruning phase (day 2) will
+yield the latter.
+
+1. Triage [Distribution issues with no
+   milestone](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+no%3Amilestone+label%3Ateam%2Fdistribution)
+   into either Backlog or the current milestone.
+1. Ask everyone to do the following in parallel:
+   1. Move their open issues from the previous milestone to the current milestone.
+   1. Write any new goals or proposals in GitHub issues and add these to the current milestone or
+      the Backlog (use best judgment).
+   1. Go through the [Distribution Backlog
+      milestone](https://github.com/issues?q=is%3Aopen+is%3Aissue+archived%3Afalse+milestone%3Abacklog+label%3Ateam%2Fdistribution)
+      and move all issues to the current milestone they think should be considered for
+      prioritization this milestone. If the issue has no owner and there is a probable owner, they
+      should assign that owner now.
+
+**Pruning phase (day 2):** The idea here is to take the list of proposed issues and winnow it down to a
+feasible set of work with clear lines of ownership.
+
+1. Consult the quarterly OKRs and use these to do a preliminary pass through the tracking issue,
+   assigning issues to the Backlog that do not fulfill the OKRs.<br>
+   1. If an issue is important but doesn't satisfy the OKRs, weigh the cost of not prioritizing the
+      issue with the cost of updating the OKRs mid-quarter.
+1. Ask everyone to go through the issues in the current milestone assigned to them. If the amount of
+   work exceeds what they think is feasible, prune the lowest priority issues (using their best
+   judgment) by unassigning themselves, but keeping the issue in the milestone. Use the OKRs as a
+   guidepost for prioritization.
+1. In a meeting (budget an hour), go through the tracking issue as a team.
+   1. Prior to the meeting, the project lead should estimate how long each discussion item should
+      take, so that they can keep the meeting on schedule. The tech lead should also talk to people
+      1-1 to clarify, align, and build consensus prior to the meeting. A good rule of thumb to shoot
+      for is that the team is 70-80% aligned on who's working on what by the time the meeting takes
+      place.
+   1. Revisit the Quarterly OKRs.
+   1. During the meeting, everyone should say 1-2 sentences about each issue assigned to them to
+      convey useful context to the rest of the team. Issues that have no useful context to share can
+      be skipped.
+   1. For each unassigned issue, decide whether it needs to be prioritized/assigned. Otherwise, move
+      it to the Backlog.
+1. If there are any remaining uncertainties following the meeting, the project lead should follow up
+   1-1 to finalize the tracking issue.
+1. If the quarterly OKRs need to be updated, propose an update and obtain approval from the VP of
+   Engineering. It may make sense to block work on issues out of line with the existing OKRs until
+   the approval to update the OKRs is received.
+
+**Note on agency and responsibility:**
+
+* It is *every* Distribution teammate's responsibility to understand the team's priorities and propose
+  the work that aligns with these priorities.
+* It is the project lead's responsibility to ensure (1) the tracking issue is the right set of
+  things to work on and (2) every team member is bought into the outcome of planning. How active a
+  role you take in planning should depend on your read of the team at the start of planning. Common
+  pitfalls are being too passive or too dictatorial. Too passive means we aren't necessarily working
+  on the right things. Too dictatorial means people aren't bought into what we're working on. Avoid
+  both of these. Keep in mind that no one (not even you) has a monopoly on useful knowledge and
+  context, but also that you are the project lead for a reason.
+
+### Retrospective
+
+This can be done in the internal sync at the start of a new iteration.
+
+The [project lead](../roles.md#project-lead) drives the retrospective. Ask everyone to review the
+previous milestone tracking issue, the planned work assigned to you, what got done, what didn't, and
+come prepared to talk about the following:
+
+* What was painful about the milestone? How can we address that pain moving forward?
+* What should we stop doing?
+* What should we start doing?
+
+## Weekly
+
+### Internal sync
+
+The [internal
+sync](https://docs.google.com/document/d/1otP6F8qfm2yNOW1hjTszkkuiYF1MGp31s5ATeA76ij4/edit) serves
+to share updates, sync on immediate plans and priorities, and discuss any topics that need
+discussing with the entire Distribution team.
+
+### External sync
+
+The [external
+sync](https://docs.google.com/document/d/1g9gb_i-Q6QXifISiS1urZ2gcfO2Pz-VHYqurW_94My4/edit)
+communicates progress updates and priority/planning changes between Distribution and the broader
+Engineering/Product organization.
+
+## Daily
+
+Post a daily update to the #distributioneers Slack channel that communicates what took up your time
+in the past day and, if relevant, what you plan to work on next.
+
+Example:
+
+> **Update:**
+>
+> * Helped $CUSTOMER with search scaling questions.
+> * Made some progress on updating the regression test suite.
+> * Opened a PR to update Jaeger tracing behavior (https://github.com/sourcegraph/sourcegraph/pull/9330)


### PR DESCRIPTION
Also reduces the amount of content on the Distribution main page by moving docs about internal infrastructure to a separate page.