### PR TITLE
Add section on how to ignore editor config files

### DIFF
--- a/handbook/engineering/ignoring_editor_config_files.md
+++ b/handbook/engineering/ignoring_editor_config_files.md
@@ -9,7 +9,7 @@ You can ignore these in Git using one of two options:
 
 ## Why not commit .gitignore editor config files?
 
-There are many editors that produce repository config files, so if we commit them to .gitignore questions arise:
+There are many editors that produce repository config files, so if we commit them to `.gitignore` questions arise:
 
 - Do we do this for every editor people at Sourcegraph use?
 - How do we keep this `.gitignore` in sync with all the other repositories?

--- a/handbook/engineering/ignoring_editor_config_files.md
+++ b/handbook/engineering/ignoring_editor_config_files.md
@@ -1,0 +1,18 @@
+# Ignoring editor config files in Git
+
+Many editors create config files when working in a project directory. For example, the `.idea/` directory that IntelliJ creates.
+
+You can ignore these in Git using one of two options:
+
+- Globally, in all Git repositories via `~/.gitignore`
+- Per-repository, via `.git/info/exclude` (which is just like `.gitignore` but not committed to the repository)
+
+## Why not commit .gitignore editor config files?
+
+There are many editors that produce repository config files, so if we commit them to .gitignore questions arise:
+
+- Do we do this for every editor people at Sourcegraph use?
+- How do we keep this .gitignore in sync with all the other repositories?
+- When creating a new repository, what should go in .gitignore?
+
+Instead of maintaining all that, we keep things simple and do not commit editor configs, nor their exclusions, to `.gitignore` in the repository and configure it as part of our development environments instead.

--- a/handbook/engineering/ignoring_editor_config_files.md
+++ b/handbook/engineering/ignoring_editor_config_files.md
@@ -13,6 +13,6 @@ There are many editors that produce repository config files, so if we commit the
 
 - Do we do this for every editor people at Sourcegraph use?
 - How do we keep this `.gitignore` in sync with all the other repositories?
-- When creating a new repository, what should go in .gitignore?
+- When creating a new repository, what should go in `.gitignore`?
 
 Instead of maintaining all that, we keep things simple and do not commit editor configs, nor their exclusions, to `.gitignore` in the repository and configure it as part of our development environments instead.

--- a/handbook/engineering/ignoring_editor_config_files.md
+++ b/handbook/engineering/ignoring_editor_config_files.md
@@ -12,7 +12,7 @@ You can ignore these in Git using one of two options:
 There are many editors that produce repository config files, so if we commit them to .gitignore questions arise:
 
 - Do we do this for every editor people at Sourcegraph use?
-- How do we keep this .gitignore in sync with all the other repositories?
+- How do we keep this `.gitignore` in sync with all the other repositories?
 - When creating a new repository, what should go in .gitignore?
 
 Instead of maintaining all that, we keep things simple and do not commit editor configs, nor their exclusions, to `.gitignore` in the repository and configure it as part of our development environments instead.

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -13,6 +13,7 @@
 - [Product documentation](product_documentation.md)
 - [Continuous releasability](continuous_releasability.md)
 - [Commit message guidelines](commit_messages.md)
+- [Why we avoid committing .gitignore for editor config files](avoid_gitignore_editor_files.md)
 - [Incidents](incidents.md)
 - [Releases](releases/index.md)
   - [Release issue template](releases/release_issue_template.md)

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -13,7 +13,7 @@
 - [Product documentation](product_documentation.md)
 - [Continuous releasability](continuous_releasability.md)
 - [Commit message guidelines](commit_messages.md)
-- [Why we avoid committing .gitignore for editor config files](avoid_gitignore_editor_files.md)
+- [Ignoring editor config files](ignoring_editor_config_files.md)
 - [Incidents](incidents.md)
 - [Releases](releases/index.md)
   - [Release issue template](releases/release_issue_template.md)

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -13,7 +13,7 @@
 - [Product documentation](product_documentation.md)
 - [Continuous releasability](continuous_releasability.md)
 - [Commit message guidelines](commit_messages.md)
-- [Ignoring editor config files](ignoring_editor_config_files.md)
+- [Ignoring editor config files in Git](ignoring_editor_config_files.md)
 - [Incidents](incidents.md)
 - [Releases](releases/index.md)
   - [Release issue template](releases/release_issue_template.md)


### PR DESCRIPTION
I recently learned of `.git/info/exclude` and [saw others did, too.](https://sourcegraph.slack.com/archives/C07KZF47K/p1590196341451100) I also think `~/.gitignore` is not common-knowledge.

Additionally, I saw a PR was sent to exclude some editor config files from Git: https://github.com/sourcegraph/deploy-sourcegraph/pull/714

I figured documenting how to do this doesn't hurt, hence this PR :)