### PR TITLE
Exchange feedback with candidates

### DIFF
--- a/handbook/people-ops/hiring.md
+++ b/handbook/people-ops/hiring.md
@@ -59,7 +59,7 @@ See [interview process](interview_process.md).
 
 We value transparency and like to exchange feedback with candidates.
 
-If you are a hiring manager who has decided to not move forward with a candidate at any stage in our hiring process, you are encourage to be as transparent as possible with the candidate when communicating the rejection. Use your judgement and ask for help crafting a message if you are unsure.
+If you are a hiring manager who has decided to not move forward with a candidate at any stage in our hiring process, you are encouraged to be as transparent as possible with the candidate when communicating the rejection. Use your judgement and ask for help crafting a message if you are unsure.
 
 If you are a candidate, we would love to know how you think we can make our hiring process better.
 

--- a/handbook/people-ops/hiring.md
+++ b/handbook/people-ops/hiring.md
@@ -55,18 +55,13 @@ For any members of a hiring team, please see [this folder](https://drive.google.
 
 See [interview process](interview_process.md).
 
-## Sharing interview feedback
+## Exchanging feedback
 
-We don't share specific reasons or feedback if we [decide](#decision-making-process) not to move forward in our hiring process with a candidate.
+We value transparency and like to exchange feedback with candidates.
 
-It would be nice if we could give feedback like this, but we don't do this today. Why?
+If you are a hiring manager who has decided to not move forward with a candidate at any stage in our hiring process, you are encourage to be as transparent as possible with the candidate when communicating the rejection. Use your judgement and ask for help crafting a message if you are unsure.
 
-- The written feedback that we collect during our interview process is intended for an internal audience. We don't ask our interviewers to spend time and effort packaging their feedback in a way that can be delivered directly to candidates.
-- Adequately summarizing all interview feedback for a candidate is challenging and time consuming. We choose to spend our time focusing on delivering developmental feedback to our existing teammates.
-
-If any interviewer is asked by a candidate for interview feedback, they may respond with the following message:
-
-> I understand the desire to receive feedback from our interview process, but unfortunately we are not in a position to give it. Here is some public documentation to that effect: https://about.sourcegraph.com/handbook/people-ops/hiring#sharing-interview-feedback.
+If you are a candidate, we would love to know how you think we can make our hiring process better.
 
 ## Respecting time
 


### PR DESCRIPTION
This PR is mostly to start a discussion (I didn't spend much time thinking about the words in the diff).

I think we should figure out how to exchange feedback with candidates.

1. We value people and transparency, and I think sharing feedback that we collect in our interview process would be something that makes our candidate experience exceptional. I have spoken with other engineering managers who have done this and made it part of their interview process (i.e., send feedback and see how candidates respond).
2. We should be more explicitly soliciting feedback from candidates on our interview process (we used to do surveys but haven't recently AFAIK), but this is hard to justify if we don't provide feedback ourselves.
3. Communicating reasons gives the candidate an understanding if/when they should apply again in the future, and also if they know of anyone who could be a better fit. I have had multiple candidates refer someone else after I rejected them and gave them specific reasons! Examples from the last month:

    > I wanted to say thank you again for your transparency, and for the nicest rejection letter I've ever received! ... I have been telling a few friends about ya'll
    
    > Understood and thanks for the follow up. I enjoyed chatting with you all. I may have a suggestion for someone that might be better for the role.

In practice, I think this means that hiring managers should:
1. Own sending rejection notes (not recruiting coordinator)
2. Have their own template in their own voice. That template should include a place to plug in custom context for that candidate.