### PR TITLE
Add 2020-Q2 OKR to reflect work of RFC 142

### DIFF
--- a/company/okrs/2020_q2.md
+++ b/company/okrs/2020_q2.md
@@ -90,8 +90,8 @@
           KR: Eliminate flakiness in CI infrastructure and production alerting (OpsGenie). (e.g.,[#9607](https://github.com/sourcegraph/sourcegraph/issues/9607)) \
           KR: Establish clear reporting on utilization of compute resources on sourcegraph.com and internal infrastructure. ([#10101](https://github.com/sourcegraph/sourcegraph/issues/10101))
        1. **Core services: Increase test coverage and reliability.** \
-          KR: Increase Go test coverage from 46% to 60%. \
-          KR: Convert 95% of e2e tests for backend functionality from browser-based to GraphQL-based.
+          KR: Increase Go test coverage from 46% to 60%. => Increased to 58.3%. \
+          KR: Migrate 95% of e2e tests for backend functionality from browser-based to GraphQL-based. => Have migrated 22% of those.
     1. **People Ops: Make our HR processes truly global and all remote.** \
        KR: Handbook outlines onboarding requirements for specific teams. \
        KR: Handbook outlines employment structure differences for US and international team members. \

--- a/company/okrs/2020_q2.md
+++ b/company/okrs/2020_q2.md
@@ -90,7 +90,8 @@
           KR: Eliminate flakiness in CI infrastructure and production alerting (OpsGenie). (e.g.,[#9607](https://github.com/sourcegraph/sourcegraph/issues/9607)) \
           KR: Establish clear reporting on utilization of compute resources on sourcegraph.com and internal infrastructure. ([#10101](https://github.com/sourcegraph/sourcegraph/issues/10101))
        1. **Core services: Increase test coverage and reliability.** \
-          KR: Increase Go test coverage from 46% to 60%.
+          KR: Increase Go test coverage from 46% to 60%. \
+          KR: Convert 95% of e2e tests for backend functionality from browser-based to GraphQL-based.
     1. **People Ops: Make our HR processes truly global and all remote.** \
        KR: Handbook outlines onboarding requirements for specific teams. \
        KR: Handbook outlines employment structure differences for US and international team members. \


### PR DESCRIPTION
The work of [RFC 142: Migrate backend e2e test with integration tests](https://docs.google.com/document/d/1LfCDPZZAkP4gFB0no-0Hb90EqMItnzv3YEb07B7WtrM/edit) is not reflected in the current 2020 Q2 OKR, thus proposed a KR regarding it.

Could have said 100% but authentication tests involve external systems which should be tested via e2e tests, and they're also considered as backend functionality.



Also updated current outcome of two testing OKRs.