### PR TITLE
team page has no automatically assigned reviewer

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -20,6 +20,10 @@
 /docs @sourcegraph/marketing
 /podcast @beyang
 
+# @sqs: I feel weird reviewing people's own biographies, so I'm intentionally marking this file as
+# having no owner (and therefore no automatically assigned reviewer).
+/company/team/index.md @sourcegraph/nobody
+
 /handbook/product @christinaforney
 /handbook/engineering @nicksnyder
 


### PR DESCRIPTION
I feel weird reviewing people's own biographies on the team page, so I'm intentionally marking this file as having no owner (and therefore no automatically assigned reviewer).