### PR TITLE
Introduce web group issue triages

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -22,6 +22,10 @@ TypeScript, React, RxJS, GraphQL, Go.
 
 We do [weekly check-ins](../tracking_issues.md#using-a-tracking-issue-for-progress-check-ins) (between Friday EOD and Monday 5am PT) and [planning](../tracking_issues.md#planning-a-milestone-with-a-tracking-issue) with [tracking issues](../tracking_issues.md).
 
+We do monthly backlog triages together, where we go through the issues in the "To do" column of our [Project board](https://github.com/orgs/sourcegraph/projects/45) and decide which issues we should work on soon by moving them to the "Next" column.
+To manage the load for these triages, a triage may have a specific theme, like "debt" or "performance".
+This helps us resurface older issues, create shared awareness for existing deficiencies among everyone working on the web codebase and ensure all issues have estimates.
+
 ## Team syncs
 
 The web team holds weekly syncs.
@@ -48,5 +52,5 @@ We are growing the web team by hiring [frontend engineers](https://github.com/so
 - Extensions and integrations
     - **Sourcegraph extensions** empower users to integrate Sourcegraph with any third-party service providing useful information about code (code coverage, exception tracking, tracing, code quality). They are consistently supported across all code host integrations and the Sourcegraph UI. Through extensions, Sourcegraph surfaces high-level [**code insights**](https://docs.google.com/document/d/1EHzor6I1GhVVIpl70mH-c10b1tNEl_p1xRMJ9qHQfoc/edit) to engineering leaders, empowering data-driven decisions.
     - The **browser extension** and code host **native integrations** are a breeze to set up, and add compelling value when reading or reviewing code. Enabling native code host integrations for all users is a no-brainer for site admins.
-    
+
 Loïc is interested to be the manager of the [Search team](../search/index.md) so we are [hiring an engineering manager for this team](https://github.com/sourcegraph/careers/blob/master/job-descriptions/engineering-manager-web.md) to replace him.


### PR DESCRIPTION
We did these multiple times a while ago but haven't done one in a while. As we define our own goals for the team, long-term and for each iteration, I think it's even more important than before we all have a shared awareness of our issue backlog (which includes everything from bugs, feature requests, debt, perf problems and tooling problems) so we can make informed decisions on what goals to set and what to work on. I am therefor proposing we make this part of our process, through a PR to the handbook 🙂 

Especially interested to hear from @marekweb and @twop if this would be helpful!