### PR TITLE
Update docsite to 1.4

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,7 +2,7 @@
 
 base = "website"
 publish = "website/public"
-command = "curl -sSL -o /tmp/docsite https://github.com/sourcegraph/docsite/releases/download/v1.1.0/docsite_v1.1.0_linux_amd64 && chmod +x /tmp/docsite && (cd .. && /tmp/docsite check) && yarn run build"
+command = "curl -sSL -o /tmp/docsite https://github.com/sourcegraph/docsite/releases/download/v1.4.0/docsite_v1.4.0_linux_amd64 && chmod +x /tmp/docsite && (cd .. && /tmp/docsite check) && yarn run build"
 
 [build.environment]
   YARN_VERSION = "1.15.2"


### PR DESCRIPTION
It looks like newer versions of the docsite have been released, but we aren't actually using the newest version when we are doing builds through netlify (which is where the previews are generated).