### PR TITLE
Document web team progress updates and retrospectives

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -2,10 +2,7 @@
 
 The web team owns all work related to our web application and browser extensions that isn't already owned by one of the other mission based teams.
 
-This is a large ownership area, so the team creates a focused plan each iteration:
-
-- ~30-40% quick wins: these are small but impactful tasks. They may come from product, design, analytics, customer engineering, or be technical debt / engineering investment tasks.
-- ~60-70% focused goal: we'll agree on a single, focused goal that we can work on as a team. Depending on priorities, this may be a product goal, or an engineering investment.
+This is a large ownership area, so the team creates a focused plan each iteration, by agreeing on an appropriately small set of [goals](../../../company/goals/index.md). Each goal should have more than one teammate working on it.
 
 The web team's current focus is documented in [the tracking issue for the current milestone](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Atracking+label%3Ateam%2Fweb+is%3Aopen).
 
@@ -20,7 +17,47 @@ TypeScript, React, RxJS, GraphQL, Go.
 
 ## Processes
 
-We do [weekly check-ins](../tracking_issues.md#using-a-tracking-issue-for-progress-check-ins) (between Friday EOD and Monday 5am PT) and [planning](../tracking_issues.md#planning-a-milestone-with-a-tracking-issue) with [tracking issues](../tracking_issues.md).
+### Planning
+
+We do [planning](../tracking_issues.md#planning-a-milestone-with-a-tracking-issue) with [tracking issues](../tracking_issues.md).
+
+### Updates
+
+We do regular updates to communicate our progress to members of the team, and to external stakeholders.
+
+#### Daily Slack updates
+
+Collaborating across timezones requires regular communication to keep each other updated on our progress, and coordinate work handoff if needed. We use daily Slack updates to achieve this.
+
+Every day, Slackbot will post a reminder in the #web to write your daily update.
+
+**At the end of each working day**, you should post your update as a threaded response to the Slackbot message.
+
+You should include in your update:
+- What you worked on during your day.
+- Whether you're blocked on anything to make progress (a code review, input in an RFC or in a GitHub issue...).
+- What you plan on tackling next.
+
+**At the beginning of each working day**, you should read the updates thread for the previous working day, to learn what your teammates have been working on, and check if they need your help.
+
+#### Weekly updates in the tracking issue
+
+We use weekly [progress updates in the tracking issue](../tracking_issues.md#progress_updates) to inform external stakeholders of the progress of the team.
+
+Every Friday, Slackbot will post a reminder in #web to write your weekly progress update. You should post your update in the tracking issue for the current milestone by EOD Friday.
+
+### Retrospectives
+
+After the 20th of each month, we hold a retrospective, to reflect on the past iteration. We use this retrospective to:
+- Understand whether we accomplished the goals we set at the beginning of the iteration. If we didn't accomplish them, reflect on the reasons why.
+- Discuss things that didn't go well in the iteration, and identify action items to improve on these in the next iteration.
+- Discuss things that went well in the past iteration, and that we should do more of / invest more into.
+
+At the beginning of each iteration, the engineering manager will:
+- Schedule the retrospective meeting
+- Set up a Slack reminder three days before the retrospective meeting, asking teammates to write their discussion topics in the retrospective document
+
+The meeting notes for all past web team retrospectives can be found [here](https://docs.google.com/document/d/1YW45Dksk0vIn7drhatwLyo6YbMMkS-naHcuShUi1OOw/edit#heading=h.dxt1jy5hsf1d).
 
 ## Team syncs
 


### PR DESCRIPTION
Following our retrospective, document that:
- We do daily updates in Slack
- We still do weekly updates in the tracking issue
- We always do a retrospective, and where our retrospective meeting notes live