### PR TITLE
Improve company meeting

### DIFF
--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -6,30 +6,53 @@
 1. The link to the slides is posted in #general each Thursday before.
 1. We used to call this "team meeting", but now we call it "company meeting" because "team meeting" sounds like it's only for one specific team inside the company.
 
-## Goals
+## Why do we have company meeting?
 
-1. Bring the team together regularly so we feel connected despite being located all around the world.
+Company meeting is an effective way to:
+
+1. Bring the team together regularly so we feel connected despite being [located all around the world](../../company/remote/index.md).
 1. Hold ourselves accountable to our goals.
-1. Convey specific information that helps other team members do their job better.
+1. Share achievements or learning across teams and functions.
 1. Recognize individual team members for special contributions and on anniversaries.
-1. Communicate any important announcements.
+
+## Effective communication
+
+1. Before you create or present something at company meeting, think about what you are trying to communicate.
+   - What important sentiment or information do you need to share with team members? Why?
+   - If you don't know, then do not present.
+1. Always give brief background on your project or function, even if it sounds obvious.
+   - This helps spread consistent, effective ways to talk about our company and product.
+     - Example: "On campaigns, we heard from Acme Corp that..." vs. "Campaigns let you make large-scale fixes across all of your code. Acme Corp told us that..."
+	 - Example: "Marketing update: our new lead sources..." vs. "Marketing is about getting enterprise developers to know about and want to try Sourcegraph. Our new lead sources..."
+   - Remember that other team members are new to the company and/or busy on their own projects.
+1. Don't make announcements or share other specific information that you expect everyone to remember.
+  - You can't assume everyone is attending company meeting and is paying attention.
+  - Use company meeting to give a reminder, but make sure the announcement is in [Slack](team_chat.md), in email, and/or on the calendar.
+1. Sharing goal-oriented progress updates is OK, but don't share task-oriented progress updates.
+  - The interface between your team and other teams is your goals ([OKRs](../../company/okrs/index.md)), not your tasks.
+  - Focusing on tasks instead of goals overloads other people with irrelevant information. This makes them tune out and probably miss or forget the important information.
+  - Example:
+    - Good: "On GitLab support in campaigns, we fixed all 7 bugs reported by other team members and are shipping it to the first beta customers today."
+	- Bad: "We fixed an issue where API rate limits for merge requests would ... and another issue where the status from the GitLab webhook payload ..."
 
 ## Agenda
 
 1. Introduce any new team members starting this week
-   - The manager of the team member presents a brief (~30-second) intro, stating the new team member's role, why we hired them, what their first project is, and a fun fact about them.
+   - The manager of the team member presents a brief (~30-second) intro, stating the new team member's role, why we hired them, what their first project is, and a fun fact about them. The new team member also has a chance to say hello and share a fun fact about themselves.
 1. Birthdays/anniversaries
 1. Inspiration of the week (message @dan to volunteer to present an inspiration)
-1. Sales and marketing
-1. People Ops
-1. Hiring
-1. Product and development updates
-   - Each engineering team owns a slide that _summarizes_ relevant progress  in the last week to the rest of the company.
-     - The engineering manager for each team is ultimately responsible for their team's slide, but they may delegate this responsibility to other teammates on any given week.
-     - The slide should contain short bullet points for each team project that has been completed, started, or is still in progress since the last update. Usually these bullet points are items on the roadmap. Ongoing work items should be marked with the [monthly release](../engineering/releases/index.md) that they are expected to be included in (if applicable).
-     - The slide should communicate how the team's progress contributes to their [quarterly OKRs](../../company/okrs/index.md), usually by inlining the teams objectives as top-level bullet points and nesting project bullet points under the relevant objective.
-     - The speaker notes on the slide should be exactly what the presenter is going to say (so anyone who can't attend company meeting can quickly catch up).
-     - [Here is an example of a good team slide](https://docs.google.com/presentation/d/1pIoUFHpKI7jLK-F-H6z_aFke_aDZDbXZKuJff6Kf_nc/edit#slide=id.g4d25168c6a_0_55)
-1. Other announcements
-   - Also share these announcements in #general.
-1. Q&A (questions and answers about anything company-wide)
+1. [#thanks](team_chat.md#thanks) summary
+1. [OKRs](../../company/okrs/index.md) progress
+1. **Alternating focus** (note: we will tweak these as we discover what is most effective/relevant)
+   1. CEO (1x/month): company pitch, vision, "are we on track?", open Q&A
+   1. Marketing, sales, customer engineering (1x/month): what's working, what's not, biggest customer pains/wins
+   1. Product release (1x/month, closest meeting to the [20th](../engineering/releases/index.md#releases-are-monthly)): what will ship in the release
+   1. Product preview (1x/month, first meeting after the [20th](../engineering/releases/index.md#releases-are-monthly)): what we're planning to build and ship in the next release
+1. All customer [bookings](../sales/index.md#booking) and churn since the previous company meeting
+1. New and expansion pipeline: include full table, discuss only significant changes since the previous company meeting
+1. Hiring: Open roles we're hiring for, offers extended/accepted/rejected
+1. What's new in the [handbook](../index.md)
+1. Anything else that team members need to communicate
+   - Just add a slide and write what you'll say in the speaker notes.
+1. Q&A about anything Sourcegraph-related
+   - [Submit a question anonymously](https://docs.google.com/forms/d/e/1FAIpQLSeiyIU67N_0m3xNBV-pONnVAGuBPsKQ_w-ZxtS-g8ZLWX--Ew/viewform?usp=sf_link)

--- a/handbook/sales/index.md
+++ b/handbook/sales/index.md
@@ -42,6 +42,14 @@ Expansion [IARR](#iarr) is IARR from *existing customers* (i.e., organizations t
 
 If within a single period a new customer signs a contract which then grows in ARR before the end of the period, the total ending ARR is all considered [new IARR](#new-iarr), not expansion IARR. For example, if Acme Corp signs a $100k contract on February 3 and then the contract expands to $200k on March 5, all $200k would be considered new IARR for Q1.
 
+### Booking
+
+A booking is when a customer commits to pay us money. This includes when:
+
+- A new customer just started paying self-service or signed a contract
+- An existing customer (depending on their contract) takes an action that increases the amount of revenue we will earn from them (such as growing usage or using more premium features)
+- An existing customer renews (including when the renewal is for the same ARR as the previous period)
+
 ### Customer
 
 A customer is an organization with a Sourcegraph subscription contract that has not ended.


### PR DESCRIPTION
- Deemphasize "progress reporting" aspect of company meeting in favor of cross-functional communication
- Alternate focus by week so that we can cover topics in-depth
- Refer to OKRs so they remain top-of-mind for people
- Include anonymous question submission form

For tomorrow's company meeting (2020-05-04), we will have no "alternating focus" item. Future company meetings will all have one.