### PR TITLE
Set social image to logo mark

### DIFF
--- a/website/src/templates/blogPostTemplate.tsx
+++ b/website/src/templates/blogPostTemplate.tsx
@@ -48,9 +48,7 @@ export default class BlogPostTemplate extends React.Component<any, any> {
         const fileName = md.fileAbsolutePath.split('blogposts/').pop()
         const description = md.frontmatter.description ? md.frontmatter.description : md.excerpt
         const content = md.html
-        const image = md.frontmatter.heroImage
-            ? `${md.frontmatter.heroImage}`
-            : 'https://about.sourcegraph.com/sourcegraph-mark.png'
+        const image = 'https://about.sourcegraph.com/sourcegraph-mark.png'
         const meta = {
             title,
             image,


### PR DESCRIPTION
Until we can figure out a design in blog images that satisfies the OG sizes of social sites, I set the default to be our logo mark.  

To preview, go to:  https://cards-dev.twitter.com/validator
Use this URL: https://deploy-preview-1310--sourcegraph.netlify.app/blog/sourcegraph-3.18
