### PR TITLE
Add Gonzalo Peci to Team page

### DIFF
--- a/company/team/index.md
+++ b/company/team/index.md
@@ -7,6 +7,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 ## Full Name (optional pronouns)
 
 - Describe how to pronounce your name
+- Team
 - Role(s)
 - City, region, country, country flag emoji
 - [you@sourcegraph.com](mailto:you@sourcegraph.com), other social media links (if any)
@@ -309,6 +310,15 @@ To add yourself to this page, copy the following template, paste it at the end o
 - New York, NY, USA 🇺🇸
 - [christine@sourcegraph.com](mailto:christine@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/lovettchristine/), [GitHub](https://github.com/christinelovett)
 - Christine is a biking, music and general fun enthusiast who likes to balance her travels exploring nature and city. Before Sourcegraph, Christine spent a few years in sales, then software development- ultimately merging her skillset in customer engingeering roles at Docker and Google. She has a strong appreciation for modern development tools and reducing friction in IT.
+
+## Gonzalo Peci (he/him)
+
+- [Distribution](../../handbook/engineering/distribution/index.md) - Engineering Manager
+- Palma de Mallorca, Balearic Islands, Spain, :es:
+- [gonzalo@sourcegraph.com](mailto:gonzalo@sourcegraph.com), [LinkedIn](https://linkedin.com/in/pecig), [GitHub](https://github.com/pecigonzalo), [pronounce my name 🔊](https://www.youtube.com/watch?v=4reRML9gTc4)
+- Gonzalo is originally from Argentina but has been moving around the world since 2012. He enojoys playing video games, traveling and reading. Recentrly he started playing the bass :guitar: and has a Metal/Punk garage band. He has an infrastructure background and has
+gone down the tech rabbithole so he started learning programming and other tools :nerd_face:.
+
 
 <!-- Paste *your* section above this line by following our template below:
 

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -314,7 +314,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [Distribution](../../handbook/engineering/distribution/index.md) - Engineering Manager
 - Palma de Mallorca, Balearic Islands, Spain, 🇪🇸
 - [gonzalo@sourcegraph.com](mailto:gonzalo@sourcegraph.com), [LinkedIn](https://linkedin.com/in/pecig), [GitHub](https://github.com/pecigonzalo), [pronounce my name 🔊](https://www.youtube.com/watch?v=4reRML9gTc4)
-- Gonzalo is originally from Argentina but has been moving around the world since 2012. He enojoys playing video games, traveling and reading. Recentrly he started playing the bass :guitar: and has a Metal/Punk garage band. He has an infrastructure background and has
+- Gonzalo is originally from Argentina but has been moving around the world since 2012. He enjoys playing video games, traveling and reading. Recently he started playing the bass 🎸 and has a Metal/Punk garage band. He has an infrastructure background and has
   gone down the tech rabbithole so he started learning programming and other tools :nerd_face:.
 
 <!-- Paste *your* section above this line by following our template below:

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -158,11 +158,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - VP Enterprise Sales
 - Nashville, Tennessee, USA 🇺🇸
 - [julia@sourcegraph.com](mailto:julia@sourcegraph.com), [@JuliaSourceress](https://twitter.com/JuliaSourceress), [LinkedIn](https://www.linkedin.com/in/juliagilinets/), [GitHub](https://github.com/juliasourceress)
-- Julia started out as a Software Engineer supporting the developer community at Palm, which to the generations of today might be thought of as mobile before mobile. She realized she loved forging business partnerships just as much as coding, and after over a decade of leading various customer facing teams has finally landed in the best of all worlds at Sourcegraph. She's passionate about technical innovation, efficiency, the human connection, and sleep. 
+- Julia started out as a Software Engineer supporting the developer community at Palm, which to the generations of today might be thought of as mobile before mobile. She realized she loved forging business partnerships just as much as coding, and after over a decade of leading various customer facing teams has finally landed in the best of all worlds at Sourcegraph. She's passionate about technical innovation, efficiency, the human connection, and sleep.
 
 ## Adam Herzog (he/him)
 
-- Product Marketing Manager 
+- Product Marketing Manager
 - San Francisco, CA, USA 🇺🇸
 - [herzog@sourcegraph.com](mailto:herzog@sourcegraph.com), [@ah3rz](https://twitter.com/ah3rz), [LinkedIn](https://www.linkedin.com/in/herzogadam/)
 - Adam is an experienced developer marketer, now focusing on product marketing at Sourcegraph. He's previously led developer relations, digital demand generation, and other marketing functions at companies like Docker, Humio, and Neo4j. Adam advocates for inclusivity 🌈 within the entire tech industry (and the world!) and probably uses the word "awesome" too much. He is passionate about good food, Hatha yoga, and jean jackets in no particular order.
@@ -238,7 +238,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [dave@sourcegraph.com](mailto:dave@sourcegraph.com), [GitHub](https://github.com/davejrt)
 - Dave likes riding his bike up hill, drinking coffee and travelling. After graduating University and getting his start as a Unix system administrator, he still has a soft spot for Solaris and enjoys solving problems on large scale infrastructure.
 
-## Dax McDonald (he/him) 
+## Dax McDonald (he/him)
 
 - Software Engineer
 - Phoenix, AZ, USA 🇺🇸
@@ -301,14 +301,14 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Developer Communications
 - Annapolis, Maryland, USA 🇺🇸
 - [laureen@sourcegraph.com](mailto:laureen@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/laureenhudson/), [GitHub](https://github.com/LaureenH)
-- Laureen is a technical and developmental editor; also a storyteller, writer, publisher, enthusiastic geek enabler, autodidact, activist, and instigator. She lives aboard a 47' catamaran with her family, and if she’s not online, it’s probably because she’s crossing an ocean. 
+- Laureen is a technical and developmental editor; also a storyteller, writer, publisher, enthusiastic geek enabler, autodidact, activist, and instigator. She lives aboard a 47' catamaran with her family, and if she’s not online, it’s probably because she’s crossing an ocean.
 
 ## Christine Lovett (she/her)
 
-- Customer Engineer 
+- Customer Engineer
 - New York, NY, USA 🇺🇸
 - [christine@sourcegraph.com](mailto:christine@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/lovettchristine/), [GitHub](https://github.com/christinelovett)
-- Christine is a biking, music and general fun enthusiast who likes to balance her travels exploring nature and city. Before Sourcegraph, Christine spent a few years in sales, then software development- ultimately merging her skillset in customer engingeering roles at Docker and Google. She has a strong appreciation for modern development tools and reducing friction in IT. 
+- Christine is a biking, music and general fun enthusiast who likes to balance her travels exploring nature and city. Before Sourcegraph, Christine spent a few years in sales, then software development- ultimately merging her skillset in customer engingeering roles at Docker and Google. She has a strong appreciation for modern development tools and reducing friction in IT.
 
 <!-- Paste *your* section above this line by following our template below:
 

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -315,7 +315,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Palma de Mallorca, Balearic Islands, Spain, 🇪🇸
 - [gonzalo@sourcegraph.com](mailto:gonzalo@sourcegraph.com), [LinkedIn](https://linkedin.com/in/pecig), [GitHub](https://github.com/pecigonzalo), [pronounce my name 🔊](https://www.youtube.com/watch?v=4reRML9gTc4)
 - Gonzalo is originally from Argentina but has been moving around the world since 2012. He enjoys playing video games, traveling and reading. Recently he started playing the bass 🎸 and has a Metal/Punk garage band. He has an infrastructure background and has
-  gone down the tech rabbithole so he started learning programming and other tools :nerd_face:.
+  gone down the tech rabbit hole so he started learning programming and other tools :nerd_face:.
 
 <!-- Paste *your* section above this line by following our template below:
 

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -7,8 +7,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 ## Full Name (optional pronouns)
 
 - Describe how to pronounce your name
-- Team
-- Role(s)
+- Team - Role(s)
 - City, region, country, country flag emoji
 - [you@sourcegraph.com](mailto:you@sourcegraph.com), other social media links (if any)
 - Name pronunciation (record an audio file from your phone [here](https://www.name-coach.com/))
@@ -131,7 +130,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Senior Digital Marketing Manager
 - San Carlos, CA and Bainbridge Island, WA USA 🇺🇸
 - [aileen@sourcegraph.com](mailto:aileen@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/aileenagricola)
-- Aileen is a techie at heart with a foundation in IT and databases. Her first startup experience was at Patrol Software where she got the startup buzz to try out multiple roles in customer support, product management, business development and sales.   Most recently, she built the website for [Neo4j](https://neo4j.com) and learned that everything is connected.  In her spare time she keeps active by hiking, running or biking.  She also loves to travel and binges the best in streaming tv.
+- Aileen is a techie at heart with a foundation in IT and databases. Her first startup experience was at Patrol Software where she got the startup buzz to try out multiple roles in customer support, product management, business development and sales. Most recently, she built the website for [Neo4j](https://neo4j.com) and learned that everything is connected. In her spare time she keeps active by hiking, running or biking. She also loves to travel and binges the best in streaming tv.
 
 ## Adam Frankl (he/him)
 
@@ -222,11 +221,11 @@ To add yourself to this page, copy the following template, paste it at the end o
 - SDR
 - Phoenix AZ, USA 🇺🇸
 - [quin@sourcegraph.com](mailto:quin@sourcegraph.com), [quinwith1n](https://github.com/qwith1n)
-- Quin has always loved traveling and seeing the world. He lives in Phoenix with his wife and 2 french bulldogs.  Quin also enjoys most sports, especially ping pong, reading, and playing his guitar.  Although his French bulldogs do not enjoy it when he attempts to play the guitar.
+- Quin has always loved traveling and seeing the world. He lives in Phoenix with his wife and 2 french bulldogs. Quin also enjoys most sports, especially ping pong, reading, and playing his guitar. Although his French bulldogs do not enjoy it when he attempts to play the guitar.
 
 ## Asdine El Hrychy
 
-- First name is pronounced *as-deen*, last name *el-ree-tchee*
+- First name is pronounced _as-deen_, last name _el-ree-tchee_
 - Software Engineer
 - Ajaccio, France 🇫🇷/ Dubai, UAE 🇦🇪
 - [asdine@sourcegraph.com](mailto:asdine@sourcegraph.com), [asdine](https://github.com/asdine)
@@ -252,15 +251,14 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Lynnwood, WA, USA 🇺🇸
 - [simon@sourcegraph.com](mailto:simon@sourcegraph.com), [Github](https://github.com/twop), [Twitter](https://twitter.com/twopSK)
 - Simon is interested in programming languages (especially functional ones), type systems, new technologies(WebAssembly) and performance. His top 3 favorite programming languages: Rust, Elm, TypeScript. Outside of work he enjoys exploring gorgeus Pacific Northwest outdoors with his wife and daughter. Interesting fact: he used to be a semiprofessional
- gamer (Magic: the Gathering) and a game developer at the same time.
+  gamer (Magic: the Gathering) and a game developer at the same time.
 
 ## Robert Lin
 
 - Software Engineer Intern
 - Vancouver, BC, Canada 🇨🇦
 - [robert@sourcegraph.com](mailto:robert@sourcegraph.com), [GitHub](https://github.com/bobheadxi), [LinkedIn](https://github.com/bobheadxi)
-- If it involves moving without *too* much thinking, Robert enjoys it: running, climbing, swimming, and more. He is in his final year studying mathematics at the University of British Columbia, but on the side he loves dabbling in building tooling, web interfaces, and writing.
-
+- If it involves moving without _too_ much thinking, Robert enjoys it: running, climbing, swimming, and more. He is in his final year studying mathematics at the University of British Columbia, but on the side he loves dabbling in building tooling, web interfaces, and writing.
 
 ## Marek Zaluski
 
@@ -281,7 +279,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Enterprise Account Executive
 - Orange County, CA 🇺🇸
 - [nick.kunszt@sourcegraph.com](mailto:nick.kunszt@sourcegraph.com), [GitHub](https://github.com/Nick-Kunszt)
-- Nick enjoys playing music, soaking in the California sun, and spending QT with friends and family. Before joining Sourcegraph, Nick spent the last 7 years at Google formalizing digital marketing and analytics solutions to companies ranging from start-ups to Fortune 500's.  He is passionate about forming long term relationships, solving business challenges by providing exceptional customer experience, and delivering data-driven results.
+- Nick enjoys playing music, soaking in the California sun, and spending QT with friends and family. Before joining Sourcegraph, Nick spent the last 7 years at Google formalizing digital marketing and analytics solutions to companies ranging from start-ups to Fortune 500's. He is passionate about forming long term relationships, solving business challenges by providing exceptional customer experience, and delivering data-driven results.
 
 ## Mark Muldez (he/him)
 
@@ -317,8 +315,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Palma de Mallorca, Balearic Islands, Spain, :es:
 - [gonzalo@sourcegraph.com](mailto:gonzalo@sourcegraph.com), [LinkedIn](https://linkedin.com/in/pecig), [GitHub](https://github.com/pecigonzalo), [pronounce my name 🔊](https://www.youtube.com/watch?v=4reRML9gTc4)
 - Gonzalo is originally from Argentina but has been moving around the world since 2012. He enojoys playing video games, traveling and reading. Recentrly he started playing the bass :guitar: and has a Metal/Punk garage band. He has an infrastructure background and has
-gone down the tech rabbithole so he started learning programming and other tools :nerd_face:.
-
+  gone down the tech rabbithole so he started learning programming and other tools :nerd_face:.
 
 <!-- Paste *your* section above this line by following our template below:
 

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -315,7 +315,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Palma de Mallorca, Balearic Islands, Spain, 🇪🇸
 - [gonzalo@sourcegraph.com](mailto:gonzalo@sourcegraph.com), [LinkedIn](https://linkedin.com/in/pecig), [GitHub](https://github.com/pecigonzalo), [pronounce my name 🔊](https://www.youtube.com/watch?v=4reRML9gTc4)
 - Gonzalo is originally from Argentina but has been moving around the world since 2012. He enjoys playing video games, traveling and reading. Recently he started playing the bass 🎸 and has a Metal/Punk garage band. He has an infrastructure background and has
-  gone down the tech rabbit hole and learned programming languages :nerd_face:.
+  gone down the tech rabbit hole and learned programming languages 🤓.
 
 <!-- Paste *your* section above this line by following our template below:
 

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -315,7 +315,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 ## Full Name (optional pronouns)
 
 - Describe how to pronounce your name
-- Role(s)
+- Team - Role(s)
 - City, region, country, country flag emoji
 - [you@sourcegraph.com](mailto:you@sourcegraph.com), other social media links (if any)
 - Bio (hobbies, work experience, family, pets, etc.)

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -312,7 +312,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 ## Gonzalo Peci (he/him)
 
 - [Distribution](../../handbook/engineering/distribution/index.md) - Engineering Manager
-- Palma de Mallorca, Balearic Islands, Spain, :es:
+- Palma de Mallorca, Balearic Islands, Spain, 🇪🇸
 - [gonzalo@sourcegraph.com](mailto:gonzalo@sourcegraph.com), [LinkedIn](https://linkedin.com/in/pecig), [GitHub](https://github.com/pecigonzalo), [pronounce my name 🔊](https://www.youtube.com/watch?v=4reRML9gTc4)
 - Gonzalo is originally from Argentina but has been moving around the world since 2012. He enojoys playing video games, traveling and reading. Recentrly he started playing the bass :guitar: and has a Metal/Punk garage band. He has an infrastructure background and has
   gone down the tech rabbithole so he started learning programming and other tools :nerd_face:.

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -7,7 +7,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 ## Full Name (optional pronouns)
 
 - Describe how to pronounce your name
-- Team - Role(s)
+- Role(s)
 - City, region, country, country flag emoji
 - [you@sourcegraph.com](mailto:you@sourcegraph.com), other social media links (if any)
 - Name pronunciation (record an audio file from your phone [here](https://www.name-coach.com/))
@@ -311,7 +311,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 ## Gonzalo Peci (he/him)
 
-- [Distribution](../../handbook/engineering/distribution/index.md) - Engineering Manager
+- Engineering Manager
 - Palma de Mallorca, Balearic Islands, Spain, 🇪🇸
 - [gonzalo@sourcegraph.com](mailto:gonzalo@sourcegraph.com), [LinkedIn](https://linkedin.com/in/pecig), [GitHub](https://github.com/pecigonzalo), [pronounce my name 🔊](https://www.youtube.com/watch?v=4reRML9gTc4)
 - Gonzalo is originally from Argentina but has been moving around the world since 2012. He enjoys playing video games, traveling and reading. Recently he started playing the bass 🎸 and has a Metal/Punk garage band. He has an infrastructure background and has
@@ -322,7 +322,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 ## Full Name (optional pronouns)
 
 - Describe how to pronounce your name
-- Team - Role(s)
+- Role(s)
 - City, region, country, country flag emoji
 - [you@sourcegraph.com](mailto:you@sourcegraph.com), other social media links (if any)
 - Bio (hobbies, work experience, family, pets, etc.)

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -315,7 +315,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 - Palma de Mallorca, Balearic Islands, Spain, 🇪🇸
 - [gonzalo@sourcegraph.com](mailto:gonzalo@sourcegraph.com), [LinkedIn](https://linkedin.com/in/pecig), [GitHub](https://github.com/pecigonzalo), [pronounce my name 🔊](https://www.youtube.com/watch?v=4reRML9gTc4)
 - Gonzalo is originally from Argentina but has been moving around the world since 2012. He enjoys playing video games, traveling and reading. Recently he started playing the bass 🎸 and has a Metal/Punk garage band. He has an infrastructure background and has
-  gone down the tech rabbit hole so he started learning programming and other tools :nerd_face:.
+  gone down the tech rabbit hole and learned programming languages :nerd_face:.
 
 <!-- Paste *your* section above this line by following our template below:
 

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -88,7 +88,7 @@ Go, Docker, Kubernetes
 
 ## Members
 
-- [Gonzalo Peci](../../../company/team/index.md#gonzalo-peci-hehim) ([engineering manager](../roles.md#engineering-manager)) estimated start date in June.
+- [Gonzalo Peci](../../../company/team/index.md#gonzalo-peci-hehim) ([engineering manager](../roles.md#engineering-manager)).
 - [Stephen Gutekanst](../../../company/team/index.md#stephen-gutekanst) ([project lead](../roles.md#project-lead))
 - [Geoffrey Gilmore](../../../company/team/index.md#geoffrey-gilmore)
 - [Uwe Hoffmann](../../../company/team/index.md#uwe-hoffmann)

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -88,7 +88,7 @@ Go, Docker, Kubernetes
 
 ## Members
 
-- [G. P.](https://hire.lever.co/search/5f3b284f-04ce-4bdc-86ba-f9eed6a0ae9e) ([engineering manager](../roles.md#engineering-manager)) estimated start date in June.
+- [Gonzalo Peci](../../../company/team/index.md#gonzalo-peci-hehim) ([engineering manager](../roles.md#engineering-manager)) estimated start date in June.
 - [Stephen Gutekanst](../../../company/team/index.md#stephen-gutekanst) ([project lead](../roles.md#project-lead))
 - [Geoffrey Gilmore](../../../company/team/index.md#geoffrey-gilmore)
 - [Uwe Hoffmann](../../../company/team/index.md#uwe-hoffmann)


### PR DESCRIPTION
As part of this PR Im adding a `Team` field to the `Role(s)` section as it will provide a high level overview of the teams.