### PR TITLE
Add clarification about new files, remove docsite specifics

### DIFF
--- a/handbook/editing.md
+++ b/handbook/editing.md
@@ -64,9 +64,9 @@ If you just need to edit a single page, you can do it entirely on the web.
 1. When you're ready to publish the change and make it live, press the **Squash and merge** button, then press **Confirm squash and merge**.
 1. Wait up to 5 minutes for your change to be live on about.sourcegraph.com.
 
-## Edit multiple files
+## Edit multiple files or add a new file
 
-To make edits multiple files and submit all of the edits as a group to be reviewed together, you will follow a more complex process than when [editing a single file](#edit-a-single-file).
+To make edits to multiple files and submit all of the edits as a group to be reviewed together, you will follow a more complex process than when [editing a single file](#edit-a-single-file). This also is required for adding new files. 
 
 > NOTE: These steps are not exhaustively documented. Please [ask for help](#how-to-get-help) as many times as you need to until you feel comfortable with this process.
 
@@ -108,20 +108,4 @@ If you want to upload a large file (such as a large image, video, or audio recor
 
 > NOTE: This is optional.
 
-We use a program called [docsite](https://github.com/sourcegraph/docsite) to turn the `.md` files into the [handbook website](https://about.sourcegraph.com/handbook). These steps walk you through running that tool locally to preview exactly how the handbook will look on the web with your changes.
-
-1. On [docsite releases](https://github.com/sourcegraph/docsite/releases), download the latest release's `docsite_vN.N.N_darwin_amd64` file (not `.tgz` or any other file extension).
-1. When the download is complete, open the terminal and run the following commands. (Replace `N.N.N` with the actual version number in the filename you downloaded in all of the commands below.)
-
-    <pre>
-chmod +x ~/Downloads/docsite_vN.N.N_darwin_amd64
-cd ~/Documents/GitHub/about
-~/Downloads/docsite_vN.N.N_darwin_amd64 serve</pre>	
-    
-	The last command will print: `# Doc site is available at http://0.0.0.0:5080`.
-	  - To check your changes for common errors (such as broken links), you can run the same commands above but replace `serve` with `check` in the last command. It will print a list of problems (if any).
-1. Visit http://0.0.0.0:5080/handbook in your web browser.
-
-Keep the terminal window open while you're browsing the local preview site.
-
-If it has been a while since you last downloaded the release of docsite, or if you see unexpected errors, follow the steps above again and get a newer version (the `N.N.N` in the filename should be larger).
+See the [handbook section](https://github.com/sourcegraph/about#handbook) in the repository README.


### PR DESCRIPTION
There is now a simple `make serve` command that will run docsite, and the instructions for running were in two places. This points folks at the README as the source of truth.