### PR TITLE
handbook: update physical worksites info in all-remote section

### DIFF
--- a/company/remote/index.md
+++ b/company/remote/index.md
@@ -2,8 +2,8 @@
 
 Sourcegraph is an all-remote company, which means:
 
-- All teammates work remotely.
-- Sourcegraph does not have any offices, except for a small office in San Francisco used to provide a mailing address, for corporate filings, and as legally required.
+- All teammates are encouraged to work remotely. Sourcegraph provides a budget for home offices or office spaces to employees as needed.
+- We use our business office address in San Francisco to provide a mailing address, for corporate filings, and on-site workspaces as legally required.
 - We work asynchronously across time zones and continents.
   - Teammates are responsible for setting their own work hours and marking them in Google Calendar.
   - We try to limit the number of synchronous meetings, but there are some [company](../../handbook/communication/company_meeting.md) and team meetings that you need to attend which might be outside of your normal working hours. We do our best to optimize meeting times for all involved participants.

--- a/company/remote/index.md
+++ b/company/remote/index.md
@@ -2,7 +2,7 @@
 
 Sourcegraph is an all-remote company, which means:
 
-- All teammates are encouraged to work remotely. Sourcegraph provides a budget for home offices or office spaces to employees as needed.
+- All teammates are encouraged to work remotely. Sourcegraph provides a budget for home offices or office spaces to teammates as needed.
 - We use our business office address in San Francisco to provide a mailing address, for corporate filings, and on-site workspaces as legally required.
 - We work asynchronously across time zones and continents.
   - Teammates are responsible for setting their own work hours and marking them in Google Calendar.

--- a/company/remote/index.md
+++ b/company/remote/index.md
@@ -3,7 +3,7 @@
 Sourcegraph is an all-remote company, which means:
 
 - All teammates are encouraged to work remotely. Sourcegraph provides a budget for home offices or office spaces to teammates as needed.
-- We use our business office address in San Francisco to provide a mailing address, for corporate filings, and on-site workspaces as legally required.
+- We use our business office in San Francisco to provide a mailing address, for corporate filings, and on-site workplaces as legally required.
 - We work asynchronously across time zones and continents.
   - Teammates are responsible for setting their own work hours and marking them in Google Calendar.
   - We try to limit the number of synchronous meetings, but there are some [company](../../handbook/communication/company_meeting.md) and team meetings that you need to attend which might be outside of your normal working hours. We do our best to optimize meeting times for all involved participants.


### PR DESCRIPTION
As discussed with @sqs, this change elaborates that our remote-all policy is inclusive of making explicit provision for physical worksites as required by some employment arrangements.

