### PR TITLE
Direct communication channels

### DIFF
--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -2,6 +2,10 @@
 
 We're an [all-remote](../../company/remote/index.md) company, with teammates from all around the world and (soon) no primary office. To make this work, we need to be deliberate about how we communicate.
 
+## Direct communication
+
+We rely on [Slack](team_chat.md) for all our internal communications and conversations so discussion can happen in public channels. For the most part we only use email for external communications. In the rare occasion of a Slack outage, we communicate by....???
+
 ## Sources of truth
 
 These places are the source of truth for information at Sourcegraph. Information in these places is expected to be accurate and up-to-date:


### PR DESCRIPTION
How do we communicate when Slack goes down? Slack is having an outage and I feel completely blind with how to get in touch with anyone on the team, start new conversations, or add any information that would be read asynchronously. I think it would be wise for us to have a documented plan to guide the team if/when these things happen. Do we have any email lists set up? Should we just start email threads to team@? 