### PR TITLE
Adding Austin Harshberger to company/team/index.md

### DIFF
--- a/company/team/index.md
+++ b/company/team/index.md
@@ -370,6 +370,13 @@ To add yourself to this page, copy the following template, paste it at the end o
 - [elizabeth@sourcegraph.com](mailto:elizabeth@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/elizabeth-stirling-753b2779/)
 - Elizabeth is a Seattle area native who loves exploring the city. She has been interested in security ever since reading [Neal Stephenson's novel Reamde](https://www.amazon.com/Reamde-Novel-Neal-Stephenson/dp/0062191497) when she was a kid. Her spare time is spent hiking around the forests of the Pacific Northwest and working on whatever side project catches her fancy. She has spent far too much money on keyboards and pretty rocks - sometimes even forging her own Bismuth crystals. Elizabeth graduated with a B.S. in Computer Science from the University of Washington in Seattle. 
 
+## Austin Harshberger (he/him)
+
+- Customer Engineer
+- San Francisco, CA, USA, 🇺🇸
+- [austin@sourcegraph.com](mailto:austin@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/aharshbe/), [GitHub](https://github.com/aharshbe), [Click here + 🔊 to have Google pronounce my name](https://translate.google.com/#view=home&op=translate&sl=auto&tl=en&text=Austin%20Harshberger)
+- First off, Austin isn't a huge fan of writing in the first person, or maybe he's just trying to be funny... 😂 Austin is a San Francisco transplant originally from the suburbs of San Bernadino (30 miles from LA). He enjoys programming and watching Netflix during his free time, is an avid ⌚ collector, gamer, and a novice gemologist 💎 Also, you might be able to steal a laugh if you find Austin at an indoor bouldering gym trying not to fall 🧗‍♂️; he often does so. Before joining Sourcegraph, Austin worked at Coinbase where he helped to prevent employees from getting pwned by deploying numerous automation techniques to relentlessly but effectively patch endpoints. Before that, Austin worked at GitHub where he helped large enterprise customers to improve their development workflows by providing training as well as custom integrations of GitHub Enterprise appliances. He is friendly, inquisitive, very high energy and loves meeting new people so don't hesitate to say "hi" 👋
+
 <!-- Paste *your* section above this line by following our template below:
 
 ## Full Name (optional pronouns)


### PR DESCRIPTION
Adding new hire Austin Harshberger from Customer Engineering to company/team/index per [new hire onboarding tasks](https://about.sourcegraph.com/handbook/people-ops/onboarding#for-all-new-teammates). Please let me know if there are any typos or suggested edits, cheers!