### PR TITLE
cloud: Team page updates

### DIFF
--- a/handbook/engineering/cloud/index.md
+++ b/handbook/engineering/cloud/index.md
@@ -17,7 +17,59 @@ The cloud team owns all work that is necessary to build, secure, scale, and oper
 
 ## Processes
 
-We do [weekly check-ins](../tracking_issues.md#using-a-tracking-issue-for-progress-check-ins) and [monthly planning](../tracking_issues.md#planning-a-milestone-with-a-tracking-issue).
+### Planning
+
+We meet every month for a planning session as the current iteration approaches its ends. In this meeting we collaborate on what our few and focused goals for the iteration should be, what their scope is and which teammates work on what.
+These goals are then captured in an iteration [tracking issue](../tracking_issues.md).
+
+It's fine for an iteration to start with only clear goals and for the specific work to make progress on those to be discovered afterwards.
+
+### Updates
+
+We do regular updates to communicate our progress to members of the team, and to external stakeholders.
+
+#### Daily personal Slack updates
+
+Collaborating across timezones requires regular communication to keep each other updated on progress, and coordinate work handoff if needed. We use daily Slack updates to achieve this.
+
+Every day, Slackbot will post a reminder in the #cloud channel for you to write your daily update.
+
+**At the end of each working day**, you should post your update as a threaded response to the Slackbot message.
+
+You should include in your update:
+- What you worked on during your day.
+- Whether you're blocked on anything to make progress (a code review, input in an RFC or in a GitHub issue...).
+- What you plan on tackling next.
+
+**At the beginning of each working day**, you should read the updates thread for the previous working day, to learn what your teammates have been working on, and check if they need your help.
+
+#### Weekly goal updates in the tracking issue
+
+We use weekly [progress updates in the tracking issue](../tracking_issues.md#progress_updates) to inform external stakeholders of the progress of the team on the iteration goals.
+
+Every Friday, Slackbot will post a reminder in #cloud for us to write weekly progress updates for each goal in the iteration.
+
+The teammates working on a goal are responsible for this update which is essentially the written version of what should be communicated in the Cloud Sync meetings the next Monday.
+
+### Retrospectives
+
+After the 20th of each month, we hold a retrospective, to reflect on the past iteration. We use this retrospective to:
+- Understand whether we accomplished the goals we set at the beginning of the iteration. If we didn't accomplish them, reflect on the reasons why.
+- Discuss things that didn't go well in the iteration, and identify action items to improve on these in the next iteration.
+- Discuss things that went well in the past iteration, and that we should do more of / invest more into.
+
+At the beginning of each iteration, the engineering manager will:
+- Schedule the retrospective meeting
+- Set up a Slack reminder three days before the retrospective meeting, asking teammates to write their discussion topics in the retrospective document
+
+## Team syncs
+
+The cloud team holds weekly syncs.
+
+The meeting notes can be found [in this doc](https://docs.google.com/document/d/1CeSzdNK1lUnEr02TvllxTxkkYlwGhs4mMHCTt3D-ZGw/).
+
+Before team syncs, teammates and stakeholders should write down under "Discussion items" in the meeting notes document anything that they'd like to bring up for discussion with the whole team.
+
 
 ## Members
 
@@ -37,4 +89,4 @@ _Updated 2020-07-03_
 
 We are hiring for these roles:
 
-- +1 [Software Engineer - Backend](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-backend.md)
+- +1 Software Engineer - Full Stack (Job req TBD)

--- a/handbook/engineering/cloud/index.md
+++ b/handbook/engineering/cloud/index.md
@@ -89,4 +89,4 @@ _Updated 2020-07-03_
 
 We are hiring for these roles:
 
-- +1 Software Engineer - Full Stack (Job req TBD)
+- +1 [Software Engineer - Backend](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-backend.md)


### PR DESCRIPTION
This commit updates the Cloud team page with a number of changes:

- Latest planning process
- Daily updates
- Changing weekly updates to be goal updates rather than personal ones
- Retrospectives section
- Team syncs
- Full stack engineer in Hiring section (job req TBD and discussed with
the team in the next sync)