### PR TITLE
create distribution tools section, add resources report docs

### DIFF
--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -77,6 +77,7 @@ Go, Docker, Kubernetes
 
 * [Recurring processes](./recurring_processes.md)
 * [Internal infrastructure](./internal_infrastructure.md)
+* [Tools](./tools/index.md)
 * Tutorials
   * [Observability developer guide](observability/index.md)
   * [How to set up a separate website maintained by Sourcegraph](separate_website.md)

--- a/handbook/engineering/distribution/tools/index.md
+++ b/handbook/engineering/distribution/tools/index.md
@@ -1,0 +1,5 @@
+# Distribution team tools
+
+Tooling owned by the distribution team.
+
+- [Resources report](./resources_report.md)

--- a/handbook/engineering/distribution/tools/resources_report.md
+++ b/handbook/engineering/distribution/tools/resources_report.md
@@ -1,0 +1,25 @@
+# Resources report tool [![Resources Report](https://github.com/sourcegraph/sourcegraph/workflows/Resources%20Report/badge.svg)](https://github.com/sourcegraph/sourcegraph/actions?query=workflow%3A%22Resources+Report%22)
+
+This tool reports on the status of various resources in AWS and GCP accounts. It runs on a regular basis as a GitHub Action and sends the results to the `#distributioneers` channel on a regular basis as a Google spreadsheet as a Slack message. The report can be accessed directly [here](https://docs.google.com/spreadsheets/d/1_bHvFXBVvtg3jOgq6fPuHFO0NlASW7SEJ3ip1bMuWJw/) as well, and the source code (and documentation on configuring the tool) is available [here](https://github.com/sourcegraph/sourcegraph/tree/master/internal/cmd/resources-report).
+
+## Using the report
+
+The generated report contains the following columns of note:
+
+| Column   | Notes
+|----------|---------
+| Platform | Either `gcp` ([Google Cloud Platform](https://console.cloud.google.com)) or `aws` ([Amazon Web Services](https://console.aws.amazon.com)).
+| Type     | Resource type - this value depends on the platform, but in general it will be `resource-category::resource-type`.
+| Location | The platform-provided region for the resource.
+| ID       | The platform-provided identifier for the resource.  The value of the ID can provide hints at why this resource was created and who owns it. This is the primary means through which you can query for this resource. In GCP, a search bar is provided at the top of the console - if the full ID value doesn't come up with a match, try a broader query by removing characters from the end of the ID). In AWS, you will have to find the appropriate service using the "Type" and make sure you are in the correct region based on the "Location" before you can filter for a resource using this ID.
+| Owner    | In GCP, this value corresponds to the project this resource belongs to. In AWS this value currently doesn't mean much.
+| Created  | UTC time at which this resource was created.
+| Meta     | Additional metadata - the main thing to look for here is `labels` (GCP) or `tags` (AWS), which can provide more hints at why this resource was created and who owns it.
+
+## Why isn't my resource in the report
+
+- the reporter currently only looks for VM instances, disks, and clusters - if a resource is not one of these types, the reporter will not pick it up
+- the reporter only looks for *active* resources - if a resource was created and destroyed before the reporter runs, it won't report it
+- the reporter can only see what it has permissions to see - make sure that the `resources-report` IAM is provided the [appropriate permissions](https://github.com/sourcegraph/sourcegraph/tree/master/internal/cmd/resources-report#authentication)
+
+To troubleshoot, refer to the [run logs](https://github.com/sourcegraph/sourcegraph/actions?query=workflow:%22Resources+Report%22) or try [running it directly](https://github.com/sourcegraph/sourcegraph/tree/master/internal/cmd/resources-report) to reproduce the issue.


### PR DESCRIPTION
closes #982 

added this in its own section because I imagine @uwedeportivo 's https://github.com/sourcegraph/sourcegraph/pull/10892 could use a section here, and we might have more tools worth documenting in the future