### PR TITLE
The handbook is a living document

### DIFF
--- a/handbook/index.md
+++ b/handbook/index.md
@@ -2,6 +2,8 @@
 
 The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's publicly visible because we are an [open company](../company/open_source_open_company.md#open-company).
 
+The handbook is a living document and we expect every teammate to propose changes, additions, and fixes to keep it continuously up-to-date and accurate. [How to edit the handbook](https://about.sourcegraph.com/handbook/editing).
+
 ## Company
 
 - [Strategy](../company/strategy.md)

--- a/handbook/index.md
+++ b/handbook/index.md
@@ -2,7 +2,7 @@
 
 The Sourcegraph handbook describes how we (Sourcegraph teammates) work. It's publicly visible because we are an [open company](../company/open_source_open_company.md#open-company).
 
-The handbook is a living document and we expect every teammate to propose changes, additions, and fixes to keep it continuously up-to-date and accurate. [How to edit the handbook](https://about.sourcegraph.com/handbook/editing).
+The handbook is a living document and we expect every teammate to propose improvements, changes, additions, and fixes to keep it continuously up-to-date and accurate. [How to edit the handbook](https://about.sourcegraph.com/handbook/editing).
 
 ## Company
 


### PR DESCRIPTION
A new teammate felt like it was necessary to add this clause to a new handbook page:

> "It’s also very much a work in progress; do not hesitate to recommend corrections and additions!"

More context from this person:

> it wasn't clear to me at all that the Handbook was anything other than solid, so the disclaimer makes sense to me in that "this is more fluid than the other stuff you'll find here." The phrase "the Handbook is the source of truth" implied a certain immutability to me.

Reference: https://docs.google.com/document/d/1bYn9-LvUWHBi7qiaRdHAl43744zK8RrYkvtTx2e-iGY/edit?disco=AAAAJ2B5wLI

This PR proposes language to help make it clear to all teammates that *every* page is a work in progress and special language is not necessary for any specific page.

