### PR TITLE
Remove project lead role

### DIFF
--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -46,8 +46,8 @@ When I create a campaign to make large-scale code changes I want to _focus on th
 
 ## Members
 
-- [C. P.](../../../company/team/index.md#todo) ([engineering manager](../roles.md#engineering-manager)) starting 2020-08-03.
-- [Thorsten Ball](../../../company/team/index.md#thorsten-ball-he-him) ([project lead](../roles.md#project-lead))
+- [Chris Pine](../../../company/team/index.md#todo) ([engineering manager](../roles.md#engineering-manager))
+- [Thorsten Ball](../../../company/team/index.md#thorsten-ball-he-him) 
 - [Adam Harvey](../../../company/team/index.md#adam-harvey-he-him)
 - [Erik Seliger](../../../company/team/index.md#erik-seliger)
 

--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -44,7 +44,7 @@ We track most of our work using [issues on the Sourcegraph main repository](http
 ## Members
 
 - [Aida DeWitt](../../../company/team/index.md#aida-dewitt-she-her) ([engineering manager](../roles.md#engineering-manager))
-- [Eric Fritz](../../../company/team/index.md#eric-fritz-he-him) ([project lead](../roles.md#project-lead))
+- [Eric Fritz](../../../company/team/index.md#eric-fritz-he-him) 
 - [Garo Brik](../../../company/team/index.md#garo-brik-they-them)
 - [N. S-C.](../../../company/team/index.md#todo) starting 2020-08-17
 

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -94,8 +94,8 @@ Go, Docker, Kubernetes
 
 ## Members
 
-- [Gonzalo Peci](../../../company/team/index.md#gonzalo-peci-hehim) ([engineering manager](../roles.md#engineering-manager)).
-- [Stephen Gutekanst](../../../company/team/index.md#stephen-gutekanst) ([project lead](../roles.md#project-lead))
+- [Gonzalo Peci](../../../company/team/index.md#gonzalo-peci-hehim) ([engineering manager](../roles.md#engineering-manager))
+- [Stephen Gutekanst](../../../company/team/index.md#stephen-gutekanst)
 - [Geoffrey Gilmore](../../../company/team/index.md#geoffrey-gilmore)
 - [Uwe Hoffmann](../../../company/team/index.md#uwe-hoffmann)
 - [Dave Try](../../../company/team/index.md#dave-try)

--- a/handbook/engineering/distribution/recurring_processes.md
+++ b/handbook/engineering/distribution/recurring_processes.md
@@ -57,7 +57,7 @@ feasible set of work with clear lines of ownership.
    judgment) by unassigning themselves, but keeping the issue in the milestone. Use the goals as a
    guidepost for prioritization.
 1. In a meeting (budget an hour), go through the tracking issue as a team.
-   1. Prior to the meeting, the project lead should estimate how long each discussion item should
+   1. Prior to the meeting, the engineering manager should estimate how long each discussion item should
       take, so that they can keep the meeting on schedule. The tech lead should also talk to people
       1-1 to clarify, align, and build consensus prior to the meeting. A good rule of thumb to shoot
       for is that the team is 70-80% aligned on who's working on what by the time the meeting takes
@@ -68,7 +68,7 @@ feasible set of work with clear lines of ownership.
       be skipped.
    1. For each unassigned issue, decide whether it needs to be prioritized/assigned. Otherwise, move
       it to the Backlog.
-1. If there are any remaining uncertainties following the meeting, the project lead should follow up
+1. If there are any remaining uncertainties following the meeting, the engineering manager should follow up
    1-1 to finalize the tracking issue.
 1. If the goals need to be updated, propose an update and obtain approval from the VP of
    Engineering. It may make sense to block work on issues out of line with the existing goals until
@@ -78,13 +78,13 @@ feasible set of work with clear lines of ownership.
 
 * It is *every* Distribution teammate's responsibility to understand the team's priorities and propose
   the work that aligns with these priorities.
-* It is the project lead's responsibility to ensure (1) the tracking issue is the right set of
+* It is the engineering manager's responsibility to ensure (1) the tracking issue is the right set of
   things to work on and (2) every team member is bought into the outcome of planning. How active a
   role you take in planning should depend on your read of the team at the start of planning. Common
   pitfalls are being too passive or too dictatorial. Too passive means we aren't necessarily working
   on the right things. Too dictatorial means people aren't bought into what we're working on. Avoid
   both of these. Keep in mind that no one (including you) has a monopoly on useful knowledge and
-  context, but also that the project lead exists for a reason.
+  context, but also that the engineering manager exists for a reason.
 
 ### Retrospective
 

--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -12,7 +12,7 @@ Every time you're curious or confused about something — just ask! When you do 
 
 ### Think and act like an owner
 
-At Sourcegraph, we don't think of engineers as resources — we think of them as owners of their work, who constantly reevaluate how to use their talents to be as impactful as possible. We value your opinions and ideas. You should always feel empowered to identify potential improvements and act upon them, whether they be improvements to processes (like onboarding), our handbook and general documentation, our codebase and tooling, or our product.
+At Sourcegraph, we don't think of teammates as resources — we think of them as owners of their work, who constantly reevaluate how to use their talents to be as impactful as possible. We value your opinions and ideas. You should always feel empowered to identify potential improvements and act upon them, whether they be improvements to processes (like onboarding), our handbook and general documentation, our codebase and tooling, or our product.
 
 Never assume that a problem is somebody else's to fix!
 

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -16,28 +16,6 @@ Software engineers build our product and infrastructure.
 - Support your teammates by reviewing their [code](code_reviews.md) and [RFCs](../communication/rfcs/index.md).
 - Help us build a great team by referring people who you would like to work with again, interviewing candidates, and suggesting improvements to our hiring process.
 
-## Project Lead
-
-Project Leads are Software Engineers that lead a specific project team to achieve its goals. They are torch carriers that champion a project. This role is an additional set of responsibilities that any engineer may take on once they demonstrate the necessary skills.
-
-While Project Leads need to have strong technical skills, they are not necessarily the most technically experienced engineer on the team. People and organizational skills are as important as technical know-how, so that Project Leads can effectively coordinate and align with others.
-
-Some teams with more experienced members may need less guidance in certain areas and may even share responsibilities of this role across the team.
-
-### Responsibilities
-
-- Directly contribute through code, RFCs or PR reviews for a minimum of roughly 50% of their time.
-- Ensure that the team has a roadmap that documents how it is going to achieve its [goals](../../company/goals/index.md).
-- Ensure the the team's [tracking issue](tracking_issues.md) captures the work that each teammate has committed to for each [monthly release](releases/index.md) and post a [weekly progress update](tracking_issues.md#progress-updates).
-- Help keep the team focused on their goals while keeping them aware of the higher level picture.
-- Identify blockers or productivity issues and work with the team to address them.
-- Run weekly team sync meetings.
-- Communicate progress to stakeholders and other parts of the company (e.g. at company meeting).
-- Conduct monthly [retrospectives](../../retrospectives/index.md) with their team.
-- Scale themselves out by organizing and delegating work to other teammates.
-- Mentor and coach other teammates with timely feedback as appropriate in order to uphold team values and help them grow.
-- Collaborate with engineering managers to ensure teammates have everything they need to succeed and deliver on the goals of the team.
-
 ## Engineering Manager
 
 Engineering managers lead, grow, and develop teams of software engineers.

--- a/handbook/engineering/tracking_issues.md
+++ b/handbook/engineering/tracking_issues.md
@@ -89,7 +89,7 @@ Each engineer is responsible for posting a weekly update on Friday to tracking i
     - https://github.com/sourcegraph/sourcegraph/issues/11494
 - Not as good: `Worked on #111, #444, and RFC 123`
 
-Each engineering manager (or project lead for projects that don't have a dedicated manager) is responsible for posting a weekly update on Monday. This update should be in prose, and should capture your individual progress as well as any team context that isn't obvious from the individual updates from others on the team (e.g., important team decisions, implementation milestones, pain points, changes to planned work, unexpected work that took time away from planned work). You should assume that anyone who reads your update will have read the previous individual updates, so no need to repeat anything.
+Each engineering manager is responsible for posting a weekly update on Monday. This update should be in prose, and should capture your individual progress as well as any team context that isn't obvious from the individual updates from others on the team (e.g., important team decisions, implementation milestones, pain points, changes to planned work, unexpected work that took time away from planned work). You should assume that anyone who reads your update will have read the previous individual updates, so no need to repeat anything.
 
 ## Contributing to the tracking issue tool
 

--- a/handbook/product/prioritizing.md
+++ b/handbook/product/prioritizing.md
@@ -32,12 +32,12 @@ Sometimes, we need to prioritize changes to our product on short notice due to n
 
 If the requested change is large enough that it would impact the planned [project roadmap](https://docs.google.com/document/d/1cBsE9801DcBF9chZyMnxRdolqM_1c2pPyGQz15QAvYI/edit#) of one or several [engineering teams](../engineering/index.md#teams), we should handle its prioritization as follows:
 
-1. The product manager should contact all relevant [project leads](../engineering/roles.md#project_lead), providing the following information in the form of an [RFC](../communication/rfcs/index.md):
+1. The product manager should contact all relevant [engineering managers](../engineering/roles.md#engineering_manager), providing the following information in the form of an [RFC](../communication/rfcs/index.md):
     - Description of the desired functionality.
     - Context on why is this important: the customers or prospects that would benefit from the change, the size of the opportunity, and the risks of not doing this work.
     - Desired timeline for the change: when do we need this by?
     - Desired timeline for the evaluation: how soon do we need to know whether we can deliver this?
-1. Project leads own providing a timely answer, either directly or by delegating evaluation of the request to a [software engineer](../engineering/roles.md#software-engineer) on their project team. If cross-team coordination is needed to evaluate the request, project leads own facilitating this coordination. The evaluation should be provided in the form of an [RFC](../communication/rfcs/index.md), or added to the original RFC provided by the product manager, and should include:
+1. Engineering managers own providing a timely answer, either directly or by delegating evaluation of the request to a [software engineer](../engineering/roles.md#software-engineer) on their project team. If cross-team coordination is needed to evaluate the request, engineering managers own facilitating this coordination. The evaluation should be provided in the form of an [RFC](../communication/rfcs/index.md), or added to the original RFC provided by the product manager, and should include:
     - An estimation of the amount of work needed to implement the request.
     - If the amount of work needed spans more than one milestone, a proposed breakdown of incremental changes (for example, shipping a first functional but slow implementation in milestone N then working on performance in milestone N+1).
     - An overview of work that would get deprioritized if we chose to prioritize the request.
@@ -45,10 +45,10 @@ If the requested change is large enough that it would impact the planned [projec
     - A recommendation on whether to move forward with prioritizing the request:
         - OK to move forward.
         - Recommend not moving forward: this may be because of outstanding concerns, or because prioritizing the request would lead to deprioritizing important engineering goals.
-1. Based on the evaluations provided by project leads, the product manager owns:
+1. Based on the evaluations provided by engineering manager, the product manager owns:
     - Making a final decision on whether to prioritize the request.
     - Communicating this decision to the engineering and sales/CE teams.
-1. Project leads own updating the project roadmap and iteration plans to reflect the product manager's decision. 
+1. Engineering managers own updating the project roadmap and iteration plans to reflect the product manager's decision. 
 
 ## Customer requests
 


### PR DESCRIPTION
The project lead role was created in https://github.com/sourcegraph/about/pull/774. That PR description is missing context on why it was created so I will add that context here for two reasons:
1. The context helps explain why we are now removing this role.
2. I discovered last week that at least one teammate made incorrect assumptions about why we had created this role in the first place, so I want to make it clear for everyone else too.

The project lead role was created out of necessity because we had more projects than engineering managers, and the product team needed an engineering point of contact for each project. @mrnugget had been effectively doing this role already for campaigns so we wanted to give it a name and define it so we could communicate expectations to other engineers on the team for their respective projects, and so it was clear to our product team who their point of contact was. We did NOT create this role because creating a label for this set of responsibilities bestowed special power on any single engineer that allowed them to do this job better (as I said before, @mrnugget was already doing this job effectively without having the role defined).

What has changed? Why are we removing this role?

We decided that we wanted to end up with an engineering manger per team, and we now have that outcome. These managers are responsible for the management portion of the removed project lead role, and the remaining responsibilities are those of every engineer on the team, therefore the project lead role is no longer necessary.

Similar to its creation, the removal of this role neither creates nor destroys agency or responsibility for each engineer to contribute to the success of their team. Nobody at Sourcegraph should feel constrained by their documented responsibilities.

The removal of this role does not preclude us from creating new roles that may become relevant in the future (such roles can be proposed by anyone by making a PR to the handbook).