### PR TITLE
handbook: Document 2021 Q1 Engineering org plan

### DIFF
--- a/handbook/engineering/2021_org.md
+++ b/handbook/engineering/2021_org.md
@@ -1,0 +1,46 @@
+# 2021 Q1 Organizational Plan
+
+Defining a vision of a future organization is necessary in order to effectively grow the engineering team. While all plans change, a plan is better than no plan. This page documents ours and will be kept up to date as it changes.
+
+- VP Engineering
+  - Director of Engineering: Core Products
+    - [Search Team](search/index.md)
+      - Engineering Manager: Search
+      - Product Manager: Search
+      - Backend Engineers: 3
+      - Frontend Engineers: 2
+    - [Campaigns Team](campaigns/index.md)
+      - Engineering Manager: Campaigns
+      - Product Manager: Campaigns
+      - Backend Engineers: 3
+      - Frontend Engineers: 2
+    - [Code Intelligence Team](code-intelligence/index.md)
+      - Engineering Manager: Code Intel
+      - Product Manager: Code Intel
+      - Backend Engineers: 3
+      - Frontend Engineers: 2
+    - [Extensibility Team](extensibility/index.md)
+      - Engineering Manager: Extensions
+      - Product Manager: Extensions
+      - Frontend Engineers: 4
+    - [Code Host Integrations Team](code-host-integrations/index.md)
+      - Engineering Manager: Code Host Integrations
+      - Product Manager: Code Host Integrations
+      - Frontend Engineers: 4
+  - Director of Engineering: Core Services
+    - [Backend Infrastructure Team](backend-infrastructure/index.md)
+      - Engineering Manager: Backend Infrastructure
+      - Backend Engineers: 4
+      - Dev Ops Engineers: 2
+    - [Distribution Team](distribution/index.md)
+      - Engineering Manager: Distribution
+      - Product Manager: Distribution
+      - Dev Ops Engineers: 4
+      - Backend Engineers: 2
+    - [Security Team](security/index.md)
+      - Engineering Manager: Security
+      - Backend Engineers: 3
+      - Security Engineers: 3
+    - [Web Infrastructure Team](web-infrastructure/index.md)
+      - Engineering Manager: Web Infrastructure
+      - Frontend Engineers: 4

--- a/handbook/engineering/2021_org.md
+++ b/handbook/engineering/2021_org.md
@@ -1,6 +1,6 @@
 # 2021 Q1 Organizational Plan
 
-Defining a vision of a future organization is necessary in order to effectively grow the engineering team. While all plans change, a plan is better than no plan. This page documents ours and will be kept up to date as it changes.
+Defining a future vision for the organization is necessary to effectively grow the engineering team. It is understood that all plans change, and this document will be kept up to date with these changes. This is our written plan to align the team and clarify hiring and growth expectations.
 
 - VP Engineering
   - Director of Engineering: Core Products

--- a/handbook/engineering/backend-infrastructure/index.md
+++ b/handbook/engineering/backend-infrastructure/index.md
@@ -1,6 +1,6 @@
 # Backend infrastructure team
 
-**The backend infrastructure team does not yet exist**. It is a team we want to create & grow. Responsibilities of the backend infrastructure team are currently owned by the [cloud team](../cloud/index.md) in some form although not entirely.
+**The backend infrastructure team does not yet exist**. It is a team we want to create & grow. The responsibilities of the backend infrastructure team are currently owned by the [cloud team](../cloud/index.md).
 
 ## Vision
 

--- a/handbook/engineering/backend-infrastructure/index.md
+++ b/handbook/engineering/backend-infrastructure/index.md
@@ -1,0 +1,7 @@
+# Backend infrastructure team
+
+**The backend infrastructure team does not yet exist**. It is a team we want to create & grow. Responsibilities of the backend infrastructure team are currently owned by the [cloud team](../cloud/index.md) in some form although not entirely.
+
+## Vision
+
+Make it easy for teammates of different experience levels to onboard and contribute to Sourcegraph backend code. Hide and remove non essential complexity from engineers working on new product features and use cases. Promote and champion consistency and simplicity across all backend code by building shared tools, libraries and infrastructure for common use cases. Scale and maintain said infrastructure. Create leverage for and accelerate other teams.

--- a/handbook/engineering/cloud/index.md
+++ b/handbook/engineering/cloud/index.md
@@ -23,14 +23,12 @@ We do [weekly check-ins](../tracking_issues.md#using-a-tracking-issue-for-progre
 - [Ryan Slade](../../../company/team/index.md#ryan-slade)
 - [Dax McDonald](../../../company/team/index.md#dax-mcdonald-he-him)
 - [Asdine El Hrychy](../../../company/team/index.md#asdine-el-hrychy)
-- [S. H.](https://hire.withgoogle.com/t/sourcegraphcom/hiring/candidates/P_AAAAAADAAC5PmuMMFoUSu3/P_AAAAAADAAC5KUwmkNJrovt) starting in July
+- [Chayim Kirshen](../../../company/team/index.md#chayim-kirshen-he-him) leads the [Security team](../security/index.md) and is currently embedded in this team.
 
 ## Hiring status
 
-_Updated 2020-06-25_
+_Updated 2020-07-03_
 
 We are hiring for these roles:
 
 - +1 [Software Engineer - Backend](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-backend.md)
-- +1 [Software Engineer - Frontend](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-frontend.md)
-- +1 [Software Engineer - Security](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-security.md)

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -26,6 +26,7 @@
 - [Adding ping data](adding_ping_data.md)
 - [Adding buildkite secrets](adding_buildkite_secrets.md)
 - [External contributions](external_contributions.md)
+- [2021 Organizational Plan](2021_org.md)
 
 ## Ownership of technical decisions
 


### PR DESCRIPTION
This change set documents our current 2021 Q1 engineering org plan and will be kept up to date as it changes.

Any new feedback is always welcome! Please share it.