### PR TITLE
Document desired team structure for web

### DIFF
--- a/handbook/engineering/code-host-integrations/index.md
+++ b/handbook/engineering/code-host-integrations/index.md
@@ -1,0 +1,16 @@
+# Code host integrations team
+
+**The code host integrations team does not yet exist**. It is a team we want to create & grow. Responsibilities of the code host integrations team are currently owned by the [../web/index.md](web team).
+
+## Vision
+
+The **browser extension** and code host **native integrations** are a breeze to set up, and add compelling value when reading or reviewing code. Enabling native code host integrations for all users is a no-brainer for site admins.
+
+## Hiring status
+
+_Updated 2020-06-25_
+
+We are looking to hire for these roles:
+
+- +1 Engineering manager for this team (TODO job description).
+- +2 [Software Engineer - Frontend](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-frontend.md)

--- a/handbook/engineering/extensibility/index.md
+++ b/handbook/engineering/extensibility/index.md
@@ -1,0 +1,16 @@
+# Extensibility team
+
+**The extensibility team does not yet exist**. It is a team we want to create & grow. Responsibilities of the extensibility team are currently owned by the [../web/index.md](web team).
+
+## Vision
+
+**Sourcegraph extensions** empower users to integrate Sourcegraph with any third-party service providing useful information about code (code coverage, exception tracking, tracing, code quality). They are consistently supported across all code host integrations and the Sourcegraph UI. Through extensions, Sourcegraph surfaces high-level [**code insights**](https://docs.google.com/document/d/1EHzor6I1GhVVIpl70mH-c10b1tNEl_p1xRMJ9qHQfoc/edit) to engineering leaders, empowering data-driven decisions.
+
+## Hiring status
+
+_Updated 2020-06-25_
+
+We are looking to hire for these roles:
+
+- +1 Engineering manager for this team (TODO job description).
+- +2 [Software Engineer - Frontend](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-frontend.md)

--- a/handbook/engineering/web-infrastructure/index.md
+++ b/handbook/engineering/web-infrastructure/index.md
@@ -1,0 +1,16 @@
+# Web infrastructure team
+
+**The web infrastructure team does not yet exist**. It is a team we want to create & grow. Responsibilities of the web infrastructure team are currently owned by the [../web/index.md](web team).
+
+## Vision
+
+The **Sourcegraph UI** is clean, cohesive, stable and performant. It's easy for all teammates to onboard & contribute to the webapp codebase.
+
+## Hiring status
+
+_Updated 2020-06-25_
+
+We are looking to hire for these roles:
+
+- +1 Engineering manager for this team (TODO job description).
+- +2 [Software Engineer - Frontend](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-frontend.md)

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -4,13 +4,15 @@
 
 ## Vision
 
-**Code host integrations** are a breeze to set up, and add compelling value when reading or reviewing code. Enabling native code host integrations for all users is a no-brainer for site admins.
+**The web team is a transitional team**, designed to be split into the following mission teams:
 
-**Sourcegraph extensions** empower users to integrate Sourcegraph with any third-party service providing useful information about code (code coverage, exception tracking, tracing, code quality). They are consistently supported across all code host integrations and the Sourcegraph UI.
+- [Web infrastructure](../web-infrastructure/index.md)
+- [Extensibility](../extensibility/index.md)
+- [Code host integrations](../code-host-integrations/index.md)
 
-Through extensions, Sourcegraph surfaces high-level [**code insights**](https://docs.google.com/document/d/1EHzor6I1GhVVIpl70mH-c10b1tNEl_p1xRMJ9qHQfoc/edit) to engineering leaders, empowering data-driven decisions.
+Its mission today is closest to that of the [web infrastructure](../web-infrastructure/index.md) team.
 
-The **Sourcegraph UI** is clean, cohesive, stable and responsive.
+We are working on hiring for these teams, so that we can achieve our desired team structure.
 
 ## Contact
 
@@ -39,12 +41,3 @@ Before web team syncs, teammates and stakeholders should write down under "Discu
 - [Felix Becker](../../../company/team/index.md#felix-becker)
 - [Simon Korzunov](../../../company/team/index.md#simon-korzunov)
 - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
-
-## Hiring status
-
-_Updated 2020-06-02_
-
-We are looking to hire for these roles:
-
-- Hire engineering manager for this team (TODO: need to write job description), so Loïc can focus on [search](../search/index.md).
-- +2 [Software Engineer - Frontend](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-frontend.md)

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -14,6 +14,14 @@ Its mission today is closest to that of the [web infrastructure](../web-infrastr
 
 We are working on hiring for these teams, so that we can achieve our desired team structure.
 
+## Focus
+
+Each iteration, the web team splits its focus as follows:
+- ~30-40% quick wins: these are small but impactful tasks. They may come from product, design, analytics, customer engineering, or be technical debt / engineering investment tasks.
+- ~60-70% focused goal: we'll agree on a single, focused goal that we can work on as a team. Depending on priorities, this may be a product goal, or an engineering investment.
+
+The web team's current focus is documented in its tracking issue for the milestone.
+
 ## Contact
 
 - #web channel or @web-team in Slack.

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -20,7 +20,7 @@ Each iteration, the web team splits its focus as follows:
 - ~30-40% quick wins: these are small but impactful tasks. They may come from product, design, analytics, customer engineering, or be technical debt / engineering investment tasks.
 - ~60-70% focused goal: we'll agree on a single, focused goal that we can work on as a team. Depending on priorities, this may be a product goal, or an engineering investment.
 
-The web team's current focus is documented in its tracking issue for the milestone.
+The web team's current focus is documented in the tracking issue for the current milestone.
 
 ## Contact
 


### PR DESCRIPTION
Document that the web team is a transitional team, designed to be split into mission teams each with a narrower, well-defined scope.