### PR TITLE
handbook: add observability developer guides

### DIFF
--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -78,6 +78,7 @@ Go, Docker, Kubernetes
 * [Recurring processes](./recurring_processes.md)
 * [Internal infrastructure](./internal_infrastructure.md)
 * Tutorials
+  * [Observability developer guide](observability/index.md)
   * [How to set up a separate website maintained by Sourcegraph](separate_website.md)
   * [How to replay a metrics dump from a customer](use_metrics_dump.md)
   * [How to simulate k8s admin security restrictions](k8s_admin_custom_policy.md)

--- a/handbook/engineering/distribution/observability/index.md
+++ b/handbook/engineering/distribution/observability/index.md
@@ -1,0 +1,9 @@
+# Sourcegraph observability developer guide
+
+**Note:** Looking for _how to monitor Sourcegraph?_ See the [observability documentation](https://docs.sourcegraph.com/admin/observability).
+
+We use three tools primarily to observe (monitor and debug) Sourcegraph:
+
+- [Monitoring](monitoring.md) 
+- Logging (developer docs coming soon, for now see [admin docs](https://docs.sourcegraph.com/admin/observability))
+- Distributed tracing (developer docs coming soon, for now see [admin docs](https://docs.sourcegraph.com/admin/observability))

--- a/handbook/engineering/distribution/observability/monitoring.md
+++ b/handbook/engineering/distribution/observability/monitoring.md
@@ -43,7 +43,7 @@ We use [Prometheus](https://prometheus.io) for:
 We use [Grafana](https://grafana.com) for:
 
 - Displaying dashboards for our Prometheus metrics.
-- Sending our Prometheus metric alerts to site admins via email, slack, etc.
+- Sending our Prometheus metric alerts to site admins via email, Slack, etc.
 
 We use a custom [declarative Go generator syntax](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/monitoring) for:
 

--- a/handbook/engineering/distribution/observability/monitoring.md
+++ b/handbook/engineering/distribution/observability/monitoring.md
@@ -125,7 +125,7 @@ It's best if you also add some Markdown documentation with your best guess of wh
 > Tip: In `PossibleSolutions` Markdown, you can use single quotes anywhere you would normally use backticks for code, and indention will automatically be removed for you.
 
 
-One you save the file, `doc/admin/observability/alert_solutions.md` will automatically be regenerated and you can even preview your changes at [http://localhost:5080/admin/observability/alert_solutions](http://localhost:5080/admin/observability/alert_solutions).
+Once you save the file, `doc/admin/observability/alert_solutions.md` will automatically be regenerated and you can even preview your changes at [http://localhost:5080/admin/observability/alert_solutions](http://localhost:5080/admin/observability/alert_solutions).
 
 ## Next steps
 

--- a/handbook/engineering/distribution/observability/monitoring.md
+++ b/handbook/engineering/distribution/observability/monitoring.md
@@ -31,7 +31,7 @@ It does not include:
 - Solving a problem end-to-end: after looking at monitoring, admins MUST go elsewhere to solve the problem.
 - Identifying individual problem cases (e.g. the details of why a single request failed).
 
-Monitoring is just one piece of Sourcegraph's observability. See the [observability developer guide](observability.md) for more information.
+Monitoring is just one piece of Sourcegraph's observability. See the [observability developer guide](index.md) for more information.
 
 ### Monitoring technology we use
 

--- a/handbook/engineering/distribution/observability/monitoring.md
+++ b/handbook/engineering/distribution/observability/monitoring.md
@@ -60,7 +60,8 @@ At Sourcegraph we impose five strict constraints to monitoring which, at first, 
 
 1. Creating dashboards that describe something other than a single Sourcegraph service is forbidden.
 2. Adding a graph/panel that visualizes a metric, without defining an associated alert, is forbidden.
-3. Creating dashboards outside of the monitoring generator, such as with the Grafana WYSIWYG editor, is forbidden. All metrics should be presented in the most plain, mundane, non-fanciful way that every site admin can understand.4. Creating graphs/panels with more than 5 cardinality (labels) is forbidden (in most cases there should only be one.)
+3. Creating dashboards outside of the monitoring generator, such as with the Grafana WYSIWYG editor, is forbidden. All metrics should be presented in the most plain, mundane, non-fanciful way that every site admin can understand.
+4. Creating graphs/panels with more than 5 cardinalities (labels) is forbidden (in most cases there should only be one.)
 5. The most useful information should be presented first, the least useful information should be hidden by default.
 
 To understand why we impose these constraints, see [the five pillars of monitoring](monitoring_pillars.md)

--- a/handbook/engineering/distribution/observability/monitoring.md
+++ b/handbook/engineering/distribution/observability/monitoring.md
@@ -1,0 +1,133 @@
+# Sourcegraph monitoring developer guide
+
+**Note:** Looking for _how to monitor Sourcegraph?_ See the [observability documentation](https://docs.sourcegraph.com/admin/observability).
+
+This document describes how to develop Sourcegraph's monitoring:
+
+![image](https://user-images.githubusercontent.com/3173176/82078081-65c62780-9695-11ea-954a-84e8e9686970.png)
+
+- [Overview](#overview)
+  - [What is monitoring?](#what-is-monitoring)
+  - [Monitoring technology we use](#monitoring-technology-we-use)
+- [The five pillars of monitoring](#the-five-pillars-of-monitoring)
+- [How easy is it to add monitoring?](#how-easy-is-it-to-add-monitoring)
+  - [(optional) configure panel options](#optional-configuring-panel-options)
+  - [(optional) add solution documentation](#optional-add-solution-documentation)
+- [Next steps](#next-steps)
+
+## Overview
+
+### What is monitoring?
+
+Monitoring at Sourcegraph encapsulates:
+
+- How site admins know something _is wrong_ or _may be wrong_.
+- Describing the overall health of Sourcegraph to site admins.
+- Making it clear to site admins _where to go next if Sourcegraph is not healthy._
+
+It does not include:
+
+- Significant detail about what went wrong: the goal is just to direct the site admin to the next step.
+- Solving a problem end-to-end: after looking at monitoring, admins MUST go elsewhere to solve the problem.
+- Identifying individual problem cases (e.g. the details of why a single request failed).
+
+Monitoring is just one piece of Sourcegraph's observability. See the [observability developer guide](observability.md) for more information.
+
+### Monitoring technology we use
+
+We use [Prometheus](https://prometheus.io) for:
+
+- Collecting high-level, and low-cardinality, metrics from our services.
+- Defining alerting rules (we do not use [Prometheus's Alertmanager](https://prometheus.io/docs/alerting/alertmanager/) but instead define alerts as a single Prometheus metric, more on this later.)
+
+We use [Grafana](https://grafana.com) for:
+
+- Displaying dashboards for our Prometheus metrics.
+- Sending our Prometheus metric alerts to site admins via email, slack, etc.
+
+We use a custom [declarative Go generator syntax](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/monitoring) for:
+
+- Defining the services we monitor.
+- Describing _what those services do_ to site admins.
+- Laying out dashboards in a uniform, consistent, and simple way.
+- Asserting constraints and principles that we want to hold ourselves to, such as ["every metric must have a defined alert"](#the-five-pillars-of-monitoring).
+- Generating the Prometheus alerting rules and Grafana dashboards.
+- Generating documentation in the form of ["possible solutions"](https://docs.sourcegraph.com/admin/observability/alert_solutions) for site admins to follow when alerts are firing.
+
+## The five pillars of monitoring
+
+At Sourcegraph we impose five strict constraints to monitoring which, at first, may seem quite surprising:
+
+1. Creating dashboards that describe something other than a single Sourcegraph service is forbidden.
+2. Adding a graph/panel that visualizes a metric, without defining an associated alert, is forbidden.
+3. Creating dashboards outside of the monitoring generator, such as with the Grafana WYSIWYG editor, is forbidden. All metrics should be presented in the most plain, mundane, non-fanciful way that every site admin can understand.4. Creating graphs/panels with more than 5 cardinality (labels) is forbidden (in most cases there should only be one.)
+5. The most useful information should be presented first, the least useful information should be hidden by default.
+
+To understand why we impose these constraints, see [the five pillars of monitoring](monitoring_pillars.md)
+
+## How easy is it to add monitoring?
+
+There are some steps involved, but it's easy and the development process is quite seamless:
+
+1. Get your Prometheus metric merged in our main codebase. You can find [examples](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+prometheus.MustRegister%28&patternType=literal) throughout our code, and [learn about the Proemtheus metric types](https://prometheus.io/docs/concepts/metric_types/).
+2. Use the Grafana Explore page [on Sourcegraph.com](https://sourcegraph.com/-/debug/grafana/explore), [k8s.sgdev.org](https://k8s.sgdev.org/-/debug/grafana/explore), or [your local development server](http://localhost:3080/-/debug/grafana/explore) to start writing your Prometheus query.
+3. Make a guess about what a good/bad value for your query is. It's OK if this isn't perfect, just do your best. Some examples:
+   - `Warning: Alert{GreaterOrEqual: 50}`
+   - `Warning: Alert{LessOrEqual: 50}`
+4. Run a Sourcegraph `dev/start.sh` server and [visit Grafana](http://localhost:3080/-/debug/grafana).
+5. Look for an existing dashboard that your information should go in. Think "when this number shows something bad, which service's logs are likely to be most relevant?"
+6. Open that service's monitoring definition (e.g. `monitoring/frontend.go`, `monitoring/git_server.go`) in your editor.
+7. Declare your [`Observable`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+file:%5Emonitoring/+type+Observable&patternType=literal) by adding it to [an existing `Row` in the file](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@64aa473/-/blob/monitoring/frontend.go#L12-43), or by adding a new [`Row`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+file:%5Emonitoring/+type+Row&patternType=literal) or [`Group`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+file:%5Emonitoring/+type+Group&patternType=literal) entirely. Here's an example `Observable` to get you started:
+
+```
+{
+    Name:        "99th_percentile_search_request_duration",
+    Description: "99th percentile successful search request duration over 5m",
+    Query:       `histogram_quantile(0.99, sum by (le)(rate(search_request_duration{status="success}[5m])))`,
+    Warning:     Alert{GreaterOrEqual: 20},
+}
+```
+
+As soon as you save the file, everything is regenerated by `dev/start.sh` (Grafana dashboards, Prometheus alerting rules, documentation, etc.) and you can simply refresh on the dashboard you're editing to see your changes.
+
+### (optional) configure panel options
+
+There are not many panel options (intentionally) to keep things simple. The primary thing you'll use is to change the Grafana display from plain numbers to a unit like seconds:
+
+```diff
+{
+    Name:        "99th_percentile_search_request_duration",
+    Description: "99th percentile successful search request duration over 5m",
+    Query:       `histogram_quantile(0.99, sum by (le)(rate(search_request_duration{status="success}[5m])))`,
+    Warning:     Alert{GreaterOrEqual: 20},
++   PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
+}
+```
+
+### (optional) add solution documentation
+
+It's best if you also add some Markdown documentation with your best guess of what someone _might consider doing_ if they observe the alert firing (again, just your best guess is good enough here):
+
+```diff
+{
+    Name:        "99th_percentile_search_request_duration",
+    Description: "99th percentile successful search request duration over 5m",
+    Query:       `histogram_quantile(0.99, sum by (le)(rate(search_request_duration{status="success}[5m])))`,
+    Warning:     Alert{GreaterOrEqual: 20},
+    PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
++	PossibleSolutions: `
++       - Look at the 'frontend' logs for details on the slow search queries.
++   `,
+}
+```
+
+> Tip: In `PossibleSolutions` Markdown, you can use single quotes anywhere you would normally use backticks for code, and indention will automatically be removed for you.
+
+
+One you save the file, `doc/admin/observability/alert_solutions.md` will automatically be regenerated and you can even preview your changes at [http://localhost:5080/admin/observability/alert_solutions](http://localhost:5080/admin/observability/alert_solutions).
+
+## Next steps
+
+- Look at the monitoring for one of our services: [monitoring/symbols.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/monitoring/symbols.go)
+- Check out [the API documentation for `Observable`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/monitoring/generator.go#L106-194)
+- Send a PR and tag `@slimsag` or `@distribution` for review!

--- a/handbook/engineering/distribution/observability/monitoring_pillars.md
+++ b/handbook/engineering/distribution/observability/monitoring_pillars.md
@@ -1,0 +1,196 @@
+# Sourcegraph: The five pillars of monitoring
+
+**Note:** Looking for _how to monitor Sourcegraph?_ See the [observability documentation](https://docs.sourcegraph.com/admin/observability).
+
+This document describes in-depth the five pillars / constraints that we impose at Sourcegraph when developing our monitoring infrastructure and, in specific, why we impose them.
+
+See [the monitoring developer guide](monitoring.md) for information on how to develop monitoring once you're convinced.
+
+- [The five pillars of monitoring](#the-five-pillars-of-monitoring)
+- [Monitoring at Sourcegraph: a brief history](#monitoring-at-sourcegraph-a-brief-history)
+- [Frequently asked questions](#frequently-asked-questions)
+  - [Why can't I create an ad-hoc dashboard (e.g. an "HTTP" dashboard)?](#faq-why-cant-i-create-an-ad-hoc-dashboard-e-g-an-http-dashboard)
+  - [I have a purely information metric, I don't want to define an alert for it. How do I do that?](#faq-i-have-a-purely-information-metric-i-dont-want-to-define-an-alert-for-it-how-do-i-do-that)
+  - [Why can't I create a dashboard in the WYSIWYG Grafana editor?](#faq-why-cant-i-create-a-dashboard-in-the-wysiwyg-grafana-editor)
+  - [Why can't I create a graph/panel with more than 5 cardinality (labels)?](#faq-why-cant-i-create-a-graph-panel-with-more-than-5-cardinality-labels)
+  - [Why can't I have all information expanded by default on the dashboard?](#faq-why-cant-i-have-all-information-expanded-by-default-on-the-dashboard)
+
+## The five pillars of monitoring
+
+At Sourcegraph we impose five strict constraints to monitoring which, at first, may seem quite surprising:
+
+1. Creating dashboards that describe something other than a single Sourcegraph service is forbidden.
+2. Adding a graph/panel that visualizes a metric, without defining an associated alert, is forbidden.
+3. Creating dashboards outside of the monitoring generator, such as with the Grafana WYSIWYG editor, is forbidden. All metrics should be presented in the most plain, mundane, non-fanciful way that every site admin can understand.
+4. Creating graphs/panels with more than 5 cardinality (labels) is forbidden (in most cases there should only be one.)
+5. The most useful information should be presented first, the least useful information should be hidden by default.
+
+To understand why we impose these constraints, see [the five pillars of monitoring](monitoring_pillars.md)
+
+## Monitoring at Sourcegraph: a brief history
+
+Before the constraints we impose will start to make sense, you need to understand the history of monitoring at Sourcegraph and the (extremely difficult) problem we're trying to solve with it.
+
+### For as long as Sourcegraph has existed as an enterprise product, it has had some form of Prometheus and Grafana monitoring
+
+It has progressed over time roughly as follows:
+
+- 2015: Using Prometheus/Grafana internally, customers _can_ use it, but they're on their own to define alerts for the 500+ metrics we expose.
+- 2016: Give select customers a copy of our dashboards "as a starting point", in most cases they are broken.
+- 2017: We give anyone who wants it a copy of our configs, but they're specific to Sourcegraph.com so most things are broken.
+- 2018: Still 100% optional, most customers do not even run Prometheus. We put Sourcegraph.com on the back-burner, a vast majority of our dashboards become broken/useless.
+- mid-2019 (Sourcegraph 3.11): We start shipping Prometheus and Grafana out-of-the-box, but still 30% of dashboards are broken with the rest being heavily outdated or useless.
+- late-2019 (Sourcegraph 3.12): We add new dashboards which work, but don't cover a lot of stuff. Many ad-hoc dashboards like "Gitserver" and "Gitserver 2" or "Debug test" exist.
+- late-2019 (Sourcegraph 3.13): New dashboards start covering more, but ad-hoc dashboards still exist. We begin adding dashboards that are extremely hard for anyone except the original author to interpret.
+- 2020 (Sourcegraph 3.15): New dashboards cover most things, are guaranteed to work in customer deployments AND be legible to anyone because we've impose strict restrictions on how we develop them. A few customers begin to set up alerting.
+
+### For almost as long as Sourcegraph has existed (at the time of writing this)
+
+- Our Prometheus metrics have been too numerous for anyone to reason about on their own (even us ourselves).
+- Our Grafana dashboards have most of the time been completely broken for customers because we do not rely on them.
+- Our Grafana dashboards have in ~70% of cases been so complex that only the author of the dashboard could interpret what it means.
+- We occasionally receive support requests like "is this dashboard showing it is healthy or not?" and we can only respond with "we're.. not sure, are you seeing errors in the app itself?"
+- It has been impossible for site admins to define meaningful alerting for Sourcegraph. 90% of admins that do set up alerting just set up external checks for "does a search query work and is it fast?"
+- It has been impossible for us to debug customer's instances through monitoring, and often we would just write one-off Prometheus queries for customers to run.
+
+### The linter of monitoring
+
+We can and should do better with monitoring than we have in the past, so we introduce strict restrictions on how we develop monitoring. This helps keep the entire engineering team aligned with what our customers and users need from us -- even if monitoring is often an afterthought or the last thing an engineer working on some feature adds.
+
+You can think of the restrictions we impose as a linter for preventing the issues described above. And, in many cases, our tooling does already prevent these issues by imposing these restrictions!
+
+## Frequently asked questions
+
+### FAQ: Why can't I create an ad-hoc dashboard (e.g. an "HTTP" dashboard)?
+
+This violates the first pillar of monitoring at Sourcegraph:
+
+> Creating dashboards that describe something other than a single Sourcegraph service is forbidden.
+
+#### Why this is bad
+
+Pretend you are a site admin and looking at Sourcegraph's monitoring:
+
+- You go to the overview dashboard and find out the issue is in some subsystem of Sourcegraph.
+- That dashboard shows you a problem with HTTP requests, or a problem with repository permission synching, or search performance
+
+What do you do now? Where do you go next with this information? How do you resolve the issue? When dashboards are not associated with a single Sourcegraph service, it makes it effectively impossible to know where the problem is. For this reason, it is forbidden to do this.
+
+Consider for example an admin who finds on a "Search" dashboard that "search query performance is bad":
+
+- "Do I look at Searcher's logs?" Well.. no, because that's for unindexed search (was the query unindexed?)
+- "Do I look at zoekt's logs?" Also no, because even thought that's for indexed search, the logs for slow queries are actually in the frontend.
+
+If instead this information is communicated only on a "Frontend" dashboard, it becomes immediately clear they can check the frontend logs first, which is where they will find next steps.
+
+#### What you should do instead
+
+Consider "when the metric I am monitoring is bad, where do I want the site admin to look?" Usually, this is just the service that emits the metric itself.
+
+In other words, you should add the metric you are monitoring to an existing service's dashboard.
+
+### FAQ: I have a purely information metric, I don't want to define an alert for it. How do I do that?
+
+This violates the second pillar of monitoring at Sourcegraph:
+
+> 2. Adding a graph/panel that visualizes a metric, without defining an associated alert, is forbidden.
+
+#### Why this is bad
+
+There is nothing worth monitoring that cannot have _some_ explanation of what a bad or good value is.
+
+By saying "I do not want to define an alert" what we are actually doing is shying away from the question of "how should someone interpret what this number means?" and instead saying "I will keep this information private, just for myself"
+
+Our monitoring infrastructure _forces_ you to declare at least a _Warning_ alert. It's OK if this is flaky, or even if it fires when something is not wrong.
+
+The point is _you have to give a best-guess at what a bad or good value looks like because you are the only one who can answer that question._ Otherwise, the information you are 'monitoring' cannot be interpreted by anyone else and is inherently useless to anyone except you: it should not exist in a dashboard then.
+
+#### What you should do instead
+
+Declare a `Warning` alert, and give it your best guess at what a threshold would look like. It's OK if it's flaky, or fires when there isn't a problem sometimes or on some Sourcegraph instances.
+
+Over time, we will adjust the alert so it becomes more reliable and becomes the baseline number that most Sourcegraph instances observe. Once it becomes really reliable (and empirically proven to be so, based on pings we get from customer instances), it can be promoted to a `Critical` alert as well if it speaks of a critical part of Sourcegraph.
+
+### FAQ: Why can't I create a dashboard in the WYSIWYG Grafana editor?
+
+This violates the third pillar of monitoring at Sourcegraph:
+
+> Creating dashboards outside of the monitoring generator, such as with the Grafana WYSIWYG editor, is forbidden. All metrics should be presented in the most plain, mundane, non-fanciful way that every site admin can understand.
+
+#### Why this is bad
+
+Using the Grafana WYSIWYG editor, or otherwise operating outside the constraints of [the monitoring generator](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/monitoring) makes it:
+
+- Extremely easy to introduce dashboards that do not comply with the constraints we want to impose.
+- Extremely easy to introduce dashboards that have inconsistency errors through mistakes that are easy to make (e.g. not using UTC time on dashboards, the preset timeframe being inconsistent, it not self-describing to admins what it does, etc.)
+- Difficult for others to modify and review without introducing regressions (e.g. due to Grafana schema version changes, which happen frequently, producing large diffs)
+- Much harder to declare proper alerts in our regular high-level alerting architecture.
+
+#### What you should do instead
+
+You might be thinking:
+
+> But writing code for dashboards is quite painful, let alone a bunch of generation code that I now need to understand!
+
+In truth, we are only using Go as a nice type-checked declarative syntax. It's as simple to use as a configuration file, and the constraints we impose in monitoring means that we do not allow doing any fanciful dashboards intentionally -- which means you are basically _just_ writing a Prometheus query, and barely any layout or styling.
+
+See: [How easy is it to add monitoring?](monitoring.md#how-easy-is-it-to-add-monitoring)
+
+### FAQ: Why can't I create a graph/panel with more than 5 cardinality (labels)?
+
+This violates the fourth pillar of monitoring at Sourcegraph:
+
+> Creating graphs/panels with more than 5 cardinality (labels) is forbidden (in most cases there should only be one.)
+
+#### Why this is bad
+
+It is the case that:
+
+1. We get screenshots of dashboards from customers in our support process.
+2. Inexperienced admins need to understand what our metrics mean.
+
+Consider, then, the following.
+
+Is it `set-info` or `get-email` causing the blips below?
+
+![](https://user-images.githubusercontent.com/3173176/78830054-35a3ae80-799c-11ea-89ed-dfce5faf70fc.png)
+
+Which searcher instance has the spike going to ~400 errors below?
+
+![](https://user-images.githubusercontent.com/3173176/78832251-c465fa80-799f-11ea-9f8a-2d775253c770.png)
+
+We expect `update_commits` to be taking ~50ms and need to confirm that. Is it ~50ms below?
+
+![](https://user-images.githubusercontent.com/3173176/81974154-03f4b780-95da-11ea-8988-069dbdc3ef92.png)
+
+#### What you should do instead
+
+If the information you are presenting is important enough to warrant being shown independently, it should be shown in its own panel. In other words, declare a separate `Query` all-together with a Prometheus selector like `{method="update_commits"}`.
+
+If the information you are presenting is not important enough to warrant being shown independently, or if you're not sure, then aggregate it! It's far better that we have clear panels showing individual numbers and learn we need to add more for specific cases, than it is for us to have every bit of information present such that it is impossible to interpret. We want a low signal-to-noise ratio.
+
+For _instances of services_ in particular, you might be thinking "surely that is an exception?" But no, it is not generally. It is better that an admin knows there is an issue with _a searcher_, or _a gitserver_ and that admin looks through the logs of each to determine the issue than it is to give an information overload which makes it hard to interpret individual panels at all.
+
+### FAQ: Why can't I have all information expanded by default on the dashboard?
+
+This violates the fifth pillar of monitoring at Sourcegraph:
+
+> The most useful information should be presented first, the least useful information should be hidden by default.
+
+#### Why this is bad
+
+Similar to "[Why can't I create a graph/panel with more than 5 cardinality (labels)?](#faq-why-cant-i-create-a-graph-panel-with-more-than-5-cardinality-labels)", having all information by default prevents site admins from looking at the information that is actually most important.
+
+Additionally, it's easier for us to say:
+
+> Go to the **Searcher** dashboard, scroll down and expand the **Internal service requests** panel and send us a screenshot.
+
+Than it is for us to say:
+
+> On the **Searcher** dashboard, send us a screenshot of the whole page (I know it's really long, sorry about that, if you could just make sure to include the "Frontend request failures over 5m" panel and the [...] panels, that is all we should need)
+
+#### What you should do instead
+
+If it can't fit on a normal laptop screen, it should generally be hidden!
+
+Additionally, admins will still see your metric if something is going wrong by nature of the fact that we enforce "there must be a defined alert per metric we are displaying." By hiding it, we're just being honest that most people aren't going to see it and making sure the most important information is front-and-center!

--- a/handbook/engineering/distribution/observability/monitoring_pillars.md
+++ b/handbook/engineering/distribution/observability/monitoring_pillars.md
@@ -29,28 +29,13 @@ To understand why we impose these constraints, see [the five pillars of monitori
 
 ## Monitoring at Sourcegraph: a brief history
 
-Before the constraints we impose will start to make sense, you need to understand the history of monitoring at Sourcegraph and the (extremely difficult) problem we're trying to solve with it.
+Before the constraints we impose will start to make sense, you need to understand the history of monitoring at Sourcegraph and the (extremely difficult) problem we're trying to solve with it. For the first five years of Sourcegraph:
 
-### For as long as Sourcegraph has existed as an enterprise product, it has had some form of Prometheus and Grafana monitoring
-
-It has progressed over time roughly as follows:
-
-- 2015: Using Prometheus/Grafana internally, customers _can_ use it, but they're on their own to define alerts for the 500+ metrics we expose.
-- 2016: Give select customers a copy of our dashboards "as a starting point", in most cases they are broken.
-- 2017: We give anyone who wants it a copy of our configs, but they're specific to Sourcegraph.com so most things are broken.
-- 2018: Still 100% optional, most customers do not even run Prometheus. We put Sourcegraph.com on the back-burner, a vast majority of our dashboards become broken/useless.
-- mid-2019 (Sourcegraph 3.11): We start shipping Prometheus and Grafana out-of-the-box, but still 30% of dashboards are broken with the rest being heavily outdated or useless.
-- late-2019 (Sourcegraph 3.12): We add new dashboards which work, but don't cover a lot of stuff. Many ad-hoc dashboards like "Gitserver" and "Gitserver 2" or "Debug test" exist.
-- late-2019 (Sourcegraph 3.13): New dashboards start covering more, but ad-hoc dashboards still exist. We begin adding dashboards that are extremely hard for anyone except the original author to interpret.
-- 2020 (Sourcegraph 3.15): New dashboards cover most things, are guaranteed to work in customer deployments AND be legible to anyone because we've impose strict restrictions on how we develop them. A few customers begin to set up alerting.
-
-### For almost as long as Sourcegraph has existed (at the time of writing this)
-
-- Our Prometheus metrics have been too numerous for anyone to reason about on their own (even us ourselves).
-- Our Grafana dashboards have most of the time been completely broken for customers because we do not rely on them.
-- Our Grafana dashboards have in ~70% of cases been so complex that only the author of the dashboard could interpret what it means.
-- We occasionally receive support requests like "is this dashboard showing it is healthy or not?" and we can only respond with "we're.. not sure, are you seeing errors in the app itself?"
-- It has been impossible for site admins to define meaningful alerting for Sourcegraph. 90% of admins that do set up alerting just set up external checks for "does a search query work and is it fast?"
+- Metrics have been too numerous for anyone to reason about on their own
+- Dashboards have been completely broken for customers because we do not rely on them heavily.
+- Dashboards have been so complex that only the author of the dashboard could interpret what it means.
+- We recieved support requests like "is this dashboard showing it is healthy or not?" and it was difficult to answer
+- It has been impossible/painful for site admins to define meaningful alerting for Sourcegraph. Many admins would fall back to poor external checks like "does a search query work and is it fast?"
 - It has been impossible for us to debug customer's instances through monitoring, and often we would just write one-off Prometheus queries for customers to run.
 
 ### The linter of monitoring


### PR DESCRIPTION
This adds developer documentation for best-practices for developing the observability of Sourcegraph.

Right now, only documentation for monitoring is added. In the future, documentation about how we develop logging and distributed tracing should be added.

This is a first pass, and can certainly be improved in some areas -- but I have had three people ask me questions about this and be confused by the lack of documentation so I want to immediately remediate that.

Once merged, you can find these docs at https://about.sourcegraph.com/handbook/engineering/distribution/observability