### PR TITLE
Security roles and responsibilities

### DIFF
--- a/handbook/engineering/security/index.md
+++ b/handbook/engineering/security/index.md
@@ -11,7 +11,7 @@ At Sourcegraph we think that security is an enabler for the business. Sourcegrap
 ## Responsibilities
 
 - Proactively improve the security of our application and infrastructure.
-    - Identify what our security needs are and develop a roadmap to improve and ensure the security of our product.
+- Define, plan, and prioritize security work that needs to be done (and then go do that work).
 - Directly contribute to our codebase (i.e., Go, TypeScript, Kubernetes, Docker, Google Cloud Platform) to secure our application and deployments, and help other engineers on our team make the necessary changes.
 - [Respond to security vulnerability reports](#how-we-respond-to-security-vulnerability-reports)
     - https://github.com/sourcegraph/security-issues

--- a/handbook/engineering/security/index.md
+++ b/handbook/engineering/security/index.md
@@ -12,7 +12,7 @@ At Sourcegraph we think that security is an enabler for the business. Sourcegrap
 
 - Proactively improve the security of our application and infrastructure.
     - Identify what our security needs are and develop a roadmap to improve and ensure the security of our product.
-- Directly contribute to our codebase (i.e., Go, TypeScript, Kubernetes, Docker, Google Cloud Platform), and help other engineers on our team make the necessary changes.
+- Directly contribute to our codebase (i.e., Go, TypeScript, Kubernetes, Docker, Google Cloud Platform) to secure our application and deployments, and help other engineers on our team make the necessary changes.
 - [Respond to security vulnerability reports](#how-we-respond-to-security-vulnerability-reports)
     - https://github.com/sourcegraph/security-issues
 - Increase our security posture by running traditional security tools such as vulnerability scanners, SAST, and DAST tools.

--- a/handbook/engineering/security/index.md
+++ b/handbook/engineering/security/index.md
@@ -11,11 +11,14 @@ At Sourcegraph we think that security is an enabler for the business. Sourcegrap
 ## Responsibilities
 
 - Proactively improve the security of our application and infrastructure.
-- Implement automated security scanning of our codebase and infrastructrure, and resolve issues.
-    - https://github.com/sourcegraph/sourcegraph/security/code-scanning
+    - Identify what our security needs are and develop a roadmap to improve and ensure the security of our product.
+- Directly contribute to our codebase (i.e., Go, TypeScript, Kubernetes, Docker, Google Cloud Platform), and help other engineers on our team make the necessary changes.
 - [Respond to security vulnerability reports](#how-we-respond-to-security-vulnerability-reports)
-- Investigate, respond to, and resolve vulnerabilities.
     - https://github.com/sourcegraph/security-issues
+- Increase our security posture by running traditional security tools such as vulnerability scanners, SAST, and DAST tools.
+    - https://github.com/sourcegraph/sourcegraph/security/code-scanning
+- Create a culture of security at Sourcegraph that empowers all of our engineers to write secure code.
+
     
 ## Roadmap
 


### PR DESCRIPTION
Moving the roles and responsibilities from the job description and into the team page. I also took the opportunity to remove deplicates.