### PR TITLE
distribution roadmap

### DIFF
--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -79,10 +79,6 @@ Distribution team members may also be involved in other areas of Sourcegraph not
   - **Primary owners**: @stephen
   - **Related code**: [Jaeger Docker images and code](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:jaeger&patternType=literal), [opentracing code (broadly)](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+opentracing&patternType=literal), Jaeger [k8s](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph%24+jaeger&patternType=literal), [docker-compose/pure-docker](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph-docker%24+jaeger&patternType=literal), and [single-container](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server+jaeger&patternType=literal) deployments & [associated docs](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:doc/admin/observability+jaeger%7Ctracing&patternType=regexp)
 
-## Tech stack
-
-Go, Docker, Kubernetes
-
 ## Details
 
 - [Recurring processes](./recurring_processes.md)

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -99,7 +99,7 @@ Distribution team members may also be involved in other areas of Sourcegraph not
 - [Geoffrey Gilmore](../../../company/team/index.md#geoffrey-gilmore)
 - [Uwe Hoffmann](../../../company/team/index.md#uwe-hoffmann)
 - [Dave Try](../../../company/team/index.md#dave-try)
-- [Robert Lin](../../../company/team/index.md#robert-lin) (2020 intern)
+- [Robert Lin](../../../company/team/index.md#robert-lin) (internship)
 
 ## Hiring status
 

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -84,13 +84,16 @@ Distribution team members may also be involved in other areas of Sourcegraph not
 - [Recurring processes](./recurring_processes.md)
 - [Internal infrastructure](./internal_infrastructure.md)
 - [Tools](./tools/index.md)
-- Tutorials
-  - [Observability developer guide](observability/index.md)
-  - [How to set up a separate website maintained by Sourcegraph](separate_website.md)
-  - [How to replay a metrics dump from a customer](use_metrics_dump.md)
-  - [How to simulate k8s admin security restrictions](k8s_admin_custom_policy.md)
-  - [How to test the Gitlab native integration locally](gitlab_native_local.md)
-  - [How to make updates to global settings and configuration on sourcegraph.com](update_sourcegraph_website.md)
+- Guides
+  - General
+    - [Updating Sourcegraph.com site / global / external service configuration](update_sourcegraph_website.md)
+  - Development
+    - [Observability developer guide](observability/index.md)
+    - [Setting up a separate website maintained by Sourcegraph](separate_website.md)
+    - [Simulating Kubernetes admin security restrictions](k8s_admin_custom_policy.md)
+    - [Testing the GitLab native integration locally](gitlab_native_local.md)
+  - Debugging
+    - [Replaying metrics dumps from a customer](use_metrics_dump.md)
 
 ## Members
 

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -15,59 +15,59 @@ The following is a breakdown of the areas of Sourcegraph that the Distribution t
 Distribution team members may also be involved in other areas of Sourcegraph not mentioned here (i.e., you're not restricted just to the distribution team or working on just the areas of ownership assigned below.)
 
 - **Infrastructure**
-    - Sourcegraph.com
-    - Dogfood instances (k8s.sgdev.org, sourcegraph.sgdev.org)
-    - 3rd-party services (ghe.sgdev.org)
-    - Buildkite, CI pipeline / infrastructure.
-    - **Primary owners:** @geoffrey, @dave
-    - **Related code**: [infrastructure repository](https://github.com/sourcegraph/infrastructure), [CI pipeline code](https://sourcegraph.com/search?q=repo%3A%5Egithub%5C.com%2Fsourcegraph%2Fsourcegraph%24+file%3Abuild.sh%7C%2Fci%2F+count%3A1000&patternType=literal)
+  - Sourcegraph.com
+  - Dogfood instances (k8s.sgdev.org, sourcegraph.sgdev.org)
+  - 3rd-party services (ghe.sgdev.org)
+  - Buildkite, CI pipeline / infrastructure.
+  - **Primary owners:** @geoffrey, @dave
+  - **Related code**: [infrastructure repository](https://github.com/sourcegraph/infrastructure), [CI pipeline code](https://sourcegraph.com/search?q=repo%3A%5Egithub%5C.com%2Fsourcegraph%2Fsourcegraph%24+file%3Abuild.sh%7C%2Fci%2F+count%3A1000&patternType=literal)
 - **Release pipeline**
-    - End-to-end release process infrastructure
-    - Creating monthly releases
-    - Testing environments when applicable
-    - Releasing security updates when asked to
-    - **Primary owners:** @uwe
-    - **Related code**: [release captain experience](https://about.sourcegraph.com/handbook/engineering/releases#release-captain), [release tooling](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/release)
+  - End-to-end release process infrastructure
+  - Creating monthly releases
+  - Testing environments when applicable
+  - Releasing security updates when asked to
+  - **Primary owners:** @uwe
+  - **Related code**: [release captain experience](https://about.sourcegraph.com/handbook/engineering/releases#release-captain), [release tooling](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/release)
 - **Deployment**
-    - **Kubernetes cluster installation & upgrade experience**
-        - Kubernetes YAML & associated tooling
-        - Cloud-specific setup docs (AWS/Google Cloud)
-        - Deployment setup & upgrade docs
-        - **Primary owners:** @uwe, @geoffrey
-        - **Related code**: [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph), [cluster installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/install/cluster.md)
-    - **Docker Compose & pure-docker installation & upgrade experience**
-        - Docker-compose YAML & associated tooling
-        - Pure-docker shell scripts & upgrade docs
-        - Cloud-specific setup docs (AWS/Google Cloud)
-        - Deployment setup & upgrade docs
-        - **Primary owners**: @stephen, @geoffrey
-        - **Related code**: [deploy-sourcegraph-docker repository](https://github.com/sourcegraph/deploy-sourcegraph-docker), [docker-compose installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/doc/admin/install/docker-compose), [docker-compose upgrade docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/updates/docker_compose.md) [pure-docker upgrade docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/updates/pure_docker.md).
-    - **Single-container installation & upgrade experience**
-        - Primarily in maintenance mode
-        - Pushing admins to upgrade to Docker Compose
-        - Communicating the limitations of single-container deployments
-        - **Primary owners**: @stephen
-        - **Related code**: [cmd/server in main repo](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server/&patternType=regexp)
-    - **Scalability**
-        - Documenting when to upgrade from one deploy type to another
-        - Resource estimation for new deployments
-        - Scaling advice for existing deployments
-        - **Primary owners**: @stephen
-        - **Related code**: [resource estimator docs](https://docs.sourcegraph.com/admin/install/resource_estimator), [resource estimator repository](https://github.com/sourcegraph/resource-estimator), [Kubernetes scaling docs](https://docs.sourcegraph.com/admin/install/kubernetes/scale)
-- **Observability: Monitoring** ("site admins should easily know the health of Sourcegraph")
-    - Monitoring & alerting infrastructure
-    - Educating site admins about how to monitor Sourcegraph
-    - Working with & ensuring engineering @ Sourcegraph adds needed monitoring
-    - **Primary owners**: @stephen, @uwe
-    - **Related code**: [monitoring generator (dashboards/alerts)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/monitoring), [Grafana docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/grafana), [Prometheus docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/prometheus)
-- **Observability: Debugging** ("site admins should be able to collect the information needed to debug issues easily")
-    - Logging & Tracing infrastructure
-    - Working with & ensuring engineering @ Sourcegraph adds needed logging/tracing to debug issues
-    - Making the debugging process for common problems seamless and straightforward
-    - Making reporting issues with all needed information easy
-    - Ensuring logs/tracing are not overly verbose, identify most useful information for solving problems
+  - **Kubernetes cluster installation & upgrade experience**
+    - Kubernetes YAML & associated tooling
+    - Cloud-specific setup docs (AWS/Google Cloud)
+    - Deployment setup & upgrade docs
+    - **Primary owners:** @uwe, @geoffrey
+    - **Related code**: [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph), [cluster installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/install/cluster.md)
+  - **Docker Compose & pure-docker installation & upgrade experience**
+    - Docker-compose YAML & associated tooling
+    - Pure-docker shell scripts & upgrade docs
+    - Cloud-specific setup docs (AWS/Google Cloud)
+    - Deployment setup & upgrade docs
+    - **Primary owners**: @stephen, @geoffrey
+    - **Related code**: [deploy-sourcegraph-docker repository](https://github.com/sourcegraph/deploy-sourcegraph-docker), [docker-compose installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/doc/admin/install/docker-compose), [docker-compose upgrade docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/updates/docker_compose.md) [pure-docker upgrade docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/updates/pure_docker.md).
+  - **Single-container installation & upgrade experience**
+    - Primarily in maintenance mode
+    - Pushing admins to upgrade to Docker Compose
+    - Communicating the limitations of single-container deployments
     - **Primary owners**: @stephen
-    - **Related code**: [Jaeger Docker images and code](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:jaeger&patternType=literal), [opentracing code (broadly)](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+opentracing&patternType=literal), Jaeger [k8s](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph%24+jaeger&patternType=literal), [docker-compose/pure-docker](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph-docker%24+jaeger&patternType=literal), and [single-container](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server+jaeger&patternType=literal) deployments & [associated docs](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:doc/admin/observability+jaeger%7Ctracing&patternType=regexp)
+    - **Related code**: [cmd/server in main repo](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server/&patternType=regexp)
+  - **Scalability**
+    - Documenting when to upgrade from one deploy type to another
+    - Resource estimation for new deployments
+    - Scaling advice for existing deployments
+    - **Primary owners**: @stephen
+    - **Related code**: [resource estimator docs](https://docs.sourcegraph.com/admin/install/resource_estimator), [resource estimator repository](https://github.com/sourcegraph/resource-estimator), [Kubernetes scaling docs](https://docs.sourcegraph.com/admin/install/kubernetes/scale)
+- **Observability: Monitoring** ("site admins should easily know the health of Sourcegraph")
+  - Monitoring & alerting infrastructure
+  - Educating site admins about how to monitor Sourcegraph
+  - Working with & ensuring engineering @ Sourcegraph adds needed monitoring
+  - **Primary owners**: @stephen, @uwe
+  - **Related code**: [monitoring generator (dashboards/alerts)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/monitoring), [Grafana docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/grafana), [Prometheus docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/prometheus)
+- **Observability: Debugging** ("site admins should be able to collect the information needed to debug issues easily")
+  - Logging & Tracing infrastructure
+  - Working with & ensuring engineering @ Sourcegraph adds needed logging/tracing to debug issues
+  - Making the debugging process for common problems seamless and straightforward
+  - Making reporting issues with all needed information easy
+  - Ensuring logs/tracing are not overly verbose, identify most useful information for solving problems
+  - **Primary owners**: @stephen
+  - **Related code**: [Jaeger Docker images and code](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:jaeger&patternType=literal), [opentracing code (broadly)](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+opentracing&patternType=literal), Jaeger [k8s](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph%24+jaeger&patternType=literal), [docker-compose/pure-docker](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph-docker%24+jaeger&patternType=literal), and [single-container](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server+jaeger&patternType=literal) deployments & [associated docs](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:doc/admin/observability+jaeger%7Ctracing&patternType=regexp)
 
 ## Tech stack
 
@@ -75,16 +75,16 @@ Go, Docker, Kubernetes
 
 ## Details
 
-* [Recurring processes](./recurring_processes.md)
-* [Internal infrastructure](./internal_infrastructure.md)
-* [Tools](./tools/index.md)
-* Tutorials
-  * [Observability developer guide](observability/index.md)
-  * [How to set up a separate website maintained by Sourcegraph](separate_website.md)
-  * [How to replay a metrics dump from a customer](use_metrics_dump.md)
-  * [How to simulate k8s admin security restrictions](k8s_admin_custom_policy.md)
-  * [How to test the Gitlab native integration locally](gitlab_native_local.md)
-  * [How to make updates to global settings and configuration on sourcegraph.com](update_sourcegraph_website.md)
+- [Recurring processes](./recurring_processes.md)
+- [Internal infrastructure](./internal_infrastructure.md)
+- [Tools](./tools/index.md)
+- Tutorials
+  - [Observability developer guide](observability/index.md)
+  - [How to set up a separate website maintained by Sourcegraph](separate_website.md)
+  - [How to replay a metrics dump from a customer](use_metrics_dump.md)
+  - [How to simulate k8s admin security restrictions](k8s_admin_custom_policy.md)
+  - [How to test the Gitlab native integration locally](gitlab_native_local.md)
+  - [How to make updates to global settings and configuration on sourcegraph.com](update_sourcegraph_website.md)
 
 ## Members
 

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -8,6 +8,16 @@ The distribution team is responsible for making Sourcegraph easy to deploy, scal
 - File issues: [team/distribution](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/distribution) label
 - What we're currently working on: [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+label%3Ateam%2Fdistribution+label%3Atracking+distribution), [roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.mi8zg2ql2uc6)
 
+## Why the "Distribution" team, not the "SRE" team, "infrastructure" team, etc?
+
+The Distribution team, like most teams at Sourcegraph, is a goal-oriented team. Our ownership areas _include_ site reliability and infrastructure because those assist in achieving our true goals:
+
+1. Make deploying, upgrading, and managing Sourcegraph as easy as possible.
+2. Support the rapid distribution of software at Sourcegraph to our users.
+3. Advocate strongly on behalf of our users unique infrastructure requirements.
+
+This is an important distinction because it means our goals of site reliability and maintaining infrastructure are not inherently opposed to the rest of the engineering organization's goals to ship code changes frequently and iteratively, instead we are _in direct support of it_.
+
 ## Ownership areas
 
 The following is a breakdown of the areas of Sourcegraph that the Distribution team owns. It aims to be 100% comprehensive, but the owners are merely aspirational goal posts, not mandates. At the end of the day, whoever has most context will own the area.

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -94,7 +94,7 @@ Distribution team members may also be involved in other areas of Sourcegraph not
 
 ## Members
 
-- [G. P.](https://hire.lever.co/search/5f3b284f-04ce-4bdc-86ba-f9eed6a0ae9e) ([engineering manager](../roles.md#engineering-manager)) estimated start date in June.
+- [Gonzalo Peci](../../../company/team/index.md#gonalo-peci) ([engineering manager](../roles.md#engineering-manager))
 - [Stephen Gutekanst](../../../company/team/index.md#stephen-gutekanst) ([project lead](../roles.md#project-lead))
 - [Geoffrey Gilmore](../../../company/team/index.md#geoffrey-gilmore)
 - [Uwe Hoffmann](../../../company/team/index.md#uwe-hoffmann)

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -2,85 +2,19 @@
 
 The distribution team is responsible for making Sourcegraph easy to deploy, scale, monitor, and debug. We solve challenging problems that our customers face when they deploy and scale Sourcegraph on-premise in a variety of environments, and that we face when we deploy and scale [Sourcegraph.com](https://sourcegraph.com/search) (the largest Sourcegraph installation in the world).
 
-## Team API
+## Where to find us
 
-- Slack: #distributioneers channel or @distribution
-- File issues: [team/distribution](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/distribution) label
-- What we're currently working on: [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+label%3Ateam%2Fdistribution+label%3Atracking+distribution), [roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#heading=h.mi8zg2ql2uc6)
+- Slack: [#distributioneers](https://sourcegraph.slack.com/archives/CJX299FGE) channel or tag us using `@distribution
+- File issues for us to look at: add the [team/distribution](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/distribution) label
+- Get our attention on GitHub: tag @sourcegraph/distribution in your message
+- What we're working on: [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+label%3Ateam%2Fdistribution+label%3Atracking+distribution), [roadmap](./product/roadmap.md)
 
-## Why the "Distribution" team, not the "SRE" team, "infrastructure" team, etc?
+## Overview
 
-The Distribution team, like most teams at Sourcegraph, is a goal-oriented team. Our ownership areas _include_ site reliability and infrastructure because those assist in achieving our true goals:
-
-1. Make deploying, upgrading, and managing Sourcegraph as easy as possible.
-2. Support the rapid distribution of software at Sourcegraph to our users.
-3. Advocate strongly on behalf of our users unique infrastructure requirements.
-
-This is an important distinction because it means our goals of site reliability and maintaining infrastructure are not inherently opposed to the rest of the engineering organization's goals to ship code changes frequently and iteratively, instead we are _in direct support of it_.
-
-## Ownership areas
-
-The following is a breakdown of the areas of Sourcegraph that the Distribution team owns. It aims to be 100% comprehensive, but the owners are merely aspirational goal posts, not mandates. At the end of the day, whoever has most context will own the area.
-
-Distribution team members may also be involved in other areas of Sourcegraph not mentioned here (i.e., you're not restricted just to the distribution team or working on just the areas of ownership assigned below.)
-
-- **Infrastructure**
-  - Sourcegraph.com
-  - Dogfood instances (k8s.sgdev.org, sourcegraph.sgdev.org)
-  - 3rd-party services (ghe.sgdev.org)
-  - Buildkite, CI pipeline / infrastructure.
-  - **Primary owners:** @geoffrey, @dave
-  - **Related code**: [infrastructure repository](https://github.com/sourcegraph/infrastructure), [CI pipeline code](https://sourcegraph.com/search?q=repo%3A%5Egithub%5C.com%2Fsourcegraph%2Fsourcegraph%24+file%3Abuild.sh%7C%2Fci%2F+count%3A1000&patternType=literal)
-- **Release pipeline**
-  - End-to-end release process infrastructure
-  - Creating monthly releases
-  - Testing environments when applicable
-  - Releasing security updates when asked to
-  - **Primary owners:** @uwe
-  - **Related code**: [release captain experience](https://about.sourcegraph.com/handbook/engineering/releases#release-captain), [release tooling](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/release)
-- **Deployment**
-  - **Kubernetes cluster installation & upgrade experience**
-    - Kubernetes YAML & associated tooling
-    - Cloud-specific setup docs (AWS/Google Cloud)
-    - Deployment setup & upgrade docs
-    - **Primary owners:** @uwe, @geoffrey
-    - **Related code**: [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph), [cluster installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/install/cluster.md)
-  - **Docker Compose & pure-docker installation & upgrade experience**
-    - Docker-compose YAML & associated tooling
-    - Pure-docker shell scripts & upgrade docs
-    - Cloud-specific setup docs (AWS/Google Cloud)
-    - Deployment setup & upgrade docs
-    - **Primary owners**: @stephen, @geoffrey
-    - **Related code**: [deploy-sourcegraph-docker repository](https://github.com/sourcegraph/deploy-sourcegraph-docker), [docker-compose installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/doc/admin/install/docker-compose), [docker-compose upgrade docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/updates/docker_compose.md) [pure-docker upgrade docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/updates/pure_docker.md).
-  - **Single-container installation & upgrade experience**
-    - Primarily in maintenance mode
-    - Pushing admins to upgrade to Docker Compose
-    - Communicating the limitations of single-container deployments
-    - **Primary owners**: @stephen
-    - **Related code**: [cmd/server in main repo](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server/&patternType=regexp)
-  - **Scalability**
-    - Documenting when to upgrade from one deploy type to another
-    - Resource estimation for new deployments
-    - Scaling advice for existing deployments
-    - **Primary owners**: @stephen
-    - **Related code**: [resource estimator docs](https://docs.sourcegraph.com/admin/install/resource_estimator), [resource estimator repository](https://github.com/sourcegraph/resource-estimator), [Kubernetes scaling docs](https://docs.sourcegraph.com/admin/install/kubernetes/scale)
-- **Observability: Monitoring** ("site admins should easily know the health of Sourcegraph")
-  - Monitoring & alerting infrastructure
-  - Educating site admins about how to monitor Sourcegraph
-  - Working with & ensuring engineering @ Sourcegraph adds needed monitoring
-  - **Primary owners**: @stephen, @uwe
-  - **Related code**: [monitoring generator (dashboards/alerts)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/monitoring), [Grafana docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/grafana), [Prometheus docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/prometheus)
-- **Observability: Debugging** ("site admins should be able to collect the information needed to debug issues easily")
-  - Logging & Tracing infrastructure
-  - Working with & ensuring engineering @ Sourcegraph adds needed logging/tracing to debug issues
-  - Making the debugging process for common problems seamless and straightforward
-  - Making reporting issues with all needed information easy
-  - Ensuring logs/tracing are not overly verbose, identify most useful information for solving problems
-  - **Primary owners**: @stephen
-  - **Related code**: [Jaeger Docker images and code](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:jaeger&patternType=literal), [opentracing code (broadly)](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+opentracing&patternType=literal), Jaeger [k8s](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph%24+jaeger&patternType=literal), [docker-compose/pure-docker](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph-docker%24+jaeger&patternType=literal), and [single-container](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server+jaeger&patternType=literal) deployments & [associated docs](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:doc/admin/observability+jaeger%7Ctracing&patternType=regexp)
-
-## Details
-
+- Product
+  - ["Distribution is a product" & personas](product/index.md)
+  - [Product roadmap](product/roadmap.md)
+  - [Concrete ownership areas](product/ownership.md)
 - [Recurring processes](./recurring_processes.md)
 - [Internal infrastructure](./internal_infrastructure.md)
 - [Tools](./tools/index.md)
@@ -109,3 +43,13 @@ Distribution team members may also be involved in other areas of Sourcegraph not
 _Updated 2020-06-02_
 
 The team has doubled in size recently so it isn't a high priority to grow this team further, but we are always open to hiring exceptional people. [Apply here](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-distribution.md).
+
+## Why the "Distribution" team, not the "SRE" team, "infrastructure" team, etc?
+
+The Distribution team, like most teams at Sourcegraph, is a goal-oriented team. Our ownership areas _include_ site reliability and infrastructure because those assist in achieving our true goals:
+
+1. Make deploying, upgrading, and managing Sourcegraph as easy as possible.
+2. Support the rapid distribution of software at Sourcegraph to our users.
+3. Advocate strongly on behalf of our users unique infrastructure requirements.
+
+This is an important distinction because it means our goals of site reliability and maintaining infrastructure are not inherently opposed to the rest of the engineering organization's goals to ship code changes frequently and iteratively, instead we are _in direct support of it_.

--- a/handbook/engineering/distribution/product/index.md
+++ b/handbook/engineering/distribution/product/index.md
@@ -1,0 +1,34 @@
+# Sourcegraph Distribution product overview
+
+## The Distribution of Sourcegraph _is a product in itself_
+
+The distribution of Sourcegraph is, to a large extent, a [constraint satisfaction problem](https://en.wikipedia.org/wiki/Constraint_satisfaction_problem):
+
+- Non-opinionated site admins demand we guide them.
+- Opinionated site admins demand we support their extensive, unique, complex configurations.
+- Engineers at Sourcegraph demand we support quick, rapid, iteration.
+
+The third constraint can often feel at odds with the first two, and this is by design: we must find ways to support quick and rapid iteration while also supporting the expansive set of requirements from customers. This is no trivial task.
+
+These constraints are the reason that the distribution of Sourcegraph is a product in itself: we're not merely choosing the technology that one person wants, or even the technology that _we want_, but rather we have an extremely wide array of users (advanced and novice site admins, Sourcegraph engineers, etc.) with vastly different requirements and goals and we must identify the best way to support them all mutually.
+
+## Personas
+
+There are several site admins we aim to support:
+
+1. Non-opinionated, inexperienced site admins who just quickly want to get a taste of Sourcegraph.
+1. Opinionated, experienced site admins who demand we support their custom configuration and infrastructure requirements
+1. Non-opinionated, inexperienced site admins who go with our recommendations and require guidance/hand-holding. We're on the hook for anything that goes wrong.
+1. Non-opinionated site admins who have heavy Kubernetes infrastructure restrictions imposed on them
+1. Site admins who want a massive-scale deployment but cannot, or refuse to, use Kubernetes
+1. Site admins who want small-scale deployments but have higher expectations around stability and performance guarantees than most site admins on cluster deployments.
+
+Additionally we aim to support engineers in Sourcegraph:
+
+1. The Sourcegraph engineer trying to make some larger architecture change
+2. The Sourcegraph engineer trying to add or heavily scale a service
+3. The Sourcegraph engineer trying to perform some deeply complex data migration
+
+## Continue reading
+
+Return to the [Distribution team page](../index.md) to continue reading.

--- a/handbook/engineering/distribution/product/ownership.md
+++ b/handbook/engineering/distribution/product/ownership.md
@@ -1,0 +1,64 @@
+## Distribution ownership areas
+
+The following is a breakdown of the areas of Sourcegraph that the Distribution team owns. It aims to be 100% comprehensive, but the owners are merely aspirational goal posts, not mandates. At the end of the day, whoever has most context will own the area.
+
+Distribution team members may also be involved in other areas of Sourcegraph not mentioned here (i.e., you're not restricted just to the distribution team or working on just the areas of ownership assigned below.)
+
+- **Infrastructure**
+  - Sourcegraph.com
+  - Dogfood instances (k8s.sgdev.org, sourcegraph.sgdev.org)
+  - 3rd-party services (ghe.sgdev.org)
+  - Buildkite, CI pipeline / infrastructure.
+  - **Primary owners:** @geoffrey, @dave
+  - **Related code**: [infrastructure repository](https://github.com/sourcegraph/infrastructure), [CI pipeline code](https://sourcegraph.com/search?q=repo%3A%5Egithub%5C.com%2Fsourcegraph%2Fsourcegraph%24+file%3Abuild.sh%7C%2Fci%2F+count%3A1000&patternType=literal)
+- **Release pipeline**
+  - End-to-end release process infrastructure
+  - Creating monthly releases
+  - Testing environments when applicable
+  - Releasing security updates when asked to
+  - **Primary owners:** @uwe
+  - **Related code**: [release captain experience](https://about.sourcegraph.com/handbook/engineering/releases#release-captain), [release tooling](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/release)
+- **Deployment**
+  - **Kubernetes cluster installation & upgrade experience**
+    - Kubernetes YAML & associated tooling
+    - Cloud-specific setup docs (AWS/Google Cloud)
+    - Deployment setup & upgrade docs
+    - **Primary owners:** @uwe, @geoffrey
+    - **Related code**: [deploy-sourcegraph repository](https://github.com/sourcegraph/deploy-sourcegraph), [cluster installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/install/cluster.md)
+  - **Docker Compose & pure-docker installation & upgrade experience**
+    - Docker-compose YAML & associated tooling
+    - Pure-docker shell scripts & upgrade docs
+    - Cloud-specific setup docs (AWS/Google Cloud)
+    - Deployment setup & upgrade docs
+    - **Primary owners**: @stephen, @geoffrey
+    - **Related code**: [deploy-sourcegraph-docker repository](https://github.com/sourcegraph/deploy-sourcegraph-docker), [docker-compose installation docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/doc/admin/install/docker-compose), [docker-compose upgrade docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/updates/docker_compose.md) [pure-docker upgrade docs](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/doc/admin/updates/pure_docker.md).
+  - **Single-container installation & upgrade experience**
+    - Primarily in maintenance mode
+    - Pushing admins to upgrade to Docker Compose
+    - Communicating the limitations of single-container deployments
+    - **Primary owners**: @stephen
+    - **Related code**: [cmd/server in main repo](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server/&patternType=regexp)
+  - **Scalability**
+    - Documenting when to upgrade from one deploy type to another
+    - Resource estimation for new deployments
+    - Scaling advice for existing deployments
+    - **Primary owners**: @stephen
+    - **Related code**: [resource estimator docs](https://docs.sourcegraph.com/admin/install/resource_estimator), [resource estimator repository](https://github.com/sourcegraph/resource-estimator), [Kubernetes scaling docs](https://docs.sourcegraph.com/admin/install/kubernetes/scale)
+- **Observability: Monitoring** ("site admins should easily know the health of Sourcegraph")
+  - Monitoring & alerting infrastructure
+  - Educating site admins about how to monitor Sourcegraph
+  - Working with & ensuring engineering @ Sourcegraph adds needed monitoring
+  - **Primary owners**: @stephen, @uwe
+  - **Related code**: [monitoring generator (dashboards/alerts)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/monitoring), [Grafana docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/grafana), [Prometheus docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/prometheus)
+- **Observability: Debugging** ("site admins should be able to collect the information needed to debug issues easily")
+  - Logging & Tracing infrastructure
+  - Working with & ensuring engineering @ Sourcegraph adds needed logging/tracing to debug issues
+  - Making the debugging process for common problems seamless and straightforward
+  - Making reporting issues with all needed information easy
+  - Ensuring logs/tracing are not overly verbose, identify most useful information for solving problems
+  - **Primary owners**: @stephen
+  - **Related code**: [Jaeger Docker images and code](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:jaeger&patternType=literal), [opentracing code (broadly)](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+opentracing&patternType=literal), Jaeger [k8s](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph%24+jaeger&patternType=literal), [docker-compose/pure-docker](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph-docker%24+jaeger&patternType=literal), and [single-container](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server+jaeger&patternType=literal) deployments & [associated docs](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:doc/admin/observability+jaeger%7Ctracing&patternType=regexp)
+
+## Continue reading
+
+Return to the [Distribution team page](../index.md) to continue reading.

--- a/handbook/engineering/distribution/product/roadmap.md
+++ b/handbook/engineering/distribution/product/roadmap.md
@@ -12,46 +12,44 @@ At least this much is missing:
 
 ## Ordered & prioritized roadmap
 
-1. [Support customers in deploying Sourcegraph with 500k+ repositories](support-customers-in-deploying-sourcegraph-with-500k-repositories) (in progress)
-1. [Kubernetes upgrades should have less merge conflicts](#kubernetes-upgrades-should-have-less-merge-conflicts) (in progress)
-1. [Docker-compose is not released on time (on the 20th)](#docker-compose-is-not-released-on-time-on-the-20th) (delayed, overdue)
-1. [Releasing Sourcegraph should be automated](#releasing-sourcegraph-should-be-automated) (delayed)
-1. [Automatic e2e testing](#automatic-e2e-testing) (delayed)
-1. [Automatic Docker image testing](#automatic-docker-image-testing)
-1. [Upgrades across multiple Sourcegraph versions should be easier](#upgrades-across-multiple-sourcegraph-versions-should-be-easier)
-1. [Sourcegraph should be released daily](#sourcegraph-should-be-released-daily)
-1. [All site admins should have alerting set up to be notified when Sourcegraph is unhealthy](#all-site-admins-should-have-alerting-set-up-to-be-notified-when-sourcegraph-is-unhealthy)
-1. [Push site admins to use Docker Compose or Kubernetes for production deployments](#push-site-admins-to-use-docker-compose-or-kubernetes-for-production-deployments)
-1. [Add monitoring for common critical issues](#add-monitoring-for-common-critical-issues)
-1. [GitOps for all internal infrastructure](#gitops-for-all-internal-infrastructure)
+1. (Q1 2020) [Support customers in deploying Sourcegraph with 500k+ repositories](support-customers-in-deploying-sourcegraph-with-500k-repositories)
+1. (Q1 2020) [Kubernetes upgrades should have less merge conflicts](#kubernetes-upgrades-should-have-less-merge-conflicts)
+1. (Q1 2020) [Docker-compose is not released on time (on the 20th)](#docker-compose-is-not-released-on-time-on-the-20th)
+1. (Q1 2020) [Releasing Sourcegraph should be automated](#releasing-sourcegraph-should-be-automated)
+1. (Q1 2020) [Automatic e2e testing](#automatic-e2e-testing)
+1. (TBD) [Automatic Docker image testing](#automatic-docker-image-testing)
+1. (TBD) [Upgrades across multiple Sourcegraph versions should be easier](#upgrades-across-multiple-sourcegraph-versions-should-be-easier)
+1. (TBD) [Sourcegraph should be released daily](#sourcegraph-should-be-released-daily)
+1. (TBD) [All site admins should have alerting set up to be notified when Sourcegraph is unhealthy](#all-site-admins-should-have-alerting-set-up-to-be-notified-when-sourcegraph-is-unhealthy)
+1. (TBD) [Push site admins to use Docker Compose or Kubernetes for production deployments](#push-site-admins-to-use-docker-compose-or-kubernetes-for-production-deployments)
+1. (TBD) [Add monitoring for common critical issues](#add-monitoring-for-common-critical-issues)
+1. (TBD) [GitOps for all internal infrastructure](#gitops-for-all-internal-infrastructure)
 
 ## Details (unordered)
 
 ### Support customers in deploying Sourcegraph with 500k+ repositories
 
-We want to support a number of customers deploying Sourcegraph at large-scales with ~500k+ repositories.
+We have had customers interested in deploying Sourcegraph at large-scale with ~500k+ repositories and will need to dedicate time to supporting them and making their trials go smoothly.
 
 - Owner: Uwe and Dave
-- In progress: yes
+- Status: unplanned -> added unexpectedly to Q1 -> in-progress
+- [Tracking issue](https://github.com/sourcegraph/customer/issues/57)
+- Discussions: [Initial planning issue](https://github.com/sourcegraph/customer/issues/57), [discussion about costs at this scale](https://github.com/sourcegraph/customer/issues/20)
 - Dependencies: none
-- [Project board](https://github.com/orgs/sourcegraph/projects/69)
-- RFCs: [Initial planning issue](https://github.com/sourcegraph/customer/issues/57), [discussion about costs at this scale](https://github.com/sourcegraph/customer/issues/20)
 
 ### Kubernetes upgrades should have less merge conflicts
 
-Kubernetes upgrades involve a large number of merge conflicts which are extremely time consuming and tedious for customers to resolve.
+Kubernetes upgrades involve a large number of merge conflicts today which are extremely time consuming and tedious for customers to resolve, preventing them from upgrading as frequently as they should be and creating a large and painful support burden for us.
 
 - Owner: Geoffrey
 - Status: planned for Q1 -> in-progress
-- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+RFC+141+label%3ARFC-141)
+- [Tracking issue](https://github.com/orgs/sourcegraph/projects/68?card_filter_query=label%3Arfc-141)
 - Discussions: none
 - Dependencies: none
 
 ### CI infrastructure that can run Docker containers in a reliable way
 
-For automating the release Sourcegraph, e2e testing, and Docker image testing - we need CI infrastructure that can run Docker containers (and possibly VMs) in a reliable way.
-
-Today, we have a [side-car DIND container in our CI pipeline](https://sourcegraph.sgdev.org/search?q=repo:%5Esourcegraph/infrastructure%24+dind&patternType=literal) but it is flaky, unreliable, and a regular source of issues which has led to us removing automated testing (see [Automatic e2e testing](#automatic-e2e-testing))
+Today we cannot release of Sourcegraph, run e2e tests, or perform Docker image tests in an automated fashion because our CI infrastructure does not support running Docker containers (or VMs/Vagrant) in a reliable way. Today we have a [side-car DIND container in our CI pipeline](https://sourcegraph.sgdev.org/search?q=repo:%5Esourcegraph/infrastructure%24+dind&patternType=literal) but it is flaky, unreliable, and a regular source of issues which has led to us removing automated testing (see [Automatic e2e testing](#automatic-e2e-testing)).
 
 - Owner: Stephen
 - Status: planning soon
@@ -61,7 +59,7 @@ Today, we have a [side-car DIND container in our CI pipeline](https://sourcegrap
 
 ### Releasing Sourcegraph should be automated
 
-A monthly release takes ~2 days of a developers time, a patch release requires ~3 hours. We want to reduce that substantially.
+A monthly release takes ~2 days of a developers' time, a patch release requires ~3 hours. We want to reduce that substantially both in order to reduce the time we must invest each month, and to increase the release cadence of Sourcegraph substantially.
 
 - Owner: Stephen
 - Status: planned for Q1 -> delayed
@@ -72,7 +70,7 @@ A monthly release takes ~2 days of a developers time, a patch release requires ~
 
 ### Automatic e2e testing
 
-[RFC 137](https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit#heading=h.trqab8y0kufp) saw us remove our e2e tests from CI entirely because it was unreliable. Now e2e tests are ran as part of our monthly release process, and are heavily broken/outdated. Fixing them often takes ~1.5d of work. Per the RFC, we want a way to run e2e tests on CI reliably.
+[RFC 137](https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit#heading=h.trqab8y0kufp) saw us remove our e2e tests from CI entirely because it was unreliable. Now e2e tests are ran as part of our monthly release process completely manually, and are heavily broken/outdated each time we attempt to do it. Fixing them often takes ~1.5d of work from a developer on the team. Per the RFC, we want to run these e2e tests on CI in an automated and reliable fashion.
 
 - [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/10646)
 - Discussions: [RFC 137](https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit#heading=h.trqab8y0kufp)
@@ -83,14 +81,14 @@ A monthly release takes ~2 days of a developers time, a patch release requires ~
 
 ### Automatic Docker image testing
 
-Today we have a number of aspects about our Docker images that are not tested automatically:
+Customers rely on several important nuanced details about our Docker images:
 
 - Do upgrades and downgrades work as expected / per our documented policies?
 - Is the docker-compose.yml valid and does each service come up healthy?
 - Are UID/GIDs properly assigned and static?
 - Are all images versioned alongside Sourcegraph properly (and are the image tags correct)?
 
-These aspects should all be tested automatically in our CI pipelines.
+Testing these cases manually as we do today means it is easy to get things wrong and customer upgrades will go poorly, increasing our support burden substantially. Additionally, testing and accounting for these factors manually today slows down the release process and our ability to iterate quickly. We want to automate testing of all these factors.
 
 - Owner: Stephen
 - Status: not planned
@@ -101,7 +99,7 @@ These aspects should all be tested automatically in our CI pipelines.
 
 ### Docker-compose is not released on time (on the 20th)
 
-Docker-compose deployments were never properly integrated into our release process, and as such it has been released late (~1 week) after the 20th when we announce the new version of Sourcegraph the past ~4 releases.
+Docker-compose deployments were never properly integrated into our release process, and as such it has been released late by about one week after the official release date of 20th when the blog post announcement goes live. This has happened for the past ~4 releases. This has been a recurring problem for customers ("I can't upgrade it doesn't seem to be released"), which has increased support load, and has been a recurring worry from the CE team and others ("can I tell this customer to upgrade to fix their issue yet?").
 
 - Owner: Stephen
 - Status: planned for Q1 -> delayed -> overdue
@@ -111,7 +109,7 @@ Docker-compose deployments were never properly integrated into our release proce
 
 ### Upgrades across multiple Sourcegraph versions should be easier
 
-Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today which is extremely painful and time consuming for site admins.
+Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today (3.14 -> 3.15 -> 3.16 -> 3.17) which is extremely painful and time consuming for site admins, especially when one must also address the merge conflicts that occur on each upgrade. We would like to make upgrades across multiple Sourcegraph versions easier.
 
 - Owner: none
 - Status: not planned
@@ -121,7 +119,7 @@ Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today whi
 
 ### Sourcegraph should be released daily
 
-We release Sourcegraph monthly on the 20th, but want to get to daily releases so that `master` is always just as stable and reliable as our official monthly releases. We expect most customers will still only upgrade monthly, and we'll only advertise changes monthly. The goal is to make engineering more connected with customers so changes for customers do not sit in an unreleased state for a month.
+Engineers at Sourcegraph are not as connected to our customers as they could be, with some changes sitting idle for a while and engineers having to gauge the importance of a customer issue ("do I need to ask Distribution to create a release for this change, or can it wait until our next scheduled release on the 20th?") which harms the feedback cycle of the engineering organization as a whole and makes the CE teams' support work harder. We should get to a point where `master` is always in a polished releasable state and releases are created daily instead of only monthly on the 20th.
 
 - Owner: none
 - Status: not planned
@@ -133,17 +131,17 @@ We release Sourcegraph monthly on the 20th, but want to get to daily releases so
 
 ### All site admins should have alerting set up to be notified when Sourcegraph is unhealthy
 
+TODO(slimsag): spec this section out
+
 ### Prevent admins from missing manual migrations
 
-Today, Sourcegraph occasionally requires manual migrations. These are documented with the expectation that site admins review our documentation before attempting an upgrade. Missing a manual migration usually means some sort of downtime, sometimes not easily noticed. We would like to prevent this by making site admins explicitly acknowledge such manual migrations.
+Sourcegraph occasionally requires manual migrations when upgrading. These [are documented](https://docs.sourcegraph.com/admin/updates) with the expectation that site admins review our documentation before attempting an upgrade. Missing a manual migration usually means some sort of downtime, sometimes not easily noticed or easily fixed without the help of Sourcegraph. We would like to prevent this by making site admins explicitly acknowledge such manual migrations.
 
 - Owner: none
 - Status: not planned
 - Tracking issue: N/A
 - Discussions: [RFC 81](https://docs.google.com/document/d/1cDrQuLly_QZ_XoDDR41hgF3qCUGojvSXItI-knaBDY4/edit)
 - Dependencies:
-  - [Releasing Sourcegraph should be automated](#releasing-sourcegraph-should-be-automated)
-  - [5) Docker-compose is not released on time (on the 20th)](#5-docker-compose-is-not-released-on-time-on-the-20th)
 
 ### Add monitoring for common critical issues
 
@@ -151,17 +149,17 @@ While Sourcegraph does have built-in monitoring that is well-defined and works g
 
 - Owner: none
 - Status: not planned
-- [Tracking issue](https://github.com/sourcegraph/sourcegraph/labels/monitoring)
+- [Tracking issue](https://github.com/orgs/sourcegraph/projects/68?card_filter_query=label%3Amonitoring)
 - Discussions: none
 - Dependencies: none
 
 ### GitOps for all internal infrastructure
 
-We want to move to a world where all of Sourcegraphs' internal infrastructure is managed by GitOps, nobody has write access to GCP/GKE, and all changes have enforced review using a Git workflow.
+Today everyone has `kubectl` and direct access to our production clusters, and it is common to require manual changes or interaction with the cluster to perform ops duties. We want to move to a world where all Sourcegraph internal infrastructure (CI pipelines, Sourcegraph.com, etc.) is managed by Git Ops, nobody has write access to GCP/GKE, and all changes have enforced review using a Git workflow.
 
 - Owner: none
 - Status: not planned
-- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/10465) (related: [sourcegraph.com terraform configuration](https://github.com/sourcegraph/sourcegraph/issues/10455))
+- [Tracking issue](https://github.com/orgs/sourcegraph/projects/68?card_filter_query=label%3Agit-ops)
 - Discussions: none
 - Dependencies: none
 

--- a/handbook/engineering/distribution/product/roadmap.md
+++ b/handbook/engineering/distribution/product/roadmap.md
@@ -1,0 +1,89 @@
+# Distribution product roadmap
+
+This living document is the product roadmap for the Distribution team.
+
+It is longer-term than our quarterly OKRs, and higher-level than our GitHub issues. Additionally, it documents dependencies of roadmap items and current owners.
+
+## IMPORTANT: This is a WIP!
+
+At least this much is missing:
+
+- Dave/Uwe's support for \$CUSTOMER
+- Monitoring federation
+- Automated docker image testing
+- Upgrade/downgrade testing
+- Release smoke testing
+- Dockerless-CI infrastructure support
+- Improved GitOps internal Sourcegraph infrastructure
+- Likely many other important things
+
+## Prioritized roadmap
+
+1. [Kubernetes upgrades should have less merge conflicts](#kubernetes-upgrades-should-have-less-merge-conflicts) (in progress)
+1. [Docker-compose is not released on time (on the 20th)](#docker-compose-is-not-released-on-time-on-the-20th) (delayed, overdue)
+1. [Releasing Sourcegraph should be automated](#releasing-sourcegraph-should-be-automated) (delayed)
+1. [CI infrastructure should support running e2e tests in a reliable way](ci-infrastructure-should-support-running-e2e-tests-in-a-reliable-way) (delayed)
+1. [Upgrades across multiple Sourcegraph versions should be easier](#upgrades-across-multiple-sourcegraph-versions-should-be-easier)
+1. [Sourcegraph should be released daily](#sourcegraph-should-be-released-daily)
+1. [All site admins should have alerting set up to be notified when Sourcegraph is unhealthy](#all-site-admins-should-have-alerting-set-up-to-be-notified-when-sourcegraph-is-unhealthy)
+
+## Details (unordered)
+
+### Kubernetes upgrades should have less merge conflicts
+
+Kubernetes upgrades involve a large number of merge conflicts which are extremely time consuming and tedious for customers to resolve.
+
+- Owner: Geoffrey
+- In progress: yes
+- Dependencies: none
+- [GitHub issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+RFC+141+label%3ARFC-141)
+
+### Releasing Sourcegraph should be automated
+
+A monthly release takes ~2 days of a developers time, a patch release requires ~3 hours. We want to reduce that substantially.
+
+- Owner: Stephen
+- In progress: delayed
+- Dependencies:
+  - [CI infrastructure should support running e2e tests in a reliable way](ci-infrastructure-should-support-running-e2e-tests-in-a-reliable-way)
+
+### CI infrastructure should support running e2e tests in a reliable way
+
+[RFC 137](https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit#heading=h.trqab8y0kufp) saw us remove our e2e tests from CI entirely because it was unreliable. Now e2e tests are ran as part of our monthly release process, and are heavily broken/outdated. Fixing them often takes ~1.5d of work. Per the RFC, we want a way to run e2e tests on CI reliably.
+
+- Owner: Uwe
+- In progress: delayed
+- Dependencies: none
+
+### Docker-compose is not released on time (on the 20th)
+
+Docker-compose deployments were never properly integrated into our release process, and as such it has been released late (~1 week) after the 20th when we announce the new version of Sourcegraph the past ~4 releases.
+
+- Owner: Stephen
+- In progress: delayed, overdue
+- Dependencies:
+  - none
+
+### Upgrades across multiple Sourcegraph versions should be easier
+
+Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today which is extremely painful and time consuming for site admins.
+
+- Owner: none
+- In progress: no
+- Dependencies: none
+
+### Sourcegraph should be released daily
+
+We release Sourcegraph monthly on the 20th, but want to get to daily releases so that `master` is always just as stable and reliable as our official monthly releases. We expect most customers will still only upgrade monthly, and we'll only advertise changes monthly. The goal is to make engineering more connected with customers so changes for customers do not sit in an unreleased state for a month.
+
+- Owner: none
+- In progress: no
+- Dependencies:
+  - [Releasing Sourcegraph should be automated](#releasing-sourcegraph-should-be-automated)
+  - [5) Docker-compose is not released on time (on the 20th)](#5-docker-compose-is-not-released-on-time-on-the-20th)
+
+### All site admins should have alerting set up to be notified when Sourcegraph is unhealthy
+
+## Continue reading
+
+Return to the [Distribution team page](../index.md) to continue reading.

--- a/handbook/engineering/distribution/product/roadmap.md
+++ b/handbook/engineering/distribution/product/roadmap.md
@@ -4,12 +4,6 @@ This living document is the product roadmap for the Distribution team.
 
 It is longer-term than our quarterly OKRs, and higher-level than our GitHub issues. Additionally, it documents dependencies of roadmap items and current owners.
 
-## IMPORTANT: This is a WIP!
-
-At least this much is missing:
-
-- Monitoring federation
-
 ## Ordered & prioritized roadmap
 
 1. (Q1 2020) [Support customers in deploying Sourcegraph with 500k+ repositories](support-customers-in-deploying-sourcegraph-with-500k-repositories)
@@ -23,6 +17,7 @@ At least this much is missing:
 1. (TBD) [All site admins should have alerting set up to be notified when Sourcegraph is unhealthy](#all-site-admins-should-have-alerting-set-up-to-be-notified-when-sourcegraph-is-unhealthy)
 1. (TBD) [Push site admins to use Docker Compose or Kubernetes for production deployments](#push-site-admins-to-use-docker-compose-or-kubernetes-for-production-deployments)
 1. (TBD) [Add monitoring for common critical issues](#add-monitoring-for-common-critical-issues)
+1. (TBD) [Monitoring federation](#monitoring-federation)
 1. (TBD) [GitOps for all internal infrastructure](#gitops-for-all-internal-infrastructure)
 
 ## Details (unordered)
@@ -131,7 +126,23 @@ Engineers at Sourcegraph are not as connected to our customers as they could be,
 
 ### All site admins should have alerting set up to be notified when Sourcegraph is unhealthy
 
-TODO(slimsag): spec this section out
+TODO(slimsag): explain this
+
+- Owner: Robert
+- Status: in progress
+- [Tracking issue](https://github.com/orgs/sourcegraph/projects/68?card_filter_query=label%3Amonitoring-for-all)
+- Discussions: TODO
+- Dependencies: none
+
+### Monitoring federation
+
+TODO(slimsag): explain this
+
+- Owner: none
+- Status: not planned
+- Tracking issue: TODO
+- Discussions: TODO
+- Dependencies: none
 
 ### Prevent admins from missing manual migrations
 
@@ -139,7 +150,7 @@ Sourcegraph occasionally requires manual migrations when upgrading. These [are d
 
 - Owner: none
 - Status: not planned
-- Tracking issue: N/A
+- Tracking issue: TODO
 - Discussions: [RFC 81](https://docs.google.com/document/d/1cDrQuLly_QZ_XoDDR41hgF3qCUGojvSXItI-knaBDY4/edit)
 - Dependencies:
 

--- a/handbook/engineering/distribution/product/roadmap.md
+++ b/handbook/engineering/distribution/product/roadmap.md
@@ -8,68 +8,116 @@ It is longer-term than our quarterly OKRs, and higher-level than our GitHub issu
 
 At least this much is missing:
 
-- Dave/Uwe's support for \$CUSTOMER
 - Monitoring federation
-- Automated docker image testing
-- Upgrade/downgrade testing
-- Release smoke testing
-- Dockerless-CI infrastructure support
 - Improved GitOps internal Sourcegraph infrastructure
 - Likely many other important things
 
-## Prioritized roadmap
+## Ordered & prioritized roadmap
 
+1. [Support customers in deploying Sourcegraph with 500k+ repositories](support-customers-in-deploying-sourcegraph-with-500k-repositories) (in progress)
 1. [Kubernetes upgrades should have less merge conflicts](#kubernetes-upgrades-should-have-less-merge-conflicts) (in progress)
 1. [Docker-compose is not released on time (on the 20th)](#docker-compose-is-not-released-on-time-on-the-20th) (delayed, overdue)
 1. [Releasing Sourcegraph should be automated](#releasing-sourcegraph-should-be-automated) (delayed)
-1. [CI infrastructure should support running e2e tests in a reliable way](ci-infrastructure-should-support-running-e2e-tests-in-a-reliable-way) (delayed)
+1. [Automatic e2e testing](#automatic-e2e-testing) (delayed)
+1. [Automatic Docker image testing](#automatic-docker-image-testing)
 1. [Upgrades across multiple Sourcegraph versions should be easier](#upgrades-across-multiple-sourcegraph-versions-should-be-easier)
 1. [Sourcegraph should be released daily](#sourcegraph-should-be-released-daily)
 1. [All site admins should have alerting set up to be notified when Sourcegraph is unhealthy](#all-site-admins-should-have-alerting-set-up-to-be-notified-when-sourcegraph-is-unhealthy)
+1. [Add monitoring for common critical issues](#add-monitoring-for-common-critical-issues)
+1. [GitOps for all internal infrastructure](#gitops-for-all-internal-infrastructure)
 
 ## Details (unordered)
+
+### Support customers in deploying Sourcegraph with 500k+ repositories
+
+We want to support a number of customers deploying Sourcegraph at large-scales with ~500k+ repositories.
+
+- Owner: Uwe and Dave
+- In progress: yes
+- Dependencies: none
+- [Project board](https://github.com/orgs/sourcegraph/projects/69)
+- RFCs: [Initial planning issue](https://github.com/sourcegraph/customer/issues/57), [discussion about costs at this scale](https://github.com/sourcegraph/customer/issues/20)
 
 ### Kubernetes upgrades should have less merge conflicts
 
 Kubernetes upgrades involve a large number of merge conflicts which are extremely time consuming and tedious for customers to resolve.
 
 - Owner: Geoffrey
-- In progress: yes
+- Status: planned for Q1 -> in-progress
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+RFC+141+label%3ARFC-141)
+- Discussions: none
 - Dependencies: none
-- [GitHub issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+RFC+141+label%3ARFC-141)
+
+### CI infrastructure that can run Docker containers in a reliable way
+
+For automating the release Sourcegraph, e2e testing, and Docker image testing - we need CI infrastructure that can run Docker containers (and possibly VMs) in a reliable way.
+
+Today, we have a [side-car DIND container in our CI pipeline](https://sourcegraph.sgdev.org/search?q=repo:%5Esourcegraph/infrastructure%24+dind&patternType=literal) but it is flaky, unreliable, and a regular source of issues which has led to us removing automated testing (see [Automatic e2e testing](#automatic-e2e-testing))
+
+- Owner: Stephen
+- Status: planning soon
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/6887)
+- Discussions: none
+- Dependencies: none
 
 ### Releasing Sourcegraph should be automated
 
 A monthly release takes ~2 days of a developers time, a patch release requires ~3 hours. We want to reduce that substantially.
 
 - Owner: Stephen
-- In progress: delayed
+- Status: planned for Q1 -> delayed
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/9252)
+- Discussions: none
 - Dependencies:
   - [CI infrastructure should support running e2e tests in a reliable way](ci-infrastructure-should-support-running-e2e-tests-in-a-reliable-way)
 
-### CI infrastructure should support running e2e tests in a reliable way
+### Automatic e2e testing
 
 [RFC 137](https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit#heading=h.trqab8y0kufp) saw us remove our e2e tests from CI entirely because it was unreliable. Now e2e tests are ran as part of our monthly release process, and are heavily broken/outdated. Fixing them often takes ~1.5d of work. Per the RFC, we want a way to run e2e tests on CI reliably.
 
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/10646)
+- Discussions: [RFC 137](https://docs.google.com/document/d/14f7lwfToeT6t_vxnGsCuXqf3QcB5GRZ2Zoy6kYqBAIQ/edit#heading=h.trqab8y0kufp)
 - Owner: Uwe
-- In progress: delayed
-- Dependencies: none
+- Status: planned for Q1 -> delayed
+- Dependencies:
+  - [CI infrastructure that can run Docker containers in a reliable way](#ci-infrastructure-that-can-run-docker-containers-in-a-reliable-way)
+
+### Automatic Docker image testing
+
+Today we have a number of aspects about our Docker images that are not tested automatically:
+
+- Do upgrades and downgrades work as expected / per our documented policies?
+- Is the docker-compose.yml valid and does each service come up healthy?
+- Are UID/GIDs properly assigned and static?
+- Are all images versioned alongside Sourcegraph properly (and are the image tags correct)?
+
+These aspects should all be tested automatically in our CI pipelines.
+
+- Owner: Stephen
+- Status: not planned
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/10646)
+- Discussions: none
+- Dependencies:
+  - [CI infrastructure that can run Docker containers in a reliable way](#ci-infrastructure-that-can-run-docker-containers-in-a-reliable-way)
 
 ### Docker-compose is not released on time (on the 20th)
 
 Docker-compose deployments were never properly integrated into our release process, and as such it has been released late (~1 week) after the 20th when we announce the new version of Sourcegraph the past ~4 releases.
 
 - Owner: Stephen
-- In progress: delayed, overdue
-- Dependencies:
-  - none
+- Status: planned for Q1 -> delayed -> overdue
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/10486)
+- Discussions: none
+- Dependencies: none
 
 ### Upgrades across multiple Sourcegraph versions should be easier
 
 Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today which is extremely painful and time consuming for site admins.
 
 - Owner: none
-- In progress: no
+- Status: not planned
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/10144)
+- Discussions: none
 - Dependencies: none
 
 ### Sourcegraph should be released daily
@@ -77,12 +125,110 @@ Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today whi
 We release Sourcegraph monthly on the 20th, but want to get to daily releases so that `master` is always just as stable and reliable as our official monthly releases. We expect most customers will still only upgrade monthly, and we'll only advertise changes monthly. The goal is to make engineering more connected with customers so changes for customers do not sit in an unreleased state for a month.
 
 - Owner: none
-- In progress: no
+- Status: not planned
+- Tracking issue: N/A
+- Discussions: [part of RFC 128](https://docs.google.com/document/d/1YHYxx63jxEyLb3Hs7VnzZcASQXn3dWb6IUyQXvP2i30) [RFC 60 ABANDONED: Introduce a bi-weekly release cadence](https://docs.google.com/document/d/1-K3RhlX7VNWR-jmJFSniZatGkZ8-KGsyVAhH68u0iN8/edit#heading=h.53phut6pq63o)
 - Dependencies:
   - [Releasing Sourcegraph should be automated](#releasing-sourcegraph-should-be-automated)
   - [5) Docker-compose is not released on time (on the 20th)](#5-docker-compose-is-not-released-on-time-on-the-20th)
 
 ### All site admins should have alerting set up to be notified when Sourcegraph is unhealthy
+
+### Prevent admins from missing manual migrations
+
+Today, Sourcegraph occasionally requires manual migrations. These are documented with the expectation that site admins review our documentation before attempting an upgrade. Missing a manual migration usually means some sort of downtime, sometimes not easily noticed. We would like to prevent this by making site admins explicitly acknowledge such manual migrations.
+
+- Owner: none
+- Status: not planned
+- Tracking issue: N/A
+- Discussions: [RFC 81](https://docs.google.com/document/d/1cDrQuLly_QZ_XoDDR41hgF3qCUGojvSXItI-knaBDY4/edit)
+- Dependencies:
+  - [Releasing Sourcegraph should be automated](#releasing-sourcegraph-should-be-automated)
+  - [5) Docker-compose is not released on time (on the 20th)](#5-docker-compose-is-not-released-on-time-on-the-20th)
+
+### Add monitoring for common critical issues
+
+While Sourcegraph does have built-in monitoring that is well-defined and works generally well, there are large gaps in several areas for common critical issues such as repositories failing to clone, repositories being deleted en-mass, search indexing failing, containers/services being unreachable, and much more.
+
+- Owner: none
+- Status: not planned
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/labels/monitoring)
+- Discussions: none
+- Dependencies: none
+
+### GitOps for all internal infrastructure
+
+We want to move to a world where all of Sourcegraphs' internal infrastructure is managed by GitOps, nobody has write access to GCP/GKE, and all changes have enforced review using a Git workflow.
+
+- Owner: none
+- Status: not planned
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/10465) (related: [sourcegraph.com terraform configuration](https://github.com/sourcegraph/sourcegraph/issues/10455))
+- Discussions: none
+- Dependencies: none
+
+## Completed
+
+This section outlines completed roadmap items, in most-recently-completed order.
+
+1. (Q1 2020) [Push admins to upgrade more frequently](#push-admins-to-upgrade-more-frequently)
+1. (Q4 2019) [Support process changes](#support-process-changes)
+1. (Q4 2019) [Deploy Jaeger tracing by default in all deployment types](#deploy-jaeger-tracing-by-default-in-all-deployment-types)
+1. (Q4 2019) [Remove the management console entirely](#remove-the-management-console-entirely)
+1. (Q4 2019) [Authless management console access](#authless-management-console-access)
+1. (Q4 2019) [Deploy Jaeger tracing by default in all deployment types](#)
+1. ...this document was created Q1 2020, many items completed before then not included here that should be added...
+
+## Completed details (unordered)
+
+### Push admins to upgrade more frequently
+
+See [RFC 80: Push users to upgrade more frequently](https://docs.google.com/document/d/17WamvKWQjEkzhun3za9KS2t5Anm9ey8ws4D0tz4xPkY/edit) for details.
+
+- Owner: Stephen
+- Status: planned for Q4 2019 -> delayed -> implemented
+- Tracking issue: N/A
+- Discussions: [RFC 80: Push users to upgrade more frequently](https://docs.google.com/document/d/17WamvKWQjEkzhun3za9KS2t5Anm9ey8ws4D0tz4xPkY/edit)
+- Dependencies: none
+
+### Support process changes
+
+See [RFC 117 Private: Support process changes](https://docs.google.com/document/d/12nCg0OuZsrWCB3_nN_F0duu5sxGXUgPbBRoqbxj8a2A/edit) for details.
+
+- Owner: Stephen
+- Status: planned for Q4 2019 -> implemented
+- Tracking issue: N/A
+- Discussions: [RFC 117 Private: Support process changes](https://docs.google.com/document/d/12nCg0OuZsrWCB3_nN_F0duu5sxGXUgPbBRoqbxj8a2A/edit)
+- Dependencies: none
+
+### Deploy Jaeger tracing by default in all deployment types
+
+See [issue #9300](https://github.com/sourcegraph/sourcegraph/issues/9300) for details.
+
+- Owner: Stephen
+- Status: planned for Q4 2019 -> implemented
+- Tracking issue: N/A
+- Discussions: [issue #9300](https://github.com/sourcegraph/sourcegraph/issues/9300)
+- Dependencies: none
+
+### Remove the management console entirely
+
+See [Proposal PR: Remove the management console (🦄unicorns and 🌈rainbows here)](https://github.com/sourcegraph/sourcegraph/pull/7197) for details.
+
+- Owner: Stephen
+- Status: unplanned -> implemented
+- Tracking issue: N/A
+- Discussions: [Proposal PR: Remove the management console (🦄unicorns and 🌈rainbows here)](https://github.com/sourcegraph/sourcegraph/pull/7197)
+- Dependencies: none
+
+### Authless management console access
+
+See [RFC 63: Authless management console access](https://docs.google.com/document/d/1RkOS4EehLtAXhunTazkjCI4yKi5Hc8eRcHZ_v1Fz_QU/edit) for details.
+
+- Owner: Stephen
+- Status: planned for Q4 2019 -> implemented
+- Tracking issue: N/A
+- Discussions: [RFC 63: Authless management console access](https://docs.google.com/document/d/1RkOS4EehLtAXhunTazkjCI4yKi5Hc8eRcHZ_v1Fz_QU/edit)
+- Dependencies: none
 
 ## Continue reading
 

--- a/handbook/engineering/distribution/product/roadmap.md
+++ b/handbook/engineering/distribution/product/roadmap.md
@@ -9,8 +9,6 @@ It is longer-term than our quarterly OKRs, and higher-level than our GitHub issu
 At least this much is missing:
 
 - Monitoring federation
-- Improved GitOps internal Sourcegraph infrastructure
-- Likely many other important things
 
 ## Ordered & prioritized roadmap
 
@@ -23,6 +21,7 @@ At least this much is missing:
 1. [Upgrades across multiple Sourcegraph versions should be easier](#upgrades-across-multiple-sourcegraph-versions-should-be-easier)
 1. [Sourcegraph should be released daily](#sourcegraph-should-be-released-daily)
 1. [All site admins should have alerting set up to be notified when Sourcegraph is unhealthy](#all-site-admins-should-have-alerting-set-up-to-be-notified-when-sourcegraph-is-unhealthy)
+1. [Push site admins to use Docker Compose or Kubernetes for production deployments](#push-site-admins-to-use-docker-compose-or-kubernetes-for-production-deployments)
 1. [Add monitoring for common critical issues](#add-monitoring-for-common-critical-issues)
 1. [GitOps for all internal infrastructure](#gitops-for-all-internal-infrastructure)
 
@@ -163,6 +162,16 @@ We want to move to a world where all of Sourcegraphs' internal infrastructure is
 - Owner: none
 - Status: not planned
 - [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/10465) (related: [sourcegraph.com terraform configuration](https://github.com/sourcegraph/sourcegraph/issues/10455))
+- Discussions: none
+- Dependencies: none
+
+### Push site admins to use Docker Compose or Kubernetes for production deployments
+
+Many customers of Sourcegraph today are still running a single-container `sourcegraph/server` deployment in production. We recently began advising all new deployments that this deployment option is _not_ for production use because it has no proper resource isolation and as such when it falls over it is impossible to debug, leading to painstakingly urgent migrations to better deployment types and frustrated/angry customers. We would like to get to a world where all production instances of Sourcegraph are Docker Compose or Kubernetes only.
+
+- Owner: none
+- Status: not planned
+- [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/11828)
 - Discussions: none
 - Dependencies: none
 


### PR DESCRIPTION
This is an early draft, I hope to finish this by EOW.

I suggest reading these two first:

- https://github.com/sourcegraph/about/blob/sg/distribution-roadmap/handbook/engineering/distribution/index.md#why-the-distribution-team-not-the-sre-team-infrastructure-team-etc
- https://github.com/sourcegraph/about/blob/sg/distribution-roadmap/handbook/engineering/distribution/product/index.md

Then I suggest reading the actual product roadmap:

- https://github.com/sourcegraph/about/blob/sg/distribution-roadmap/handbook/engineering/distribution/product/roadmap.md

@pecigonzalo please spam me with as many questions/comments as you have, or we can go over this live soon :)