### PR TITLE
add auto-compiled goals page, add top company goals

### DIFF
--- a/company/goals/guidelines.md
+++ b/company/goals/guidelines.md
@@ -1,0 +1,73 @@
+# Guidelines for goals
+
+Our company goals are public:
+
+- [New *continuously updated* goals starting as of FY20-Q3 (upcoming, not publicly visible yet, will be moved to handbook soon)](https://docs.google.com/document/d/1Z6avFUmnGW-ZC6zrktqqQd_g5mhBE96C_mTwXwFc1H4/edit#)
+- Historical snapshots:
+  - [FY20-Q2 (active)](2020_q2.md)
+  - [FY20-Q1](2020_q1.md)
+  - [CY19-Q4](2019_q4.md)
+  - [CY19-Q3](2019_q3.md)
+
+## Philosophy
+
+We believe:
+
+- "Plans are useless, but planning is essential."
+- "No plan survives first contact with the customer."
+- "A plan is only useful for determining the immediate next thing to do. Beyond that, you must be ready to abandon the plan in the face of new evidence."
+- Discarding a goal that turns out to be wrong is better than following through on the wrong goal. People know this intellectually but disregard it in practice.
+- Each problem we're solving has a different (and often unknown/unknowable) timeline and rate of progress.
+- Only people with skin in the game can set useful goals.
+- A goal is good if people think about it regularly and it helps them make decisions.
+
+## Goals are continuous, not quarterly
+
+1. Goals are continuously updated, and each goal specifies its own time period. They are not (for example) quarterly.
+   - No single update/review cadence (such as quarterly) makes sense for all goals.
+1. Change your goal immediately if/when you discover it's the wrong goal.
+   - Reflect on why you needed to change the goal (so you can learn), but don't keep working toward the wrong goal.
+
+## Choosing goals
+
+A goal's format is:
+
+> **Goal title** \
+> Description of the goal and how to evaluate whether we met the goal (with a link to an automatically updated metrics dashboard, if appropriate).
+
+1. Each goal has a single person (not multiple people) who's ultimately responsible for it.
+   - Many people can be working toward a goal, but there must be one person who's ultimately responsible.
+   - It's OK for a team to own a goal. That means the manager is ultimately responsible for it. A team should not have more than 1 or 2 goals (to make sure it's not becoming a workgroup with too many disparate goals).
+1. No person can have more than 5 goals at once. (This number is arbitrary, but it feels right.) Fewer is better.
+1. Pick goals where failure would be painful.
+1. Pick goals where you can influence the outcome. Avoid using a lagging indicator as a goal.
+1. For a new project, it can be hard to define the right goal and measurement. Do your best. (You can just list some metrics to track if you don't know what numeric target to set yet.) Then refine the goal as you learn more.
+1. Set goals to be ambitious but achievable, so that they convey your aims and what you could achieve if things go well.
+   - Goals are **not** the 99.99% likelihood outcome or the 1% moonshot outcome.
+1. Goals are for communication and alignment (everyone knowing what's important, why, and how it'll get done), **not** for estimation, scheduling, or promising/committing.
+   - Setting a goal for _X_ is not the same as _committing_ to shipping _X_ to customers. We are much more conservative in setting expectations with customers about firm ship dates than we are in setting goals.
+   - Write your goals so they communicate effectively to an audience who understands that goals aren't promises. Don't write goals so cautiously that they are hard to understand. (For example, "Improve code intelligence support for Java" is a good goal, especially with well defined outcomes. But "Investigate feasibility of improvements to Java code intelligence" is probably bad.)
+1. If a goal's success criteria can be reduced to a single quantitative metric, that's great. But don't try to force it. It's OK to rely on human judgment to judge the success of a goal.
+
+### Sensitive information
+
+Do not include any specific financial numbers, customer names, or any other sensitive information in the public goals. Instead, use placeholders (such as *N<sub>0</sub>*, *N<sub>1</sub>*, and so on) and link to the definitions in a Google Doc that is only visible to Sourcegraph team members.
+
+## Progress updates
+
+1. As you make progress toward a goal, add `Status: ...` with a brief description of the progress. If possible, link to a live dashboard tracking the progress.
+1. When you make meaningful progress toward a goal, post in the #progress channel and include a link to the PR that updates the goal's status.
+
+## Reflecting on goals
+
+We've just switched from using OKRs (which have a quarterly cadence) to continuous goals. It's important that we regularly reflect on our goals even without the quarterly cadence. We're still figuring out the best way to do this. Relevant comment from a team member:
+
+> [It will be important to have] some sort of regular reflection process or template that people write up to reflect on and report on progress. It could be a document they write every quarter that uses their goals commit log as a starting point and explains to themselves, their manager, and the rest of the team the evolution of their goals and accomplishments.
+
+> I like this idea [of regular reflections] and I think it would be really cool to be able to go to a handbook page for a team and see "what did this team do last quarter/year?".
+
+## Why not just use OKRs?
+
+- Using OKRs implies a process where the goals are defined at the start of a time period and don't change until the start of the next time period. This makes people reluctant to change their goals when they are the wrong goals, which is a bad incentive. Realizing the goals are wrong and quickly changing them is way better than hitting the wrong goals.
+- [We don't like jargon and acronyms](https://about.sourcegraph.com/handbook/communication/style_guide#jargon-and-acronyms), and "OKR" is both. Why say "objective" when you can say "goal"? Why say "key result" and not just "result"? Questions like these make people think that there's some special science behind OKRs, when really the hard part is the fundamentally hard problem of coming up with the right goals.
+- There are so many ways to "do [OKRs](https://en.wikipedia.org/wiki/OKR)." Why name the overall goal-setting process after something that defines just a small part of the overall process?

--- a/company/goals/index.md
+++ b/company/goals/index.md
@@ -1,73 +1,108 @@
 # Goals
 
-Our company goals are public:
+Our company goals are public.
 
-- [New *continuously updated* goals starting as of FY20-Q3 (upcoming, not publicly visible yet, will be moved to handbook soon)](https://docs.google.com/document/d/1Z6avFUmnGW-ZC6zrktqqQd_g5mhBE96C_mTwXwFc1H4/edit#)
-- Historical snapshots:
-  - [FY20-Q2 (active)](2020_q2.md)
-  - [FY20-Q1](2020_q1.md)
-  - [CY19-Q4](2019_q4.md)
-  - [CY19-Q3](2019_q3.md)
+See "[Guidelines for goals](guidelines.md)" for more information about how we choose and use goals at Sourcegraph. Need to [edit the goals on this page](#how-to-edit)?
 
-## Philosophy
+<div id="goals-loading">
+	Compiling goals...
+	<br/>
+	<small>If the goals do not appear, please <a href="https://github.com/sourcegraph/about/issues">report this issue</a> and include the output from your browser's devtools JavaScript console.</small>
+</div>
 
-We believe:
+## [Top company goals](../../handbook/ceo/index.md#goals)
 
-- "Plans are useless, but planning is essential."
-- "No plan survives first contact with the customer."
-- "A plan is only useful for determining the immediate next thing to do. Beyond that, you must be ready to abandon the plan in the face of new evidence."
-- Discarding a goal that turns out to be wrong is better than following through on the wrong goal. People know this intellectually but disregard it in practice.
-- Each problem we're solving has a different (and often unknown/unknowable) timeline and rate of progress.
-- Only people with skin in the game can set useful goals.
-- A goal is good if people think about it regularly and it helps them make decisions.
+## Engineering
+<!-- When updating the engineering team list below, please also update handbook/index.md. -->
+### [Cloud team](../../handbook/engineering/cloud/index.md#goals)
+### [Distribution team](../../handbook/engineering/distribution/goals.md)
+### [Search team](../../handbook/engineering/search/index.md#goals)
 
-## Goals are continuous, not quarterly
+## [Product](../../handbook/product/goals.md)
 
-1. Goals are continuously updated, and each goal specifies its own time period. They are not (for example) quarterly.
-   - No single update/review cadence (such as quarterly) makes sense for all goals.
-1. Change your goal immediately if/when you discover it's the wrong goal.
-   - Reflect on why you needed to change the goal (so you can learn), but don't keep working toward the wrong goal.
+---
 
-## Choosing goals
+## How to edit
 
-A goal's format is:
+This page is generated automatically based on the contents of other handbook pages.
 
-> **Goal title** \
-> Description of the goal and how to evaluate whether we met the goal (with a link to an automatically updated metrics dashboard, if appropriate).
+1. To add a team's goals, [edit this page](https://github.com/sourcegraph/about/edit/master/company/goals/index.md) and add a link to the section of the team's page that lists the goals (such as `### [My team](../../handbook/myteam/index.md#goals)`). If the entire page is about goals, omit the section from the URL (for example, omit `#goals`).
+1. To edit a team's goals, edit the linked section on the team's page. In the example above, you'd edit the `Goals` section of `../../handbook/myteam/index.md`. Everything in that section until the next same-level heading is displayed on this page.
+1. To add any other text or structure to this page, just insert it as you would normally. Only 3rd-level heading links (lines that start with `###` and that have a link) are treated specially; all other content is preserved.
 
-1. Each goal has a single person (not multiple people) who's ultimately responsible for it.
-   - Many people can be working toward a goal, but there must be one person who's ultimately responsible.
-   - It's OK for a team to own a goal. That means the manager is ultimately responsible for it. A team should not have more than 1 or 2 goals (to make sure it's not becoming a workgroup with too many disparate goals).
-1. No person can have more than 5 goals at once. (This number is arbitrary, but it feels right.) Fewer is better.
-1. Pick goals where failure would be painful.
-1. Pick goals where you can influence the outcome. Avoid using a lagging indicator as a goal.
-1. For a new project, it can be hard to define the right goal and measurement. Do your best. (You can just list some metrics to track if you don't know what numeric target to set yet.) Then refine the goal as you learn more.
-1. Set goals to be ambitious but achievable, so that they convey your aims and what you could achieve if things go well.
-   - Goals are **not** the 99.99% likelihood outcome or the 1% moonshot outcome.
-1. Goals are for communication and alignment (everyone knowing what's important, why, and how it'll get done), **not** for estimation, scheduling, or promising/committing.
-   - Setting a goal for _X_ is not the same as _committing_ to shipping _X_ to customers. We are much more conservative in setting expectations with customers about firm ship dates than we are in setting goals.
-   - Write your goals so they communicate effectively to an audience who understands that goals aren't promises. Don't write goals so cautiously that they are hard to understand. (For example, "Improve code intelligence support for Java" is a good goal, especially with well defined outcomes. But "Investigate feasibility of improvements to Java code intelligence" is probably bad.)
-1. If a goal's success criteria can be reduced to a single quantitative metric, that's great. But don't try to force it. It's OK to rely on human judgment to judge the success of a goal.
+<script>
+// This script injects the goals content into each section of this page that links to a team page.
+// It is similar to the script used to generate the org chart in ../team/org_chart.md.
 
-### Sensitive information
+const getHeadingLevel = heading => heading instanceof HTMLHeadingElement ? parseInt(heading.tagName.slice(1), 10) : undefined
 
-Do not include any specific financial numbers, customer names, or any other sensitive information in the public goals. Instead, use placeholders (such as *N<sub>0</sub>*, *N<sub>1</sub>*, and so on) and link to the definitions in a Google Doc that is only visible to Sourcegraph team members.
+const cloneHeading = (origHeading, level) => {
+	const newHeading = document.createElement(`h${level}`)
+	newHeading.innerHTML = origHeading.innerHTML
+	return newHeading
+}
 
-## Progress updates
+async function getPageSectionContent(pageUrl, level) {
+	const sectionId = pageUrl.includes('#') ? pageUrl.replace(/^.*#/, '') : null
 
-1. As you make progress toward a goal, add `Status: ...` with a brief description of the progress. If possible, link to a live dashboard tracking the progress.
-1. When you make meaningful progress toward a goal, post in the #progress channel and include a link to the PR that updates the goal's status.
+	const resp = await fetch(pageUrl)
+	const doc = new DOMParser().parseFromString(await resp.text(), "text/html")
+	const section = sectionId ? doc.getElementById(sectionId) : doc.querySelector('.markdown-body > h1')
+	if (!section) {
+		const error = document.createElement('p')
+		error.innerText = `Error compiling goals: page at ${pageUrl} has no ${sectionId ? `section with ID ${sectionId}` : 'content'}.`
+		return error
+	}
 
-## Reflecting on goals
+	const wrapper = document.createElement('section')
+	const iterator = doc.createNodeIterator(doc, NodeFilter.SHOW_ELEMENT, () => NodeFilter.FILTER_ACCEPT)
+	let curNode
+	let started = false
+	let startLevel = undefined
+	let demoteByLevels = undefined
+	while (curNode = iterator.nextNode()) {
+		if (curNode instanceof HTMLHeadingElement && sectionId ? curNode.id === sectionId : curNode === section) {
+			started = true
+			startLevel = getHeadingLevel(curNode)
+			demoteByLevels = level - startLevel
+			continue
+		}
+		if (started) {
+			if (curNode instanceof HTMLHeadingElement) {
+				const curNodeLevel = getHeadingLevel(curNode)
 
-We've just switched from using OKRs (which have a quarterly cadence) to continuous goals. It's important that we regularly reflect on our goals even without the quarterly cadence. We're still figuring out the best way to do this. Relevant comment from a team member:
+				if (curNodeLevel <= startLevel) {
+					// End at next same-level heading.
+					break
+				}
 
-> [It will be important to have] some sort of regular reflection process or template that people write up to reflect on and report on progress. It could be a document they write every quarter that uses their goals commit log as a starting point and explains to themselves, their manager, and the rest of the team the evolution of their goals and accomplishments.
+				// Demote headings so that the injected content's headings are smaller.
+				const demotedLevel = Math.min(curNodeLevel + demoteByLevels, 6)
+				curNode = cloneHeading(curNode, demotedLevel)
+			}
 
-> I like this idea [of regular reflections] and I think it would be really cool to be able to go to a handbook page for a team and see "what did this team do last quarter/year?".
+			wrapper.appendChild(curNode)
+		}
+	}
 
-## Why not just use OKRs?
+	return wrapper
+}
 
-- Using OKRs implies a process where the goals are defined at the start of a time period and don't change until the start of the next time period. This makes people reluctant to change their goals when they are the wrong goals, which is a bad incentive. Realizing the goals are wrong and quickly changing them is way better than hitting the wrong goals.
-- [We don't like jargon and acronyms](https://about.sourcegraph.com/handbook/communication/style_guide#jargon-and-acronyms), and "OKR" is both. Why say "objective" when you can say "goal"? Why say "key result" and not just "result"? Questions like these make people think that there's some special science behind OKRs, when really the hard part is the fundamentally hard problem of coming up with the right goals.
-- There are so many ways to "do [OKRs](https://en.wikipedia.org/wiki/OKR)." Why name the overall goal-setting process after something that defines just a small part of the overall process?
+const sectionHeaders = Array.from(document.querySelectorAll('h2,h3')).filter(section => Boolean(section.querySelector('a[href]:not([aria-hidden])')))
+Promise.all(
+	sectionHeaders.map(async sectionHeader => ({
+		header: sectionHeader,
+		content: await getPageSectionContent(
+			sectionHeader.querySelector('a[href]:not([aria-hidden])').href,
+			getHeadingLevel(sectionHeader)
+		),
+	}))
+).then(sections => {
+	const loading = document.getElementById('goals-loading')
+	loading.innerHTML = '' // clear
+
+	for (const {header, content} of sections) {
+		header.parentNode.insertBefore(content, header.nextSibling)
+	}
+})
+</script>

--- a/company/team/org_chart.md
+++ b/company/team/org_chart.md
@@ -40,6 +40,7 @@ This org chart is generated automatically based on the contents of other handboo
 
 <script>
 // This script injects the org chart content into each section of this page that links to a team page.
+// It is similar to the script used to compile the goals in ../goals/index.md.
 
 async function getPageOrgChart(pageUrl) {
 	const sectionId = pageUrl.replace(/^.*#/, '')
@@ -83,10 +84,10 @@ Promise.all(
 ).then(sections => {
 	const loading = document.getElementById('org-chart-loading')
 	loading.innerHTML = '' // clear
-	
+
 	for (const {header, content} of sections) {
 		header.parentNode.insertBefore(content, header.nextSibling)
-		
+
 		// Make header link to top of page, not the members section.
 		const headerLink = header.querySelector('a[href]:not([aria-hidden])')
 		const headerLinkUrl = new URL(headerLink.href)

--- a/handbook/ceo/index.md
+++ b/handbook/ceo/index.md
@@ -4,6 +4,44 @@ I (Quinn Slack) am the CEO of Sourcegraph. This page describes my responsibiliti
 
 My personal site is [slack.org](https://slack.org).
 
+## Goals
+
+Everyone at Sourcegraph contributes to these top company goals, but the CEO is *ultimately* responsible for achieving these goals through building the right team and setting the right [strategy](../../company/strategy.md).
+
+### Grow adoption
+
+Owner: @sqs
+
+We want to grow the number of people who actually regularly choose to use Sourcegraph. This is a leading indicator of progress toward our mission to make it so everyone can code.
+
+- We say "adoption" not just "usage" or "awareness" because we don't want just drive-by/one-time visitors.
+- We want to target people whose adoption would lead to us getting more customers.
+- Ideally, the ways in which we grow adoption are scalable (that is, they can be extrapolated over time to reach ~10M+ devs monthly).
+
+We'll measure adoption using a combination of the following metrics (WIP):
+
+- User feedback, as measured by the NPS survey
+- Number of first-time users
+- Cohort retention
+
+First, we need to get solid measurements of all of these numbers. Then we will set quantitative targets.
+
+### Grow pipeline
+
+Owner: @sqs
+
+Our pipeline is the list of organizations that we think will pay for Sourcegraph in the future (see [sales stages](../sales/index.md#stages)). This is a way to predict our future revenue. Revenue, like user adoption, is a leading indicator of progress toward our mission, and pipeline is a leading indicator of revenue.
+
+We'll measure goal success using 2 pipeline coverage ratios (which show how much pipeline we have relative to the amount of revenue we'd like to book in a period):
+
+- New customer pipeline coverage
+- Expansion pipeline coverage
+
+We have plans for these figures already, and we'll revisit the quantitative targets when we have Sales and Customer Success leadership in place starting in early Aug 2020.
+
+> Why choose pipeline, not revenue, as the goal? Revenue is a lagging indicator. Something you do today (such as shipping a new feature or making new people aware of Sourcegraph) can show up in pipeline within hours or days if it generates interest from a prospect, but it may take weeks or months to turn into a signed deal and actual revenue. As long as our sales team is rigorous about measuring pipeline, everyone else can rely on the pipeline abstraction for their own goal-setting.
+
+
 ## Responsibilities
 
 See "[Roles of the CEO](roles.md)".

--- a/handbook/ceo/roles.md
+++ b/handbook/ceo/roles.md
@@ -11,3 +11,4 @@ This page lists the roles and responsibilities of the Sourcegraph CEO.
 - Engage with the current and prospective Sourcegraph community in person, on social media, etc.
 - Create an environment and a set of processes to support giving teammates a high level of ownership over their work.
 - Lead by example in accountability, continuous improvement, and truth-seeking.
+- Achieve the [current CEO goals](index.md#goals).


### PR DESCRIPTION
The goals page now (automatically) compiles the goals from other pages in the handbook. All existing handbook pages with goal content are included.

Also adds the top company goals.

![image](https://user-images.githubusercontent.com/1976/88884598-d0debf00-d1eb-11ea-8e1d-ccc5eb8982e5.png)
