### PR TITLE
Add interview process to people-ops index

### DIFF
--- a/handbook/people-ops/index.md
+++ b/handbook/people-ops/index.md
@@ -6,6 +6,7 @@
 
 ## Teammate experience
 - [All-remote work](../../company/remote/index.md)
+- [Interview process](interview_process.md)
 - [Hiring](hiring.md)
 - [Onboarding](onboarding/index.md)
 - [Performance review cycles](review-cycles.md)


### PR DESCRIPTION
Noticed this wasn't listed here when I ended up on this page previously.