### PR TITLE
resources: Add redirects for pages previously reshuffled

### DIFF
--- a/_resources/assets/redirects
+++ b/_resources/assets/redirects
@@ -1,1 +1,5 @@
+/handbook/documentation /handbook/engineering/product_documentation 308
+/handbook/documentation/separate_website /handbook/engineering/distribution/separate_website 308
+/handbook/documentation/site /handbook/engineering/distribution/update_sourcegraph_website 308
+/handbook/engineering/go_style_guide /handbook/engineering/languages/go 308
 /handbook/values /company/values 308


### PR DESCRIPTION
These redirects correspond to dead links found in various bits of the main https://github.com/sourcegraph/sourcegraph repo. The sourcegraph PR that matches this is https://github.com/sourcegraph/sourcegraph/pull/10964.