### PR TITLE
handbook: distribution: minor observability changes

### DIFF
--- a/handbook/engineering/distribution/observability/index.md
+++ b/handbook/engineering/distribution/observability/index.md
@@ -2,8 +2,19 @@
 
 **Note:** Looking for _how to monitor Sourcegraph?_ See the [observability documentation](https://docs.sourcegraph.com/admin/observability).
 
-We use three tools primarily to observe (monitor and debug) Sourcegraph:
+Observability includes:
 
-- [Monitoring](monitoring.md) 
-- Logging (developer docs coming soon, for now see [admin docs](https://docs.sourcegraph.com/admin/observability))
-- Distributed tracing (developer docs coming soon, for now see [admin docs](https://docs.sourcegraph.com/admin/observability))
+- Monitoring - how you know _when something is wrong_, which includes:
+  - Dashboards & metrics
+  - Alerting
+  - Health checks
+- Debugging - how you debug _what is wrong_, which includes:
+  - Distributed tracing
+  - Logging
+
+## Developer guides
+
+- [Monitoring developer guide](monitoring.md)
+    - [The five pillars of monitoring](monitoring_pillars.md)
+- Distributed tracing developer guide (coming soon)
+- Logging developer guide (coming soon)

--- a/handbook/engineering/distribution/observability/monitoring.md
+++ b/handbook/engineering/distribution/observability/monitoring.md
@@ -127,8 +127,16 @@ It's best if you also add some Markdown documentation with your best guess of wh
 
 Once you save the file, `doc/admin/observability/alert_solutions.md` will automatically be regenerated and you can even preview your changes at [http://localhost:5080/admin/observability/alert_solutions](http://localhost:5080/admin/observability/alert_solutions).
 
+## Additional reading
+
+- [How Sourcegraph's high-level alerting metrics work](https://docs.sourcegraph.com/admin/observability/metrics_guide)
+- [The difference between Warning and Critical alerts](https://docs.sourcegraph.com/admin/observability/alerting_custom_consumption#the-difference-between-critical-and-warning-alerts)
+- [How some organizations query our high-level alerts for integration with their own systems](https://docs.sourcegraph.com/admin/observability/alerting_custom_consumption)
+- [Admin documentation for observability](https://docs.sourcegraph.com/admin/observability)
+
 ## Next steps
 
 - Look at the monitoring for one of our services: [monitoring/symbols.go](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/monitoring/symbols.go)
 - Check out [the API documentation for `Observable`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/monitoring/generator.go#L106-194)
 - Send a PR and tag `@slimsag` or `@distribution` for review!
+

--- a/handbook/engineering/distribution/observability/monitoring_pillars.md
+++ b/handbook/engineering/distribution/observability/monitoring_pillars.md
@@ -74,11 +74,13 @@ Consider "when the metric I am monitoring is bad, where do I want the site admin
 
 In other words, you should add the metric you are monitoring to an existing service's dashboard.
 
+This also allows our [high-level alerting metrics](https://docs.sourcegraph.com/admin/observability/metrics_guide), which are generated from the same observables that each dashboard is generated from, to describe the health of Sourcegraph per-service (instead of per-service + topic like "HTTP").
+
 ### FAQ: I have a purely information metric, I don't want to define an alert for it. How do I do that?
 
 This violates the second pillar of monitoring at Sourcegraph:
 
-> 2. Adding a graph/panel that visualizes a metric, without defining an associated alert, is forbidden.
+> Adding a graph/panel that visualizes a metric, without defining an associated alert, is forbidden.
 
 #### Why this is bad
 
@@ -89,6 +91,8 @@ By saying "I do not want to define an alert" what we are actually doing is shyin
 Our monitoring infrastructure _forces_ you to declare at least a _Warning_ alert. It's OK if this is flaky, or even if it fires when something is not wrong.
 
 The point is _you have to give a best-guess at what a bad or good value looks like because you are the only one who can answer that question._ Otherwise, the information you are 'monitoring' cannot be interpreted by anyone else and is inherently useless to anyone except you: it should not exist in a dashboard then.
+
+See also ["the difference between Warning and Critical alerts"](https://docs.sourcegraph.com/admin/observability/alerting_custom_consumption#the-difference-between-critical-and-warning-alerts) for how we communicate this to site admins.
 
 #### What you should do instead
 


### PR DESCRIPTION
I linked a bunch of people to https://about.sourcegraph.com/handbook/engineering/distribution/observability but it's a bit barebones right now and could use more direction on where to go:

![image](https://user-images.githubusercontent.com/3173176/82107715-aeee9980-96de-11ea-898a-fd1f0045f54c.png)

This adds that direction:

![image](https://user-images.githubusercontent.com/3173176/82107741-e0676500-96de-11ea-879c-9ffcce032077.png)

And additionally points people to some additional reading not mentioned in the developer guide, like (1) how high-level alerting metrics work and (2) the difference between Critical and Warning alerts and how admins consume those.

