### PR TITLE
update install links

### DIFF
--- a/blogposts/2020/announcing-sourcegraph-3.17.md
+++ b/blogposts/2020/announcing-sourcegraph-3.17.md
@@ -33,7 +33,7 @@ Sourcegraph couldn't be what it is without the community.
 
 </div>
 
-**Deploy or upgrade:** [Local](https://docs.sourcegraph.com/#quickstart-guide) | [AWS](https://github.com/sourcegraph/deploy-sourcegraph-aws) | [DigitalOcean](https://marketplace.digitalocean.com/apps/sourcegraph?action=deploy&refcode=48dfb3ccb51c) | [Kubernetes cluster](https://github.com/sourcegraph/deploy-sourcegraph)
+[**Install Sourcegraph 3.17**](https://docs.sourcegraph.com/admin/install) or [upgrade to Sourcegraph 3.17](https://docs.sourcegraph.com/admin/updates).
 
 ---
 


### PR DESCRIPTION
This links to the comprehensive docs for installing, instead of arbitrarily choosing different categories to mention in our blog post vs. our docs. (The blog post had "Local/AWS/DigitalOcean/Kubernetes cluster" vs. the docs' "Single-container server/Docker Compose/Kubernetes". The latter is better IMO.)

It also adds a link to upgrade, which was mentioned in the blog post but was not actually linked.