### PR TITLE
use new sourcegraphstatic.com host for static assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ The data between the `---` is called front matter and is used to provide post me
 ### Adding images
 
 - Small images can be placed in the `website/static/blog` directory and have the url of `/blog/example-image.jpg` in your markdown.
-- Large images, GIFs, and other binary assets should be uploaded to the `sourcegraph-assets` Google Cloud Storage bucket with `gsutil cp -a public-read local/path/to/myasset.png gs://sourcegraph-assets/`, with the image `src` being `https://storage.googleapis.com/sourcegraph-assets/myasset.png`.
+- Large images, GIFs, and other binary assets should be uploaded to the `sourcegraph-assets` Google Cloud Storage bucket with `gsutil cp -a public-read local/path/to/myasset.png gs://sourcegraph-assets/`, with the image `src` being `https://sourcegraphstatic.com/myasset.png`.
 - Make images as small as possible (aim for less than 200Kb).
 - Images should be no larger than 1600px wide (if you want @2x retina quality) but often, this isn't needed and 800px is fine.
 - JPEG images should be compressed at no larger than 80% quality to reduce file size.

--- a/blogposts/2019/code-navigation-in-github-pull-requests.md
+++ b/blogposts/2019/code-navigation-in-github-pull-requests.md
@@ -4,7 +4,7 @@ author: Quinn Slack
 publishDate: 2019-12-09T10:00-08:00
 tags: [blog]
 slug: code-navigation-in-github-pull-requests
-heroImage: https://storage.googleapis.com/sourcegraph-assets/code-navigation-in-github-pull-requests-typescript-hover-hero.png
+heroImage: https://sourcegraphstatic.com/code-navigation-in-github-pull-requests-typescript-hover-hero.png
 published: true
 ---
 
@@ -16,7 +16,7 @@ Code navigation helps you review code in GitHub pull requests more quickly and e
 
 Here's what it looks like:
 
-<img src="https://storage.googleapis.com/sourcegraph-assets/code-navigation-in-github-pull-requests-typescript-hover.png" />
+<img src="https://sourcegraphstatic.com/code-navigation-in-github-pull-requests-typescript-hover.png" />
 
 How does it help? Suppose you're reviewing a pull request that calls a function you don't recognize. You'll be able to quickly answer:
 

--- a/blogposts/2020/announcing-sourcegraph-3.16.md
+++ b/blogposts/2020/announcing-sourcegraph-3.16.md
@@ -102,7 +102,7 @@ Campaigns are currently in beta. During the beta period, campaigns are free to u
 
 ## Best-in-class syntax highlighting
 
