### PR TITLE
Clarifying branching guidelines

### DIFF
--- a/handbook/people-ops/onboarding/git_intro.md
+++ b/handbook/people-ops/onboarding/git_intro.md
@@ -13,7 +13,7 @@ To visualize the git flow, there's [an article version](https://guides.github.co
 
 ## Unique to sourcegraph
 
-- For repositories such as `sourcegraph/sourcegraph` you should make pull requests from branches on the main repository instead of forking and making a pull request. This is due to how CI currently only runs on trusted contributors. See [external contributions](handbook/engineering/external_contributions.md)
+- For repositories such as `sourcegraph/sourcegraph` you should make pull requests from branches on the same repository instead of forking and making a pull request from your personal forks. This is because our CI currently only runs automatically for trusted contributors. See [external contributions](handbook/engineering/external_contributions.md) for more details.
 
 ## More information
 

--- a/handbook/people-ops/onboarding/git_intro.md
+++ b/handbook/people-ops/onboarding/git_intro.md
@@ -11,6 +11,10 @@ To visualize the git flow, there's [an article version](https://guides.github.co
 
 [Video introduction to GitHub](https://www.youtube.com/watch?v=sz6zfrQpCQg)
 
+## Unique to sourcegraph
+
+- For repositories such as `sourcegraph/sourcegraph` you should make pull requests from branches on the main repository instead of forking and making a pull request. This is due to how CI currently only runs on trusted contributors. See [external contributions](handbook/engineering/external_contributions.md)
+
 ## More information
 
 Once you have the basics down, you can look into the [full reference docs](https://git-scm.com/docs) and [glossary](https://git-scm.com/docs/gitglossary). 

--- a/handbook/people-ops/onboarding/git_intro.md
+++ b/handbook/people-ops/onboarding/git_intro.md
@@ -13,7 +13,7 @@ To visualize the git flow, there's [an article version](https://guides.github.co
 
 ## Unique to sourcegraph
 
-- For repositories such as `sourcegraph/sourcegraph` you should make pull requests from branches on the same repository instead of forking and making a pull request from your personal forks. This is because our CI currently only runs automatically for trusted contributors. See [external contributions](handbook/engineering/external_contributions.md) for more details.
+- For repositories such as `sourcegraph/sourcegraph` you should make pull requests from branches on the main repository instead of forking and making a pull request. This is due to how CI currently only runs on trusted contributors. See [external contributions](../../engineering/external_contributions.md)
 
 ## More information
 


### PR DESCRIPTION
Due to the current way Sourcegraph CI works we require members of
Sourcegraph to make branches on the main repository.

https://github.com/sourcegraph/sourcegraph/pull/10656#issuecomment-629258607