### PR TITLE
Add proper cookiebot styles

### DIFF
--- a/website/src/css/components/_Cookiebot.scss
+++ b/website/src/css/components/_Cookiebot.scss
@@ -3,5 +3,6 @@
 // (Cards for the website are configured to have white background, but body text is also configured to be white).
 // stylelint-disable-next-line selector-max-id
 #CybotCookiebotDialog {
-    color: map.get($theme-colors, 'dark')
+    color: map.get($theme-colors, 'dark');
+    opacity: 0.95;
 }

--- a/website/src/css/components/_Cookiebot.scss
+++ b/website/src/css/components/_Cookiebot.scss
@@ -3,6 +3,6 @@
 // (Cards for the website are configured to have white background, but body text is also configured to be white).
 // stylelint-disable-next-line selector-max-id
 #CybotCookiebotDialog {
-    color: map.get($theme-colors, 'dark');
+    color: map-get($theme-colors, 'dark');
     opacity: 0.95;
 }

--- a/website/src/css/components/_Cookiebot.scss
+++ b/website/src/css/components/_Cookiebot.scss
@@ -1,45 +1,7 @@
-#CybotCookiebotDialog,
-#CybotCookiebotDialog a,
-#CybotCookiebotDialog div,
-#CybotCookiebotDialogBodyContentControls,
-#CybotCookiebotDialogBodyContentTitle,
-#CybotCookiebotDialogBodyButtons a {
-    font-family: Circular!important;
-}
+
+// Needed to make sure cookie banner doesn't have white text on white background
+// (Cards for the website are configured to have white background, but body text is also configured to be white).
+// stylelint-disable-next-line selector-max-id
 #CybotCookiebotDialog {
-    opacity: .90 !important;
-}
-#CybotCookiebotDialogBodyContent,
-#CybotCookiebotDialogBodyContentTitle {
-    font-weight:300!important;
-}
-#CybotCookiebotDialogBody {
-    max-width: 1000px!important;
-}
-#CybotCookiebotDialogBodyContentText {
-    font-size: 0.9rem !important;
-}
-#CybotCookiebotDialogBodyButtonDetails {
-    display: none!important;
-}	
-a#CookiePolicyLink {
-  color: #0a65ea!important;
-  text-decoration: none!important;
-}
-#CybotCookiebotDialogBodyButtonDecline {
-   background-color:transparent!important;
-   border: none!important;
-   color: #0a65ea!important;
-   font-weight: 300;
-}
-a:hover#CybotCookieDialogBodyButtonDecline,
-a:hover#CookiePolicyLink {
-   color: #0745a1!important;
-   text-decoration: underline!important;
-}
-#CybotCookiebotDialogBodyButtonAccept {
-   color: #fff!important;
-}
-#CybotCookiebotDialogBodyButtonAccept {
-   float: left;
+    color: map.get($theme-colors, 'dark')
 }


### PR DESCRIPTION
The Cookiebot template is now defined with Bootstrap classes that work on both our website and the webapp, in both light and dark theme.

The style here is currently needed because cards are defined as having a white background, but the body text color is also defined as white text. @sqs I'll let you handle this as I assume with the new homepage design that has a white background the default body color will be changed to be dark and this whole file can be deleted then.