### PR TITLE
team: Welcome to the Cloud, Dax

### DIFF
--- a/handbook/engineering/cloud/index.md
+++ b/handbook/engineering/cloud/index.md
@@ -21,6 +21,7 @@ We do [weekly check-ins](../tracking_issues.md#using-a-tracking-issue-for-progre
 - [Keegan Carruthers-Smith](../../../company/team/index.md#keegan-carruthers-smith) (dividing his time between this team and [search](../search/index.md))
 - [Joe Chen](../../../company/team/index.md#joe-chen)
 - [Ryan Slade](../../../company/team/index.md#ryan-slade)
+- [Dax McDonald](../../../company/team/index.md#dax-mcdonald-he-him)
 - [S. H.](https://hire.withgoogle.com/t/sourcegraphcom/hiring/candidates/P_AAAAAADAAC5PmuMMFoUSu3/P_AAAAAADAAC5KUwmkNJrovt) starting in July
 
 ## Hiring status

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -34,7 +34,7 @@ Distribution team members may also be involved in other areas of Sourcegraph not
         - Cloud-specific setup docs (AWS/Google Cloud)
         - Deployment setup & upgrade docs
         - **Primary owners:** @uwe, @geoffrey
-        - **Related code**: [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph), [cluster installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/install/cluster.md) 
+        - **Related code**: [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph), [cluster installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/install/cluster.md)
     - **Docker Compose & pure-docker installation & upgrade experience**
         - Docker-compose YAML & associated tooling
         - Pure-docker shell scripts & upgrade docs
@@ -93,7 +93,6 @@ Go, Docker, Kubernetes
 - [Geoffrey Gilmore](../../../company/team/index.md#geoffrey-gilmore)
 - [Uwe Hoffmann](../../../company/team/index.md#uwe-hoffmann)
 - [Dave Try](../../../company/team/index.md#dave-try)
-- [Dax McDonald](../../../company/team/index.md#dax-mcdonald-he-him)
 - [Robert Lin](../../../company/team/index.md#robert-lin) (2020 intern)
 
 ## Hiring status


### PR DESCRIPTION
This PR updates the handbook team pages to welcome Dax to the Cloud team.

He'll be helping with all things infrastructure in the context of the evolving [RFC 151 roadmap](https://docs.google.com/document/d/1qSSo83MJNcNbJhQOhDyHsGBCYPjyr7uhVQKGfZ8Vxfg/edit#heading=h.az00lc90wa5j), starting with [RFC 174 - HA Postgres](https://docs.google.com/document/d/1zNy-9QTAS4-i4C-ooFsfSwLf-kdnIJlTE8-uyub6-Ik).