-![syntax_highlighting](https://storage.googleapis.com/sourcegraph-assets/blog/diff.gif?v=2)
+![syntax_highlighting](https://sourcegraphstatic.com/blog/diff.gif?v=2)
 
 Sourcegraph 3.16 includes major improvements to syntax highlighting throughout Sourcegraph. In addition to general improvements, six new languages are supported (Smarty, Ethereum / Solidity / Vyper, Cuda, COBOL, vb.NET, and ASP.NET), and 30 new file extensions are now detected.
 
@@ -126,7 +126,7 @@ Our precise code intelligence backend has been rewritten from TypeScript to Go. 
 
 ## Discover useful scopes with `repogroup` autocompletion
 
-![Repogroup-autocompletion](https://storage.googleapis.com/sourcegraph-assets/repogroup_completion.gif)
+![Repogroup-autocompletion](https://sourcegraphstatic.com/repogroup_completion.gif)
 
 The `repogroup` filter is useful for creating collections of repositories to search over within Sourcegraph. However, there wasn’t an easy way for users to learn what `repogroups` were available. Now, Sourcegraph provides autocompletion to help you discover available options. This happens automatically when you start typing, or can be triggered using the ctrl-spacebar keyboard shortcut. Try it out in the new smart search bar for plain text mode or in interactive mode!
 

--- a/blogposts/2020/announcing-sourcegraph-3.17.md
+++ b/blogposts/2020/announcing-sourcegraph-3.17.md
@@ -45,7 +45,7 @@ Sourcegraph couldn't be what it is without our contributors.
 Precise code intelligence queries are now faster. The following chart shows the decrease in query latency while running our [integration test suite](https://github.com/sourcegraph/sourcegraph/tree/5f51043ad2130a1acdcfca8b969f907cd03a220d/internal/cmd/precise-code-intel-test) compared to the previous two Sourcegraph releases. Sourcegraph 3.17 is 50% faster than in Sourcegraph 3.15, and 35% faster than in Sourcegraph 3.16.
 
 <div class="text-center benchmark-results">
-  <img src="https://storage.googleapis.com/sourcegraph-assets/lsif-query-latency-317.png" width="70%">
+  <img src="https://sourcegraphstatic.com/lsif-query-latency-317.png" width="70%">
 </div>
 
 In [Sourcegraph 3.16](https://about.sourcegraph.com/blog/sourcegraph-3.16#performance-improvements-for-precise-code-intelligence), our precise code intelligence backend was rewritten from TypeScript to Go. This was part of a larger effort to aggressively optimize conversion and querying of LSIF data. That effort is now well underway!
@@ -53,17 +53,17 @@ In [Sourcegraph 3.16](https://about.sourcegraph.com/blog/sourcegraph-3.16#perfor
 The task of uploading and processing precise code intelligence bundles, which has previously been a sticking point on private instances with large repositories, has also been improved (around 45% faster than Sourcegraph 3.16 and 48% faster than Sourcegraph 3.15). The following chart shows the time required to upload the indexes for our integration test suite. This includes three commits from [etcd-io/etcd](https://github.com/etcd-io/etcd), [pingcap/tidb](https://github.com/pingcap/tidb), and [distributedio/titan](https://github.com/distributedio/titan), and two commits from [uber-go/zap](https://github.com/uber-go/zap).
 
 <div class="text-center benchmark-results">
-  <img src="https://storage.googleapis.com/sourcegraph-assets/lsif-processing-latency-317.png" width="50%">
+  <img src="https://sourcegraphstatic.com/lsif-processing-latency-317.png" width="50%">
 </div>
 
 We’ve also poured some love into the on-disk format of precise code intel bundles (each bundle is now 30-50% smaller than the previous release). This should be helpful in private instances with large, frequent index uploads and constrained disk, where frequent eviction of recent bundles was previously an issue.
 
 <div class="text-center benchmark-results">
-  <img src="https://storage.googleapis.com/sourcegraph-assets/tidb-bundle-size.png" width="48%">
-  <img src="https://storage.googleapis.com/sourcegraph-assets/etcd-bundle-size.png" width="48%">
+  <img src="https://sourcegraphstatic.com/tidb-bundle-size.png" width="48%">
+  <img src="https://sourcegraphstatic.com/etcd-bundle-size.png" width="48%">
   <br />
-  <img src="https://storage.googleapis.com/sourcegraph-assets/titan-bundle-size.png" width="48%">
-  <img src="https://storage.googleapis.com/sourcegraph-assets/zap-bundle-size.png" width="48%">
+  <img src="https://sourcegraphstatic.com/titan-bundle-size.png" width="48%">
+  <img src="https://sourcegraphstatic.com/zap-bundle-size.png" width="48%">
 </div>
 
 <style>

--- a/blogposts/2020/evolution-of-the-precise-code-intel-backend.md
+++ b/blogposts/2020/evolution-of-the-precise-code-intel-backend.md
@@ -13,7 +13,7 @@ published: true
 Jumping to the definition of a symbol under your cursor and finding all its references are two of the basic mental mechanics of software engineering. Fast code navigation accelerates the rate at which you can build a mental model of the code, and when it's available, you're likely to use it hundreds, if not thousands, of times per day.
 
 <div style="margin: 2em;">
-<img src="https://storage.googleapis.com/sourcegraph-assets/predcise-j2d-find-refs.gif" alt="Precise jump to definition and find refs" />
+<img src="https://sourcegraphstatic.com/predcise-j2d-find-refs.gif" alt="Precise jump to definition and find refs" />
 </div>
 
 Code navigation is the core of how Sourcegraph helps you understand the parts of the universe of code that are most relevant and important to you. Code navigation also presents a difficult technical challenge, especially when you want to provide code navigation *outside the IDE* in a variety of other applications where developers are trying to understand code: a web-based code search engine like [Sourcegraph.com](https://sourcegraph.com/search), [private instances of Sourcegraph](https://docs.sourcegraph.com/#quickstart-guide), and in code hosts like GitHub, GitLab, Bitbucket, and Phabricator through the [Sourcegraph browser extension](https://docs.sourcegraph.com/integration/browser_extension).
@@ -55,7 +55,7 @@ Today, the Sourcegraph LSIF backend has multiple components that each handle som
 
 The LSIF backend began life as a simple [Express](https://expressjs.com/) server written in TypeScript, proxied to the outside world by an endpoint in the Sourcegraph frontend API. This server accepted LSIF uploads and wrote them directly to disk. On a query request, the server would read the LSIF data for the current repository from disk into memory, parse it into a structured representation, and walk the graph of vertices and edges to construct the appropriate response.
 
-![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/lsif-arch-1.png)
+![architecture diagram](https://sourcegraphstatic.com/lsif-arch-1.png)
 
 On the client side, we wrote a simple [Sourcegraph extension](https://docs.sourcegraph.com/extensions) to query the lsif-server API.
 
@@ -91,7 +91,7 @@ We also started to see more frequent OOM errors in the lsif-server process for l
 
 To address this issue, we decided to separate the work of converting LSIF into SQLite bundles into a separate background process. The lsif-server process would continue to handle uploads and queries, but the uploads handler would be similar to that of the MVP implementation, transparently writing the raw data to disk rather that converting it synchronously. The lsif-worker[^1] process would consume the queue of LSIF dumps to process, converting these to SQLite bundles in the background.
 
-![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/lsif-arch-2.png)
+![architecture diagram](https://sourcegraphstatic.com/lsif-arch-2.png)
 
 To coordinate work between the LSIF upload handler and the lsif-worker process, we needed a queue. We used [node-resque](https://github.com/actionhero/node-resque), a Node.js port of the popular Rails library [resque](https://github.com/resque/resque). This library stores job data in Redis, which was already a component of our stack. We also considered using PostreSQL (but accessing the existing PostgreSQL instance came with certain restrictions due to concerns for uptime and performance), some sort of local [IPC](https://en.wikipedia.org/wiki/Inter-process_communication) (but this would have prevented scaling lsif-server and lsif-worker independently), and using an AMQP server (but this would have required introducing a new major service into our architecture).
 
@@ -106,7 +106,7 @@ To enable that, we added an additional SQLite database (`xrepo.db`) that enabled
 
 This was fine so long as there was just one instance each of lsif-server and lsif-worker and they both lived in the same Docker container. However, in order to support LSIF across large, multi-repository codebases, we needed to scale. This meant that the multiple lsif-server and lsif-worker instances would be running in different Docker containers, perhaps on different machines, and could no longer rely on share access to a single-writer-at-a-time SQLite database. We moved the `xrepo.db` data into PostgreSQL.
 
-![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/lsif-arch-3.png)
+![architecture diagram](https://sourcegraphstatic.com/lsif-arch-3.png)
 
 The potential volume of additional writes continued to concern us. As LSIF use grew, would it cause operational issues in the PostgreSQL instance that would affect the performance of unrelated parts of the application? To be safe, we kept the table spaces of the LSIF data disjoint (prefixed table names, no foreign keys to existing tables) from the other data. We also tried migrating the LSIF tables into a second PostgreSQL instance. However, this required some nasty trickery with [db_link](https://github.com/sourcegraph/sourcegraph/blob/d1cffed06e58a90082243601d936279214547e30/migrations/1528395594_create_lsif_database.up.sql) in order to run migrations, which we found quite painful and [eventually reverted](https://github.com/sourcegraph/sourcegraph/pull/5935). Some more back-of-the-envelope calculations suggested that the LSIF-related load wouldn't overwhelm the single shared PostgreSQL instance, and these calculations have largely held up over time.
 
@@ -140,7 +140,7 @@ Furthermore, Redis is treated by other parts of Sourcegraph as an ephemeral and 
 
 To address these issues, we moved the queue data from Redis into PostgreSQL. This reduced a lot of complexity. As it turned out, all of the custom Lua scripts that reached into the Redis data could be reduced into a few SQL queries. We could now also use PostgreSQL transaction to enforce all-or-nothing atomicity on LSIF-related updates.
 
-![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/lsif-arch-4.png)
+![architecture diagram](https://sourcegraphstatic.com/lsif-arch-4.png)
 
 ## Adding GraphQL resolvers
 
@@ -150,7 +150,7 @@ For a while, the lsif-server was accessible only through an undocumented proxy i
 
 Adding a GraphQL API enabled the LSIF backend to be used by other parts of Sourcegraph, such as the nascent [Campaigns](https://docs.sourcegraph.com/user/campaigns) feature and the currently in-progress [Code Insights](https://about.sourcegraph.com/blog/sourcegraph-3.17#product-preview-code-insights), and also to third-party Sourcegraph extension authors and third-party API consumers. As the functionality of the LSIF backend continues to grow (we've recently added support for [diagnostics](https://github.com/sourcegraph/sourcegraph/pull/11233)), so do the possibilities for users of this API.
 
-![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/lsif-arch-5.png)
+![architecture diagram](https://sourcegraphstatic.com/lsif-arch-5.png)
 
 ## Introducing multiple workers
 
@@ -160,7 +160,7 @@ The lsif-server and lsif-worker were still run together in the [same container](
 
 This was a rudimentary way to scale, as overall resource use was still constrained by the single container and there was no isolation between worker processes (meaning runaway memory use in one can starve out all the others in the container), but this worked well enough for the time being. This change also helped us resolve some issues with LSIF processing on [Sourcegraph.com](https://sourcegraph.com), which was suffering from [head-of-line blocking](https://en.wikipedia.org/wiki/Head-of-line_blocking).
 
-![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/lsif-arch-6.png)
+![architecture diagram](https://sourcegraphstatic.com/lsif-arch-6.png)
 
 ## Introducing the bundle manager
 
@@ -172,7 +172,7 @@ Naively, we thought this might be possible by simply attaching a shared disk to 
 
 The solution was to factor out the responsibility of managing the shared storage into a separate service, the bundle manager (originally called the lsif-dump-manager, today known as the precise-code-intel-bundle-manager).
 
-![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/lsif-arch-7.png)
+![architecture diagram](https://sourcegraphstatic.com/lsif-arch-7.png)
 
 This made the lsif-server and lsif-worker stateless, freeing them to scale horizontally. Scaling the bundle managers requires a sharding scheme, similar to what we already used for the gitserver service that is responsible for serving Git data in the Sourcegraph backend.
 
@@ -207,7 +207,7 @@ After rewriting the LSIF backend in Go, the LSIF API server (lsif-server) was co
 
 We moved what remained of the LSIF API server logic from the server handlers into the client used by other parts of Sourcegraph (the external HTTP and GraphQL APIs) to query LSIF data. Then we dropped the LSIF API server:
 
-![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/lsif-arch-8.png)
+![architecture diagram](https://sourcegraphstatic.com/lsif-arch-8.png)
 
 ## Looking forward
 

--- a/blogposts/2020/home-offices-of-sourcegraph.md
+++ b/blogposts/2020/home-offices-of-sourcegraph.md
@@ -18,92 +18,92 @@ Here are all the photos that were contributed to the pull request behind this bl
 
 ## Thorsten Ball, Software Engineer
 
-![Home office setup of Thorsten Ball, software engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/thorsten_ball.jpg)
+![Home office setup of Thorsten Ball, software engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/thorsten_ball.jpg)
 
 ## Ryan Slade, Software Engineer
 
-![Home office setup of Ryan Slade, software engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/ryan_slade.jpg)
+![Home office setup of Ryan Slade, software engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/ryan_slade.jpg)
 
 ## Joe Chen, Software Engineer
 
-![Home office setup of Joe Chen, software engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/joe_chen.jpg)
+![Home office setup of Joe Chen, software engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/joe_chen.jpg)
 
 ## Eric Fritz, Software Engineer
 
-![Home office setup of Eric Fritz, software engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/eric_fritz.jpg)
+![Home office setup of Eric Fritz, software engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/eric_fritz.jpg)
 
 ## Erik Seliger, Software Engineer
 
-![Home office setup of Erik Seliger, software engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/erik_seliger.jpg)
+![Home office setup of Erik Seliger, software engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/erik_seliger.jpg)
 
 ## Michael Fromberger, Software Engineer
 
-![Home office setup of Michael Fromberger, software engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/michael_fromberger.jpg)
+![Home office setup of Michael Fromberger, software engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/michael_fromberger.jpg)
 
 ## Nick Snyder, VP Engineering
 
-![Home office setup of Nick Snyder, VP Engineering](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/nick_snyder.jpg)
+![Home office setup of Nick Snyder, VP Engineering](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/nick_snyder.jpg)
 
 ## Ryan Blunden, Developer Advocate
 
 <!--I do a lot of screencasts and livestreams, hence the microphone, camera, and light. You might think the light is overkill, but it helps you look a lot more healthy and human when it's 4am Australian time.-->
 
-![Home office setup of Ryan Blunden, Developer Advocate](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/ryan_blunden.jpg)
+![Home office setup of Ryan Blunden, Developer Advocate](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/ryan_blunden.jpg)
 
 ## Christina Forney, Product Manager
 
-![Home office setup of Christina Forney, Product Manager](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/christina_forney.jpg)
+![Home office setup of Christina Forney, Product Manager](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/christina_forney.jpg)
 
 ## Aileen Agricola, Senior Digital Marketing Manager
 
-![Home office setup of Aileen Agricola, Senior Digital Marketing Manager](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/aileen_agricola.jpg)
+![Home office setup of Aileen Agricola, Senior Digital Marketing Manager](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/aileen_agricola.jpg)
 
 ## Uwe Hoffmann, Software Engineer
 
-![Home office setup of Uwe Hoffmann, Software Engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/uwe_hoffmann.jpg)
+![Home office setup of Uwe Hoffmann, Software Engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/uwe_hoffmann.jpg)
 
 ## Stephen Gutekanst, Senior Software Engineer
 
 (apologies for the clutter)
 
-![Home office setup of Stephen Gutekanst, Senior Software Engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/stephen_gutekanst.gif)
+![Home office setup of Stephen Gutekanst, Senior Software Engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/stephen_gutekanst.gif)
 
 ## Farhan Attamimi, Software Engineer
 
-![Home office setup of Farhan Attamimi, Software Engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/Farhan_Home_Office.jpg)
+![Home office setup of Farhan Attamimi, Software Engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/Farhan_Home_Office.jpg)
 
 ## Rijnard van Tonder, Software Engineer
 
-![Home office setup of Rijnard van Tonder, Software Engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/rijnard_van_tonder.jpg)
+![Home office setup of Rijnard van Tonder, Software Engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/rijnard_van_tonder.jpg)
 
 ## Dan Adler, VP Business
 
-![Home office setup of Dan Adler, VP Business](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/Dan_home_office.jpg)
+![Home office setup of Dan Adler, VP Business](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/Dan_home_office.jpg)
 
 ## Adam Frankl, VP Marketing
 
-![Home office setup of Adam Frankl, VP Marketing](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/adam_frankl.jpg)
+![Home office setup of Adam Frankl, VP Marketing](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/adam_frankl.jpg)
 
 ## Keegan Carruthers-Smith, Software Engineer
 
-![Home office setup of Keegan Carruthers-Smith, Software Engineer](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/keegan_carruthers_smith.jpg)
+![Home office setup of Keegan Carruthers-Smith, Software Engineer](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/keegan_carruthers_smith.jpg)
 
 ## Loïc Guychard, Engineering Manger
 
-![Home office setup of Loïc Guychard, Engineering Manager](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/Loic_home_office.jpg)
+![Home office setup of Loïc Guychard, Engineering Manager](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/Loic_home_office.jpg)
 
 ## Tomás Senart, Engineering Manager
 
-![Home office setup of Tomás Senart, Engineering Manager](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/tomas_senart.jpg)
+![Home office setup of Tomás Senart, Engineering Manager](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/tomas_senart.jpg)
 
 ## Quinn Slack, CEO
 
-![Home office setup of Quinn Slack, CEO](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/quinn_slack_homeoffice.jpg)
+![Home office setup of Quinn Slack, CEO](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/quinn_slack_homeoffice.jpg)
 
 ## Eric Brody-Moore, Growth & Business Operations
 
-![Home office setup of Eric Brody-Moore, Growth & Business Operations](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/ericbm_home_office.jpg)
+![Home office setup of Eric Brody-Moore, Growth & Business Operations](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/ericbm_home_office.jpg)
 
 ## Noemi Mercado, Head of PeopleOps
 
-![Home office setup of Noemi Mercado, Head of PeopleOps](https://storage.googleapis.com/sourcegraph-assets/about.sourcegraph.com/blog/home-office-setups/noemi_mercado.jpg)
+![Home office setup of Noemi Mercado, Head of PeopleOps](https://sourcegraphstatic.com/about.sourcegraph.com/blog/home-office-setups/noemi_mercado.jpg)

--- a/handbook/ce/support.md
+++ b/handbook/ce/support.md
@@ -125,7 +125,7 @@ In the past, we have provided support on private GitHub issue trackers and priva
 
 2. Make the first line your name in bold
 3. Make the second line your title
-4. Choose **Insert image** and then **Web Address (URL)** and enter https://storage.googleapis.com/sourcegraph-assets/sourcegraph-logo.png then choose **Medium** size after it has been entered.
+4. Choose **Insert image** and then **Web Address (URL)** and enter https://sourcegraphstatic.com/sourcegraph-logo.png then choose **Medium** size after it has been entered.
 5. Click the image, then click **Link** and paste https://sourcegraph.com into the **Web Address** field. Now your image links to the website!
 6. Your signature should now look something like this, and clicking the Sourcegraph logo should bring you to sourcegraph.com:
 

--- a/handbook/engineering/product_documentation.md
+++ b/handbook/engineering/product_documentation.md
@@ -21,7 +21,7 @@ We use the [monthly release blog post](https://about.sourcegraph.com/blog) as a 
 1. Always cross-link to `.md` files, including the file extension, so that the docs are browseable as-is (e.g., in GitHub's file browser).
 1. When you create a new directory, always start with an `index.md` file. Don't use another file name and don't create `README.md` files.
 1. Don't use special chars and spaces, or capital letters in file names, directory names, branch names, and anything that generates a path.
-1. For large images and other binary assets, upload them to the `sourcegraph-assets` Google Cloud Storage bucket instead with `gsutil cp -a public-read local/path/to/myasset.png gs://sourcegraph-assets/` (and refer to them as `https://storage.googleapis.com/sourcegraph-assets/myasset.png`).
+1. For large images and other binary assets, upload them to the `sourcegraph-assets` Google Cloud Storage bucket instead with `gsutil cp -a public-read local/path/to/myasset.png gs://sourcegraph-assets/` (and refer to them as `https://sourcegraphstatic.com/myasset.png`).
 1. When creating a new document and it has more than one word in its name, use underscores instead of spaces or dashes (`-`). For example, a proper name would be `import_projects_from_github.md`.
 1. Start a new directory with an `index.md` file.
 

--- a/handbook/marketing/adding_screenshots_screen_recording.md
+++ b/handbook/marketing/adding_screenshots_screen_recording.md
@@ -113,7 +113,7 @@ Provided your image is less than 100Kb, it can be added to the same repository t
 Before you go to upload your video, ensure someone from the marketing team has added you as an owner for the Sourcegraph brand account (shown below) as we want all Sourcegraph videos to be owned by the brand account.
 
 <div class="text-center">
-  <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/make-sourcegraph-brand-owner.gif" class="drop-shadow"/>
+  <img src="https://sourcegraphstatic.com/handbook/make-sourcegraph-brand-owner.gif" class="drop-shadow"/>
 </div>
 
 <br/>
@@ -121,7 +121,7 @@ Once you’ve been added as an owner, switch to the Sourcegraph user account.
 <br/>
 
 <div class="text-center">
-  <img src="https://storage.googleapis.com/sourcegraph-assets/handbook/youtube-switch-account.gif"class="drop-shadow"/>
+  <img src="https://sourcegraphstatic.com/handbook/youtube-switch-account.gif"class="drop-shadow"/>
 </div>
 
 Export your video in 16:9 ratio (should probably be 720p), then [upload your video to YouTube](https://studio.youtube.com/channel/UCOy2N25-AHqE43XupT9mwZQ):

--- a/handbook/people-ops/donations.md
+++ b/handbook/people-ops/donations.md
@@ -4,11 +4,11 @@ If you are an employee based in the United States, you can set up recurring cont
 
 Charitable contributions can be made as a one-time or a recurring (per paycheck) donation. In order to set up a contribution, select _Giving_ from the Gusto sidebar.
 
-![](https://storage.googleapis.com/sourcegraph-assets/gusto-giving-sidebar.png)
+![](https://sourcegraphstatic.com/gusto-giving-sidebar.png)
 
 Then, select _Choose a charity_ and _Search for charity_ to open a dialog box.
 
-![](https://storage.googleapis.com/sourcegraph-assets/gusto-giving-modal.png)
+![](https://sourcegraphstatic.com/gusto-giving-modal.png)
 
 It is recommended to search for a charity through [Charity Navigator](https://www.charitynavigator.org) to find its federal Employer Identification Number (EIN). For example, the ACLU page can be found [here](https://www.charitynavigator.org/index.cfm?bay=search.summary&orgid=3247).
 

--- a/website/src/pages/case-studies/convoy-improved-on-boarding.tsx
+++ b/website/src/pages/case-studies/convoy-improved-on-boarding.tsx
@@ -24,7 +24,7 @@ export default ((props: any) => (
                 author: 'Brandon Bloom, Senior Software Engineer, Convoy',
                 image: '/case-studies/brandon-bloom-convoy.jpg',
             }}
-            pdf="https://storage.googleapis.com/sourcegraph-assets/convoy_improved_on_boarding.pdf"
+            pdf="https://sourcegraphstatic.com/convoy_improved_on_boarding.pdf"
         >
             <ContentSection color="white" className="col-md-6">
                 <div className="container">

--- a/website/src/pages/case-studies/convoy-software-engineers-and-data-scientists-work-better-together.tsx
+++ b/website/src/pages/case-studies/convoy-software-engineers-and-data-scientists-work-better-together.tsx
@@ -24,7 +24,7 @@ export default ((props: any) => (
                 author: 'Owen Kim, Senior Software Engineer, Convoy',
                 image: '/case-studies/owen-kim-convoy.jpg',
             }}
-            pdf="https://storage.googleapis.com/sourcegraph-assets/convoy_software_engineers_and_data_scientists_work_better_together.pdf"
+            pdf="https://sourcegraphstatic.com/convoy_software_engineers_and_data_scientists_work_better_together.pdf"
         >
             <ContentSection color="white" className="col-md-6">
                 <div className="container">

--- a/website/src/pages/case-studies/lyft-monolith-to-microservices.tsx
+++ b/website/src/pages/case-studies/lyft-monolith-to-microservices.tsx
@@ -26,7 +26,7 @@ export default ((props: any) => (
                 author: justinPhilips,
                 image: '/case-studies/justin-phillips-lyft.jpg',
             }}
-            pdf="https://storage.googleapis.com/sourcegraph-assets/Lyft-Sourcegraph-case-study.pdf"
+            pdf="https://sourcegraphstatic.com/Lyft-Sourcegraph-case-study.pdf"
         >
             <ContentSection color="white" className="col-md-6">
                 <div className="container">

--- a/website/src/pages/case-studies/quantcast-large-scale-refactoring.tsx
+++ b/website/src/pages/case-studies/quantcast-large-scale-refactoring.tsx
@@ -23,7 +23,7 @@ export default ((props: any) => (
                 author: 'Simon Law, Staff Software Engineer, Quantcast',
                 image: '/case-studies/simon-law-quantcast.jpg',
             }}
-            pdf="https://storage.googleapis.com/sourcegraph-assets/Quantcast-Sourcegraph-case-study.pdf"
+            pdf="https://sourcegraphstatic.com/Quantcast-Sourcegraph-case-study.pdf"
         >
             <ContentSection color="white" className="col-md-6">
                 <div className="container">

--- a/website/src/pages/case-studies/sofi-moves-fast-on-hundreds-of-microservices.tsx
+++ b/website/src/pages/case-studies/sofi-moves-fast-on-hundreds-of-microservices.tsx
@@ -24,7 +24,7 @@ export default ((props: any) => (
                 author: 'Ursula Robertson, Engineering Manager, SoFi',
                 image: '/case-studies/ursula-robertson-sofi.jpg',
             }}
-            pdf="https://storage.googleapis.com/sourcegraph-assets/sofi_case_study.pdf"
+            pdf="https://sourcegraphstatic.com/sofi_case_study.pdf"
         >
             <ContentSection color="white" className="col-md-6">
                 <div className="container">

--- a/website/src/pages/case-studies/we-are-thorn.tsx
+++ b/website/src/pages/case-studies/we-are-thorn.tsx
@@ -24,7 +24,7 @@ export default ((props: any) => (
                 author: 'Thorn Software Engineer Jacob Gillespie',
                 image: '/case-studies/jacob-gillespie-thorn-square.jpg',
             }}
-            pdf="https://storage.googleapis.com/sourcegraph-assets/Thorn%20Sourcegraph%20case%20study%20v2.pdf"
+            pdf="https://sourcegraphstatic.com/Thorn%20Sourcegraph%20case%20study%20v2.pdf"
         >
             <ContentSection color="white" className="col-md-6">
                 <div className="container">


### PR DESCRIPTION
The https://sourcegraphstatic.com site serves content from the `sourcegraph-assets` Google Cloud Storage bucket. We are using this hostname instead of https://storage.googleapis.com/sourcegraph-assets/ because the latter is blocked by some ad blockers, which means our assets are not visible to many of our users.

`fastmod https://storage.googleapis.com/sourcegraph-assets/ https://sourcegraphstatic.com/`

Related PR: https://github.com/sourcegraph/sourcegraph/pull/12419