### PR TITLE
Additional changes to code-xy pages to improve readability

### DIFF
--- a/website/src/components/Jumbotron.tsx
+++ b/website/src/components/Jumbotron.tsx
@@ -33,7 +33,7 @@ export const Jumbotron: React.FunctionComponent<{
                 />
             )}
             <h1 className={titleClassName}>{title}</h1>
-            {description && <p className="mb-5">{description}</p>}
+            {description && <p>{description}</p>}
             {children}
         </div>
     </div>

--- a/website/src/css/components/actions/GetSourcegraphNowActions.tsx
+++ b/website/src/css/components/actions/GetSourcegraphNowActions.tsx
@@ -4,7 +4,7 @@ import { RequestDemoAction } from './RequestDemoAction'
 import { ViewDeveloperDocumentationAction } from './ViewDeveloperDocumentationAction'
 
 export const GetSourcegraphNowActions: React.FunctionComponent<any> = () => (
-    <div className="d-flex justify-content-center w-100 pt-2 mb-3">
+    <div className="d-flex justify-content-center w-100 pt-2 my-3">
         <div
             className="flex-0 rounded rounded-lg py-4 px-6"
             style={{

--- a/website/src/pages/product/code-discovery.tsx
+++ b/website/src/pages/product/code-discovery.tsx
@@ -4,7 +4,6 @@ import HistoryIcon from 'mdi-react/HistoryIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
 import StopwatchIcon from 'mdi-react/StopwatchIcon'
 import React from 'react'
-import { Blockquote } from '../../components/Blockquote'
 import { ContentPage } from '../../components/content/ContentPage'
 import { ContentSection } from '../../components/content/ContentSection'
 import { IconItem } from '../../components/IconItem'
@@ -12,36 +11,25 @@ import { Jumbotron } from '../../components/Jumbotron'
 import Layout from '../../components/Layout'
 import { PageSectionLinks } from '../../components/PageSectionLinks'
 import { EbookUniversalCodeSearch } from '../../components/product/EbookUniversalCodeSearch'
+import { IntegratesWithSection } from '../../components/product/IntegratesWithSection'
 import { OpenSourcePrivacyFeatureItem } from '../../components/product/OpenSourcePrivacyFeatureItem'
 import { SupportedProgrammingLanguagesLink } from '../../components/product/SupportedProgrammingLanguagesLink'
 import { UseCasesTable } from '../../components/product/UseCasesTable'
 import { YouTube } from '../../components/YouTube'
 import { GetSourcegraphNowActions } from '../../css/components/actions/GetSourcegraphNowActions'
-import { RequestDemoAction } from '../../css/components/actions/RequestDemoAction'
-import { ViewDeveloperDocumentationAction } from '../../css/components/actions/ViewDeveloperDocumentationAction'
 
 export default ((props: any) => (
     <Layout location={props.location}>
         <ContentPage
             title="Code discovery"
             description="Navigate, explore, and understand the code you are looking for, even if you didn’t know it existed."
-            mainActions={
-                <div className="d-flex flex-column align-items-center">
-                    <RequestDemoAction className="mt-3" />
-                    <ViewDeveloperDocumentationAction
-                        className="text-light mt-2"
-                        url="https://docs.sourcegraph.com/#quickstart"
-                    >
-                        Documentation &amp; self-service install
-                    </ViewDeveloperDocumentationAction>
-                </div>
-            }
         >
             <PageSectionLinks
                 sections={[
                     { text: 'Features', url: '#features' },
                     { text: 'Use cases', url: '#use-cases' },
                     { text: 'Demo screencasts', url: '#demo' },
+                    { text: 'Integrations', url: '#integrations' },
                 ]}
             />
             <ContentSection className="py-2" color="white">
@@ -253,7 +241,6 @@ export default ((props: any) => (
                     </div>
                 </div>
             </div>
-
             <ContentSection color="white" className="py-3">
                 <div className="row justify-content-center">
                     <div className="col-lg-10 text-center">
@@ -267,7 +254,6 @@ export default ((props: any) => (
                     </div>
                 </div>
             </ContentSection>
-
             <ContentSection color="black" className="py-6">
                 {/*<ProductDemoVideo title="See how Sourcegraph code search makes you a faster and better developer" />*/}
                 <h2 id="demo" className="text-center display-4 pb-4">
@@ -275,6 +261,10 @@ export default ((props: any) => (
                 </h2>
                 <YouTube id="OGd8wr7XpgU" className="mb-6" />
                 <YouTube id="GuqWw3t6H-k" />
+            </ContentSection>
+            <ContentSection color="white" className="pt-3">
+                <hr id="integrations" />
+                <IntegratesWithSection className="mt-4 pt-5 pb-6" />
             </ContentSection>
             <Jumbotron
                 color="purple"

--- a/website/src/pages/product/code-intelligence.tsx
+++ b/website/src/pages/product/code-intelligence.tsx
@@ -17,25 +17,12 @@ import { OpenSourcePrivacyFeatureItem } from '../../components/product/OpenSourc
 import { SupportedProgrammingLanguagesLink } from '../../components/product/SupportedProgrammingLanguagesLink'
 import { YouTube } from '../../components/YouTube'
 import { GetSourcegraphNowActions } from '../../css/components/actions/GetSourcegraphNowActions'
-import { RequestDemoAction } from '../../css/components/actions/RequestDemoAction'
-import { ViewDeveloperDocumentationAction } from '../../css/components/actions/ViewDeveloperDocumentationAction'
 
 export default ((props: any) => (
     <Layout location={props.location}>
         <ContentPage
             title="Code intelligence"
             description="Find answers faster, with inline contextual information around code."
-            mainActions={
-                <div className="d-flex flex-column align-items-center">
-                    <RequestDemoAction className="mt-3" />
-                    <ViewDeveloperDocumentationAction
-                        className="text-light mt-2"
-                        url="https://docs.sourcegraph.com/integration"
-                    >
-                        Code review integrations documentation
-                    </ViewDeveloperDocumentationAction>
-                </div>
-            }
         >
             <PageSectionLinks
                 sections={[
@@ -105,9 +92,9 @@ export default ((props: any) => (
                             <p>
                                 See a call to a function you don't recognize? With Sourcegraph, you can see its
                                 documentation and type signature by hovering over it&mdash;and go to its definition in a
-                                single click. Works for <SupportedProgrammingLanguagesLink />. Even if your IDE supports
-                                this, being able to do it in your web browser instantly without losing context saves
-                                tons of time&mdash;and helps you do more thorough reviews.
+                                single click. Even if your IDE supports this, being able to do it in your web browser
+                                instantly without losing context saves tons of time&mdash;and helps you do more thorough
+                                reviews. Works for <SupportedProgrammingLanguagesLink />.
                             </p>
                         </IconItem>
                     </div>

--- a/website/src/pages/product/code-review.tsx
+++ b/website/src/pages/product/code-review.tsx
@@ -29,7 +29,7 @@ export default ((props: any) => (
                 sections={[
                     { text: 'Why code review is critical', url: '#why' },
                     { text: 'Features', url: '#features' },
-                    { text: 'Demo screencasts', url: '#demo' },
+                    { text: 'Demo screencast', url: '#demo' },
                     { text: 'Integrations', url: '#integrations' },
                 ]}
             />
@@ -68,8 +68,8 @@ export default ((props: any) => (
                         <blockquote className="blockquote case-studies__quote case-studies__quote--in-content">
                             <p>
                                 The Sourcegraph integration [with GitLab] also adds inline code intelligence when you
-                                review code in merge requests which helps you speed up the review cycle and catch
-                                more bugs.
+                                review code in merge requests which helps you speed up the review cycle and catch more
+                                bugs.
                             </p>
                             <footer className="blockquote-footer">Sid Sijbrandij, GitLab CEO</footer>
                         </blockquote>
@@ -147,6 +147,10 @@ export default ((props: any) => (
                     </div>
                 </div>
             </ContentSection>
+            <ContentSection color="white" className="pt-3">
+                <hr id="integrations" />
+                <IntegratesWithSection className="mt-4 pt-5 pb-6" />
+            </ContentSection>
             <ContentSection color="black" className="py-6">
                 <h2 id="demo" className="text-center display-4 pb-4">
                     Better code reviews with the Sourcegraph browser extension
@@ -166,10 +170,6 @@ export default ((props: any) => (
                         </a>
                     </div>
                 </div>
-            </ContentSection>
-            <ContentSection color="white" className="pt-3">
-                <hr id="integrations" />
-                <IntegratesWithSection className="mt-4 pt-5 pb-6" />
             </ContentSection>
             <Jumbotron
                 color="purple"

--- a/website/src/pages/product/code-review.tsx
+++ b/website/src/pages/product/code-review.tsx
@@ -22,7 +22,7 @@ export default ((props: any) => (
     <Layout location={props.location}>
         <ContentPage
             title="Code review"
-            description="Make your code reviews fast and thorough so you can catch more bugs before they're deployed to production."
+            description="Make code reviews fast and thorough to catch more bugs before they're deployed to production."
             className="pb-2"
         >
             <PageSectionLinks

--- a/website/src/pages/product/code-review.tsx
+++ b/website/src/pages/product/code-review.tsx
@@ -13,34 +13,24 @@ import { Jumbotron } from '../../components/Jumbotron'
 import Layout from '../../components/Layout'
 import { PageSectionLinks } from '../../components/PageSectionLinks'
 import { EbookUniversalCodeSearch } from '../../components/product/EbookUniversalCodeSearch'
+import { IntegratesWithSection } from '../../components/product/IntegratesWithSection'
 import { SupportedProgrammingLanguagesLink } from '../../components/product/SupportedProgrammingLanguagesLink'
 import { YouTube } from '../../components/YouTube'
 import { GetSourcegraphNowActions } from '../../css/components/actions/GetSourcegraphNowActions'
-import { RequestDemoAction } from '../../css/components/actions/RequestDemoAction'
-import { ViewDeveloperDocumentationAction } from '../../css/components/actions/ViewDeveloperDocumentationAction'
 
 export default ((props: any) => (
     <Layout location={props.location}>
         <ContentPage
             title="Code review"
-            description="Better code reviews with code intelligence in context. Sourcegraph enhances your existing code review tool with inline code intelligence, helping you speed up the review cycle and catch more bugs before they're deployed to production."
-            mainActions={
-                <div className="d-flex flex-column align-items-center">
-                    <RequestDemoAction className="mt-3" />
-                    <ViewDeveloperDocumentationAction
-                        className="text-light mt-2"
-                        url="https://docs.sourcegraph.com/#quickstart"
-                    >
-                        Documentation &amp; self-service install
-                    </ViewDeveloperDocumentationAction>
-                </div>
-            }
+            description="Make your code reviews fast and thorough so you can catch more bugs before they're deployed to production."
+            className="pb-2"
         >
             <PageSectionLinks
                 sections={[
                     { text: 'Why code review is critical', url: '#why' },
                     { text: 'Features', url: '#features' },
-                    { text: 'Demo screencast', url: '#demo' },
+                    { text: 'Demo screencasts', url: '#demo' },
+                    { text: 'Integrations', url: '#integrations' },
                 ]}
             />
             <ContentSection color="white" className="py-2">
@@ -74,14 +64,14 @@ export default ((props: any) => (
                 </div>
                 <div className="row justify-content-center py-4">
                     <div className="col-lg-10 text-center">
-                        <img src="/external-logos/lyft-logo.svg" width="100px" />
+                        <img src="/external-logos/gitlab-logo.svg" width="125px" />
                         <blockquote className="blockquote case-studies__quote case-studies__quote--in-content">
                             <p>
-                                Sourcegraph [code search] … has made me insanely more productive and efficient at
-                                writing code here. I’m able to understand and deeply dive through all of our
-                                microservices and get my work done really fast.
+                                The Sourcegraph integration [with GitLab] also adds inline code intelligence when you
+                                review code in merge requests (MRs) which helps you speed up the review cycle and catch
+                                more bugs.
                             </p>
-                            <footer className="blockquote-footer">Lyft engineering manager</footer>
+                            <footer className="blockquote-footer">Sid Sijbrandij, GitLab CEO</footer>
                         </blockquote>
                     </div>
                 </div>
@@ -101,9 +91,9 @@ export default ((props: any) => (
                             <p>
                                 See a call to a function you don't recognize? With Sourcegraph, you can see its
                                 documentation and type signature by hovering over it&mdash;and go to its definition in a
-                                single click. Works for <SupportedProgrammingLanguagesLink />. Even if your IDE supports
-                                this, being able to do it in your web browser instantly without losing context saves
-                                tons of time&mdash;and helps you do more thorough reviews.
+                                single click. Even if your IDE supports this, being able to do it in your web browser
+                                instantly without losing context saves tons of time&mdash;and helps you do more thorough
+                                reviews. Works for <SupportedProgrammingLanguagesLink />.
                             </p>
                         </IconItem>
                     </div>
@@ -140,6 +130,23 @@ export default ((props: any) => (
             <ContentSection color="gray" className="py-6">
                 <EbookUniversalCodeSearch />
             </ContentSection>
+            <ContentSection color="black" className="py-6 text-center">
+                <h2 id="demo" className="display-4">
+                    Sourcegraph and GitLab
+                </h2>
+                <h3 class="pb-4">See code discovery and code review in action</h3>
+                <YouTube id="LgpuH2iaZ3w" />
+                <div className="row justify-content-center">
+                    <div className="col-lg-10 mt-2 py-4">
+                        <h5>
+                            Learn how{' '}
+                            <a href="/blog/gitlab-integrates-sourcegraph-code-navigation-and-code-intelligence">
+                                GitLab integrates with Sourcegraph
+                            </a>
+                        </h5>
+                    </div>
+                </div>
+            </ContentSection>
             <ContentSection color="black" className="py-6">
                 <h2 id="demo" className="text-center display-4 pb-4">
                     Better code reviews with the Sourcegraph browser extension
@@ -159,6 +166,10 @@ export default ((props: any) => (
                         </a>
                     </div>
                 </div>
+            </ContentSection>
+            <ContentSection color="white" className="pt-3">
+                <hr id="integrations" />
+                <IntegratesWithSection className="mt-4 pt-5 pb-6" />
             </ContentSection>
             <Jumbotron
                 color="purple"

--- a/website/src/pages/product/code-review.tsx
+++ b/website/src/pages/product/code-review.tsx
@@ -68,7 +68,7 @@ export default ((props: any) => (
                         <blockquote className="blockquote case-studies__quote case-studies__quote--in-content">
                             <p>
                                 The Sourcegraph integration [with GitLab] also adds inline code intelligence when you
-                                review code in merge requests (MRs) which helps you speed up the review cycle and catch
+                                review code in merge requests which helps you speed up the review cycle and catch
                                 more bugs.
                             </p>
                             <footer className="blockquote-footer">Sid Sijbrandij, GitLab CEO</footer>

--- a/website/src/pages/product/index.tsx
+++ b/website/src/pages/product/index.tsx
@@ -1,16 +1,14 @@
 import { Link } from 'gatsby'
-import MapIcon from 'mdi-react/MapIcon'
 import AutorenewIcon from 'mdi-react/AutorenewIcon'
+import MapIcon from 'mdi-react/MapIcon'
 import SearchIcon from 'mdi-react/SearchIcon'
 import ToolboxIcon from 'mdi-react/ToolboxIcon'
 import * as React from 'react'
-import { Blockquote } from '../../components/Blockquote'
 import { ContentPage } from '../../components/content/ContentPage'
 import { ContentSection } from '../../components/content/ContentSection'
 import { IconItem } from '../../components/IconItem'
 import { Jumbotron } from '../../components/Jumbotron'
 import Layout from '../../components/Layout'
-import { PageSectionLinks } from '../../components/PageSectionLinks'
 import { CustomerLogosSection } from '../../components/product/CustomerLogosSection'
 import { EbookUniversalCodeSearch } from '../../components/product/EbookUniversalCodeSearch'
 import { EnterpriseReadySolution } from '../../components/product/EnterpriseReadySolution'
@@ -45,14 +43,6 @@ export default ((props: any) => {
                 description="Explore, navigate, and understand all code, everywhere, faster"
                 mainActions={actions}
             >
-                <PageSectionLinks
-                    sections={[
-                        { text: 'Why universal', url: '#ucs' },
-                        { text: 'Features', url: '#features' },
-                        { text: 'Who uses it', url: '#customers' },
-                        { text: 'Integrations', url: '#integrations' },
-                    ]}
-                />
                 <ContentSection color="primary" className="py-5">
                     <span id="ucs" />
                     <h2 className="text-center">Universal across everything </h2>


### PR DESCRIPTION
 I updated code pages to improve readability for new visitors to the pages.  
On the code review page, I included an excerpt of the GitLab video which focuses on code discovery and code review.
https://deploy-preview-1055--sourcegraph.netlify.app/product/code-review
https://deploy-preview-1055--sourcegraph.netlify.app/product/code-discovery
https://deploy-preview-1055--sourcegraph.netlify.app/product/code-intelligence

Note: I did not remove the CTA demo request from the code change mgmt page since this feature is in beta.