### PR TITLE
release process: ensure we always release Docker Compose and keep upgrade docs up-to-date

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -59,6 +59,10 @@ In [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph):
     git push origin v$MAJOR.$MINOR.$PATCH
     ```
 
+## Release Docker Compose
+
+- [ ] Release Docker Compose by following [these instructions](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/RELEASING.md)
+
 ## Update the docs
 
 - [ ] Open and merge PRs that publish the release (the PRs created by this command must be merged manually):

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -65,6 +65,7 @@ In [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph):
   ```
   yarn run release release:publish $MAJOR.$MINOR.$PATCH
   ```
+- [ ] Add an entry to https://docs.sourcegraph.com/admin/updates/kubernetes indicating the steps required to upgrade.
 - [ ] Cherry pick the release-publishing PR from sourcegraph/sourcegraph@master into the release branch.  
 - [ ] Create a new section for the patch version in the changelog. Verify that all changes that have been cherry picked onto the release branch have been moved to this section of the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/master/CHANGELOG.md) on `master`.
 - [ ] Post a reply in the #dev-announce thread to say that the release is complete.

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -99,6 +99,7 @@ Cut a new release candidate daily if necessary:
         ```
         VERSION='v$MAJOR.$MINOR.0' bash -c 'git tag -a "$VERSION" -m "$VERSION" && git push origin "$VERSION"'
         ```
+- [ ] Release Docker Compose by following [these instructions](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/RELEASING.md)
 - [ ] Open (but do not merge) PRs that publish the new release:
   ```
   # Run this in the main sourcegraph repository in the `dev/release` directory on `master` branch:

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -104,6 +104,7 @@ Cut a new release candidate daily if necessary:
   # Run this in the main sourcegraph repository in the `dev/release` directory on `master` branch:
   yarn run release release:publish $MAJOR.$MINOR.0
   ```
+- [ ] Create (but do not merge) a PR to update https://docs.sourcegraph.com/admin/updates/kubernetes indicating the steps required to upgrade.
 - [ ] Review [all issues in the release milestone](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Asourcegraph+milestone%3A$MAJOR.$MINOR). Backlog things that didn't make it into the release and ping issues that still need to be done for the release (e.g. Tweets, marketing).
 - [ ] Verify the blog post is ready to be merged.
 


### PR DESCRIPTION
- Adds instructions for releasing Docker Compose.
- Ensures we always release Docker Compose on time, and on every patch release.
- Ensures we always keep upgrade docs up-to-date: https://docs.sourcegraph.com/admin/updates/kubernetes and https://docs.sourcegraph.com/admin/updates/docker_compose

@daxmc99 please account for these changes in the 3.18 release you are currently doing