### PR TITLE
Add automatically generated org chart

### DIFF
--- a/company/team/org_chart.md
+++ b/company/team/org_chart.md
@@ -9,7 +9,7 @@ The org chart is generated automatically. [Need to edit it?](#how-to-edit)
 </div>
 
 <!-- When updating the engineering team list below, please also update on the handbook root handbook/index.md -->
-## [Engineering: Distribution team](../../handbook/engineering/code-intelligence/index.md#members)
+## [Engineering: Distribution team](../../handbook/engineering/distribution/index.md#members)
 ## [Engineering: Campaigns team](../../handbook/engineering/campaigns/index.md#members)
 ## [Engineering: Cloud team](../../handbook/engineering/cloud/index.md#members)
 ## [Engineering: Code intelligence team](../../handbook/engineering/code-intelligence/index.md#members)

--- a/company/team/org_chart.md
+++ b/company/team/org_chart.md
@@ -1,0 +1,83 @@
+# Org chart
+
+The org chart is generated automatically. [Need to edit it?](#how-to-edit)
+
+<div id="org-chart-loading">
+	Generating org chart...
+	<br/>
+	<small>If the org chart does not appear, please <a href="https://github.com/sourcegraph/about/issues">report this issue</a> and include the output from your browser's devtools JavaScript console.</small>
+</div>
+
+<!-- When updating the engineering team list below, please also update on the handbook root handbook/index.md -->
+## [Engineering: Distribution team](../../handbook/engineering/code-intelligence/index.md#members)
+## [Engineering: Campaigns team](../../handbook/engineering/campaigns/index.md#members)
+## [Engineering: Cloud team](../../handbook/engineering/cloud/index.md#members)
+## [Engineering: Code intelligence team](../../handbook/engineering/code-intelligence/index.md#members)
+## [Engineering: Search team](../../handbook/engineering/search/index.md#members)
+## [Engineering: Security team](../../handbook/engineering/security/index.md#members)
+## [Engineering: Web team](../../handbook/engineering/web/index.md#members)
+
+## Other teams: TODO
+
+Not all teams are listed here yet.
+
+---
+
+## How to edit
+
+This org chart is generated automatically based on the contents of other handbook pages.
+
+1. To add a team, [edit this page](https://github.com/sourcegraph/about/edit/master/company/team/org_chart.md) and add a link to the section of the team's page that lists the members (such as `## [My team](../../handbook/myteam/index.md#members)`).
+1. To edit a team, edit the linked section on the team's page. In the example above, you'd edit the `Members` section of `../../handbook/myteam/index.md`. Everything in that section until the next heading is displayed on this page.
+
+<script>
+// This script injects the org chart content into each section of this page that links to a team page.
+
+async function getPageOrgChart(pageUrl) {
+	const sectionId = pageUrl.replace(/^.*#/, '')
+
+	const resp = await fetch(pageUrl)
+	const doc = new DOMParser().parseFromString(await resp.text(), "text/html")
+	const section = doc.getElementById(sectionId)
+	if (!section) {
+		const error = document.createElement('p')
+		error.innerText = `Error generating org chart: page at ${pageUrl} has no section with ID ${sectionId}.`
+		return error
+	}
+
+	const wrapper = document.createElement('section')
+	const iterator = doc.createNodeIterator(doc, NodeFilter.SHOW_ELEMENT, () => NodeFilter.FILTER_ACCEPT)
+	let curNode
+	let orgChartStarted = false
+	while (curNode = iterator.nextNode()) {
+		if (curNode instanceof HTMLHeadingElement && curNode.id === sectionId) {
+			orgChartStarted = true
+			continue
+		}
+		if (orgChartStarted) {
+			// End at next heading.
+			if (curNode instanceof HTMLHeadingElement) {
+				break
+			}
+
+			wrapper.appendChild(curNode)
+		}
+	}
+	return wrapper
+}
+
+const sectionHeaders = Array.from(document.querySelectorAll('h2')).filter(section => Boolean(section.querySelector('a[href]:not([aria-hidden])')))
+Promise.all(
+	sectionHeaders.map(async sectionHeader => ({
+		header: sectionHeader,
+		content: await getPageOrgChart(sectionHeader.querySelector('a[href]:not([aria-hidden])').href),
+	}))
+).then(sections => {
+	const loading = document.getElementById('org-chart-loading')
+	loading.innerHTML = '' // clear
+
+	for (const {header, content} of sections) {
+		header.parentNode.insertBefore(content, header.nextSibling)
+	}
+})
+</script>

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -55,7 +55,7 @@ In any case, you should report the results of your work in [progress updates](tr
 
 Our engineering organization is divided into mission based teams that contain the necessary cross-functional skillsets to achieve the desired mission.
 
-<!-- When updating the engineering team list below, please also update on the handbook root handbook/index.md -->
+<!-- When updating the engineering team list below, please also update handbook/index.md and company/team/org_chart.md. -->
 
 - [Distribution](distribution/index.md)
 - [Campaigns](campaigns/index.md)

--- a/handbook/engineering/security/index.md
+++ b/handbook/engineering/security/index.md
@@ -48,3 +48,7 @@ When we receive [a report of a security vulnerability](#how-to-report-a-security
   > Thank you for your report. Could you please provide us with $INFOX, $INFOY, and $INFOZ so we can investigate this further? 
 
   > Thank you for your report. We will not be taking further action on this report because $REASONS.
+
+## Members
+
+TODO

--- a/handbook/index.md
+++ b/handbook/index.md
@@ -10,6 +10,7 @@ The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's pub
 - [Communication](communication/index.md)
   - [Style guide](communication/style_guide.md)
 - [Team](../company/team/index.md)
+  - [Org chart](../company/team/org_chart.md)
 - [OKRs](../company/okrs/index.md)
 - [CEO](ceo/index.md)
 
@@ -32,7 +33,7 @@ The below headers are roughly the teams at Sourcegraph. Everyone should feel emp
 
 ### [Engineering](engineering/index.md)
 
-<!-- When updating the engineering team list below, please also update in engineering/index.md -->
+<!-- When updating the engineering team list below, please also update engineering/index.md and company/team/org_chart.md. -->
 
 - [Engineering](engineering/index.md)
   - [Distribution](engineering/distribution/index.md)


### PR DESCRIPTION
The new org chart page pulls in the `Members` sections from team pages on-the-fly using JavaScript.

![image](https://user-images.githubusercontent.com/1976/87505005-a8b46500-c61c-11ea-951a-85cc1c0f76cd.png)
