### PR TITLE
add FY20-Q2 OKRs

### DIFF
--- a/company/okrs/2020_q1.md
+++ b/company/okrs/2020_q1.md
@@ -1,6 +1,6 @@
 # FY20-Q1 OKRs
 
-> These OKRs are for Q1 in [fiscal year 2020](../../handbook/communication/index.md#fiscal-year), which runs from 2020-02-01 to 2020-04-30. This is the first quarter we are using the new February-through-January fiscal year. Some OKRs have not yet been extended to include April; this sentence will be removed when all have been updated.
+> These OKRs are for Q1 in [fiscal year 2020](../../handbook/communication/index.md#fiscal-year), which runs from 2020-02-01 to 2020-04-30. This is the first quarter we are using the new February-through-January fiscal year.
 
 ## CEO
 

--- a/company/okrs/2020_q2.md
+++ b/company/okrs/2020_q2.md
@@ -1,0 +1,123 @@
+# FY20-Q2 OKRs
+
+> These OKRs are for Q2 in [fiscal year 2020](../../handbook/communication/index.md#fiscal-year), which runs from 2020-03-01 to 2020-07-31.
+
+1. **CEO: Scale up pipeline and ARR** \
+   KR: Q3 and Q4 new and expansion pipelines ahead of plan \
+   KR: Marketing, Product, Sales, and Customer Engineering aligned on strategy, execution, and metrics => In progress, wrote up [Sales personas, new paths to winning deals, etc.](https://drive.google.com/a/sourcegraph.com/open?id=1I72rKXmVzQIYsOS6MOz2yCYnh5qGWI1Y-9-EkTycytk) \
+   KR: Street capacity ahead of plan \
+   KR: Clear value prop for buyer (not just users)
+   1. **Marketing: Put a repeatable, measurable process in place to scale demand generation for multiple personas.** \
+      KR: Reach pipeline coverage of at least 3x Q3 new IARR by the end of Q2 (relative to [“Company plan”](https://docs.google.com/spreadsheets/d/1EkZ7O69-2jbgtacoFDrY8L6rP73Hlqp_syyVCnmGAFA/edit#gid=498016854)). \
+      KR: Hire a [Demand Generation Manager](https://docs.google.com/document/d/1vo_yz6WAbzUkZh3C7U2u5U6xKfujQkYAyOYxe8NxyZE/edit#). \
+      KR: Develop a model which can predict growth in awareness and lead generation. \
+      KR: Manage our advertising as a portfolio with measured and priced results. \
+      KR: Develop and publish on our site a set of compelling video and text content that attracts developers, development leaders, and other people such as application security analysts and delivers leads.
+   1. **Marketing: [Promote the concept of Big Code](https://docs.google.com/document/d/17IBdc5T_UW4iVr6KMqhYCzsyF_EwEiP1JMTvAq4_gI8/edit) as generating a new class of problems for enterprise developers.** \
+      KR: Deliver a paper defining the problem (Big Code) and measuring its cost and the value of our solution, that the sales team can use with executives to convey the business value of Universal Code Search. \
+      KR: Define the scope of the problems with a survey of 100+ US enterprise developers. \
+      KR: Publish the findings in an ebook and/or a standalone site. \
+      KR: Promote the idea with a press campaign that creates at least 3 published original features.
+   1. **Customer Engineering: Build a team and pipeline to achieve the company sales plan.** \
+      KR: Reach pipeline coverage of at least 1.5x Q3 + Q4 expansion IARR by the end of Q2 (relative to [“Company plan”](https://docs.google.com/spreadsheets/d/1EkZ7O69-2jbgtacoFDrY8L6rP73Hlqp_syyVCnmGAFA/edit#gid=498016854)). \
+      KR: Reach [*$N<sub>0</sub>*][N0] in expansion IARR (“Company plan”). ([“Company plan” for Q2 expansion, Targets sheet =E4+F4+G4](https://docs.google.com/spreadsheets/d/1EkZ7O69-2jbgtacoFDrY8L6rP73Hlqp_syyVCnmGAFA/edit#gid=498016854)). \
+      KR: Hire +2 CEs by June 30 (per hiring plan), and up to 5 if hiring targets are expanded.
+   1. **Sales: Create clear paths to value/purchase for non-development teams (such as CISO and Digital Transformation).** \
+      KR: Move [*existing such deals*](https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.6awzhy8xk6lh) to Contract Negotiation or Closed Won. \
+      KR: Generate and move through the pipeline an additional [*N<sub>1</sub>*][N1] potential such deals (minimum total IARR: [*N<sub>2</sub>*][N2]), which moves through to the Evaluation stage within two weeks of first meeting.
+      1. **Product: Surface value metrics and [code insights](https://drive.google.com/a/sourcegraph.com/open?id=1EHzor6I1GhVVIpl70mH-c10b1tNEl_p1xRMJ9qHQfoc) for engineering leaders.** \
+         KR: Sales uses prototypes or design mocks in 10+ demo calls. \
+         KR: Compile list of top 10 questions engineering leaders have about their organization’s code. \
+         KR: Code insights feature is validated and included with deals in Q3 pipeline with [*$N<sub>3</sub>*][N3] weighted IARR.
+   1. **Product: Deliver on projects to increase and support sales efforts.** \
+      KR: Users can search across contexts of their organization's code as outlined in [RFC 136](https://drive.google.com/a/sourcegraph.com/open?id=1-Hn3bSVmwZ9iY0nfztXMoDfzWMdOHYTKrhK2F5ZJZI8). \
+      KR: Non-git version control can be set up in the site admin area. \
+      KR: License keys enable features for each license tier. \
+      KR: [*N<sub>4</sub>*][N4] new trials begin in Q2 using self-service trial start flow from Sourcegraph.com
+      1. **Engineering (Distribution): Site admins can painlessly deploy, upgrade, and maintain Sourcegraph.** \
+         KR: Reporting an issue with all the information needed by Sourcegraph requires no more than 5 minutes of customer time (i.e., no back-and-forth). \
+         KR: Upgrades take less than 30 minutes.
+   1. **Sales: Expand the team and playbook to achieve the company sales plan.** \
+      KR: Hire 1 more SDR and 3 AEs (at least 2 Enterprise AEs) by June 30. \
+      KR: Reach pipeline coverage of at least 5x Q3 new IARR by the end of Q2 (Evaluation and Contract Negotiation stages only). \
+      KR: Business value/prop provided to every prospect in Evaluation stage. \
+      KR: Reach [*$N<sub>5</sub>*][N5] in new IARR (["Company plan" for Q2 new, Targets sheet =E3+F3+G3](https://docs.google.com/spreadsheets/d/1EkZ7O69-2jbgtacoFDrY8L6rP73Hlqp_syyVCnmGAFA/edit#gid=1071026049)). \
+      KR: Attribute pipeline and deal dollars to new outbound/SDR initiatives.
+1. **CEO: Kick off long-term projects to massively grow awareness and usage.**
+   1. **Marketing: Take big risks to massively increase awareness** \
+      KR: Hire a [Developer Televangelist](https://docs.google.com/document/d/10JHQ4vX94jGiWqxRIFRyEliUf8o_Jq4HBhHqsueS5Kk/edit) (aka online developer advocate). \
+      KR: Ramp up to **almost daily** live events including partners, customers, and more. \
+      KR: >100 user tweets.
+   1. **Product: Deliver on projects to grow awareness and usage ([Roadmap planning with engineering/product OKRs](https://docs.google.com/document/d/1HFn5HwE34N1z9eyM9qENTBYiNG_F8O0qSrSt7jkphgk/edit#heading=h.q1ucxch38t59))** \
+      KR: [Sourcegraph.com WAU](https://sourcegraph.looker.com/looks/521) grows by 5x to [*N<sub>6</sub>*][N6] WAU. \
+      KR: MQLs from Sourcegraph.com contribute [*$N<sub>7</sub>*][N7] weighted pipeline (closing in Q3 and earlier). \
+      KR: ≥[*N<sub>8</sub>*][N8] WAU of LSIF [code intelligence actions](https://sourcegraph.looker.com/explore/sourcegraph_events/code_intel_events?qid=7iKSbu85XgC64zGMkFuvZY&origin_space=128&toggle=vis) across self-hosted instances and Sourcegraph.com. \
+      KR: ≥[*N<sub>9</sub>*][N9] WAU total for [code host integrations](https://sourcegraph.looker.com/explore/sourcegraph_events/server_weekly_usage?qid=168XAjjRvou3zkSc2gvpeK&origin_space=129&toggle=vis) at customers, and ≥[*N<sub>10</sub>*][N10] WAU each for public code hosts (GitLab.com, GitHub.com) \
+      KR: ≥[*N<sub>11</sub>*][N11] organizations have [created campaigns](https://sourcegraph.looker.com/dashboards/136), and at each of those organizations they have merged ≥[*N<sub>12</sub>*][N12] campaign changesets
+   1. **Product: Scale product team to achieve product growth.** \
+      KR: Hire 2 Product Managers. \
+      KR: Hire 2 Designers. => Hired 1 so far
+   1. **Business Operations: Ensure Sourcegraph decisions are data-driven.** \
+      KR: All key metrics for, and determined by, marketing, sales, and customer engineering, are measured, easily accessed, and used in weekly meetings. \
+      KR: 50%+ of product and marketing prioritization and resource allocation decisions (at the RFC and new program levels) are supported by [growth frameworks and models](https://docs.google.com/document/d/10-sq4iZrA_wSlYA2S19UDmHwkWldJfS_wf-hEX3Phgw/edit#).
+   1. **CTO: Reduce time to market for new features by helping engineering teams identify the MVP and providing high-fidelity feedback.** \
+      KR: Identify 3 engineering efforts to assist, validated by anonymous survey at the end of each iteration that will measure whether assistance was valuable.
+   1. **CTO: Create a trusted authority that is a source of engaging content for a broad developer audience (with emphasis on dev tools and productivity).** \
+      KR: [*N<sub>13</sub>*][N13] interested inquiries (professional dev, employed by a company with 200+ developers) generated from this new content.
+1. **CEO: Effective team communication and growth** \
+   KR: Handbook-first; 75% of team members make a handbook edit weekly, 100% make a handbook edit monthly. \
+   KR: Meet hiring plan. \
+   KR: The [canonical FY20 plan](https://docs.google.com/spreadsheets/d/1EkZ7O69-2jbgtacoFDrY8L6rP73Hlqp_syyVCnmGAFA/edit#gid=498016854) for sales, marketing, hiring, and costs is used by the exec team and is up to date.
+    1. **Product: Maintain updated and useful product vision and roadmap.** \
+       KR: Everyone at Sourcegraph knows where to find the product roadmap and trusts it is up to date. \
+       KR: The roadmap is public and easily discoverable. \
+       KR: End of quarter survey proves engineers at Sourcegraph know why their work is important and how it ties to the company strategy and OKRs.
+    1. **Engineering: Organize and grow engineering team to support product initiatives** \
+       KR: Hire engineers: +1 code intel, +2 frontend, +1 security \
+       KR: Hire engineering managers: +1 distribution, +1 backend
+    1. **VP Engineering: Raise the quality bar of our application and product.** \
+       KR: Define and measure KPIs for software engineers, project leads, and engineering managers. \
+       KR: Flaky tests are disabled or fixed within 1 day of being discovered to be flaky.
+       1. **Code intel: Increase test coverage and reliability** \
+          KR: Increase test coverage of code intel owned code from 57% to 65%. \
+          KR: 1 integration test per supported precise code intel language.
+       1. **Web: Pay down tech/design debt** \
+          KR: Each web team member devotes 2d per milestone to work on tech debt issues. \
+          KR: The web team devotes 3d per milestone to work on design debt issues.
+       1. **Web: Increase test coverage and reliability** \
+          KR: Increase TypeScript test coverage from 34% to 55%. \
+          KR: Grow number of Percy snapshots from 8 to 40.
+       1. **Distribution: Increase efficiency by increasing developer productivity and managing costs.** \
+          KR: Provide adequate customer support with no more than 1 developer-month per month. \
+          KR: Fully automate the QA and release process. ([#7148](https://github.com/sourcegraph/sourcegraph/issues/7148), [#9814](https://github.com/sourcegraph/sourcegraph/issues/9814)) \
+          KR: Eliminate flakiness in CI infrastructure and production alerting (OpsGenie). (e.g.,[#9607](https://github.com/sourcegraph/sourcegraph/issues/9607)) \
+          KR: Establish clear reporting on utilization of compute resources on sourcegraph.com and internal infrastructure. ([#10101](https://github.com/sourcegraph/sourcegraph/issues/10101))
+       1. **Core services: Increase test coverage and reliability** \
+          KR: Increase Go test coverage from 46% to 60%.
+    1. **People Ops: Make our HR processes truly global and all remote.** \
+       KR: Handbook outlines onboarding requirements for specific teams. \
+       KR: Handbook outlines employment structure differences for US and international teammates. \
+       KR: All HR policies are updated to be suitable for an all-remote and geographically distributed team. \
+    1. **People Ops: Continue to foster connections and belonging.** \
+       KR: Increase team participation by having 100% of team join at least 1 activity per month. \
+    1. **People Ops: Build a consistent hiring process that supports scaling a team.** \
+       KR: Interview repo contains guidelines and FAQs on ATS for varying access roles (referrers, interviewers, HMs, coordinators). \
+       KR: 100% of applicants get a response (rejected or continuing to next stage) within 7 days (no accidental "ghosting").
+    1. **Sales: Effective team onboarding to sales productivity (pipeline and revenue generation)** \
+       KR: Handbook to contain detailed tasks and expectations for each new Sales role for the first 2 weeks. \
+       KR: Handbook Sales section is up to date and documents processes and definitions.
+
+[N0]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.k2i8a693nt03
+[N1]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.rcsa4nrzhfth
+[N2]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.78lfgk6n8g1
+[N3]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.cflce5c26p0t
+[N4]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.kyb6vf54kq6n
+[N5]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.zfd4s7f6l96
+[N6]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.el36web1a8lh
+[N7]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.kwvjy8a59zqq
+[N8]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.tb34mxx6cpdw
+[N9]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.s15cevsvq3r0
+[N10]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.9znxsajwsep5
+[N11]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.mcssqvtg6g9u
+[N12]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.60b1ec8o51kl
+[N13]: https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#bookmark=id.byvw6hihxyze

--- a/company/okrs/index.md
+++ b/company/okrs/index.md
@@ -4,7 +4,7 @@
 
 Our OKRs are public:
 
-- [FY20-Q2 (upcoming, not yet public)](https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit)
+- [FY20-Q2](2020_q2.md)
 - [FY20-Q1 (active)](2020_q1.md)
 - [CY19-Q4](2019_q4.md)
 - [CY19-Q3](2019_q3.md)


### PR DESCRIPTION
Moved the OKRs from the gdoc at https://docs.google.com/document/d/1fAB7HMD7rmcyI68f2WuMAvt3uf0UqIruFvKhJUHMCyY/edit#. Sensitive numbers are extracted from the public page (referred to only as, e.g., *N<sub>5</sub>*) and live in the gdoc ([why?](https://about.sourcegraph.com/company/okrs#sensitive-information)).