### PR TITLE
Remind people of your role in internal meetings

### DIFF
--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -25,6 +25,7 @@ Company meeting is an effective way to:
      - Example: "On campaigns, we heard from Acme Corp that..." vs. "Campaigns let you make large-scale fixes across all of your code. Acme Corp told us that..."
 	 - Example: "Marketing update: our new lead sources..." vs. "Marketing is about getting enterprise developers to know about and want to try Sourcegraph. Our new lead sources..."
    - Remember that other team members are new to the company and/or busy on their own projects.
+1. When speaking, remind people of your role. For example: `I'm Alice Zhao, a developer on the security team` or `I'm Bob Schmidt, and I run the website on our marketing team`.
 1. Don't make announcements or share other specific information that you expect everyone to remember.
   - You can't assume everyone is attending company meeting and is paying attention.
   - Use company meeting to give a reminder, but make sure the announcement is in [Slack](team_chat.md), in email, and/or on the calendar.

--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -48,6 +48,7 @@ The following places are not sources of truth. Treat documents and conversations
   - Enable "Guest permissions: Modify event" so that other people can easily reschedule the meeting if needed.
 - Add a Google Doc link to the event description for taking notes during the meeting.
   - If the meeting is recurring, use the same Google Doc for all meetings.
+- Remind people of your role in cross-functional meetings (including company meeting) or any other meeting that has team members you haven't met yet. We're growing, and it's hard to remember everyone's role! (The [org chart](../../company/team/org_chart.md) helps.)
 
 #### Structured meetings
 


### PR DESCRIPTION
As we grow, it's hard for everyone (especially new people) to remember what each person does. Give a quick reminder when you're speaking at company meeting, other cross-functional meetings, and any other meetings with folks who might not know.

(Thanks to Gregg for this tip!)