### PR TITLE
cloud: document manual migrations we're performing

### DIFF
--- a/handbook/engineering/cloud/index.md
+++ b/handbook/engineering/cloud/index.md
@@ -14,6 +14,7 @@ The cloud team owns all work that is necessary to build, secure, scale, and oper
 ## Resources
 
 - [Tracking Issues](https://github.com/sourcegraph/sourcegraph/issues?utf8=%E2%9C%93&q=is%3Aissue+label%3Ateam%2Fcloud+label%3Atracking)
+- [Manual migrations](manual_migrations.md)
 
 ## Processes
 

--- a/handbook/engineering/cloud/manual_migrations.md
+++ b/handbook/engineering/cloud/manual_migrations.md
@@ -28,5 +28,5 @@ https://github.com/sourcegraph/sourcegraph/pull/12591
 Exact SQL:
 
 ```sql
-TODO(beyang,rijnard)
+CREATE INDEX CONCURRENTLY repo_name_idx ON public.repo USING btree (lower(name::text) COLLATE pg_catalog."C");
 ```

--- a/handbook/engineering/cloud/manual_migrations.md
+++ b/handbook/engineering/cloud/manual_migrations.md
@@ -1,0 +1,32 @@
+# Cloud manual migrations
+
+Sourcegraph.com occassionally requires migrations be ran against it that are not ran against other deployments of Sourcegraph.
+
+Examples of this include:
+
+- Modifying DB users, which may not always be possible in customer environments https://github.com/sourcegraph/sourcegraph/pull/12561
+- One-off index modification tests like https://twitter.com/beyang/status/1287826896281989120 that _should_ eventually become migrations in our product.
+
+We soon want to eliminate the need for such manual migrations against prod ([tracking issue](https://github.com/sourcegraph/sourcegraph/issues/12590)), but in the meantime this document serves as a list of manual migrations that have been ran against production.
+
+## Aug 3rd, 2020 - read only user addition
+
+https://github.com/sourcegraph/sourcegraph/pull/12561
+
+Exact SQL:
+
+```sql
+TODO(efritz,chayim)
+```
+
+## July 27th, 2020 - index addition
+
+https://twitter.com/beyang/status/1287826896281989120
+
+https://github.com/sourcegraph/sourcegraph/pull/12591
+
+Exact SQL:
+
+```sql
+TODO(beyang,rijnard)
+```

--- a/handbook/engineering/cloud/manual_migrations.md
+++ b/handbook/engineering/cloud/manual_migrations.md
@@ -19,7 +19,11 @@ Exact SQL:
 TODO(efritz,chayim)
 ```
 
+**Impact if this migration is undone:** Sourcegraph personnel would need to use the write-only `sg` user, does not impact product or performance behavior.
+
 ## July 27th, 2020 - index addition
+
+https://gist.github.com/rvantonder/7745c2360cfced6f12c922588bfbef79
 
 https://twitter.com/beyang/status/1287826896281989120
 
@@ -30,3 +34,5 @@ Exact SQL:
 ```sql
 CREATE INDEX CONCURRENTLY repo_name_idx ON public.repo USING btree (lower(name::text) COLLATE pg_catalog."C");
 ```
+
+**Impact if this migration is undone:** Degraded performance when searching a lot of repos with a common prefix, no impact otherwise.


### PR DESCRIPTION
Historically Sourcegraph.com has not been a priority for us, and as such we do not have Sourcegraph.com-only migrations today. See https://github.com/sourcegraph/sourcegraph/issues/12590

This means that today there have been a number of migrations, indexes, etc. that have been applied by hand against the Sourcegraph.com production DB. Some of these have been captured in the [Ops incidents log](https://docs.google.com/document/d/1dtrOHs5STJYKvyjigL1kMm6u-W0mlyRSyVxPfKIOfEw/edit) but I fear the vast majority have not.

Recently, we saw another one performed and [have a need to perform one that gets us away from this prod-DB-tech-debt issue further](https://github.com/sourcegraph/sourcegraph/pull/12561).

Until we have a [better process in place](https://github.com/sourcegraph/sourcegraph/issues/12590), this document will serve as a record of which manual migrations were ran against prod, when, why, and how.