### PR TITLE
Update security page

### DIFF
--- a/docs/security.md
+++ b/docs/security.md
@@ -30,7 +30,7 @@ Learn more in our [pings documentation](https://docs.sourcegraph.com/admin/pings
 
 When you run Sourcegraph on your own infrastructure, all application and user access logs are stored locally only. Sourcegraph employees and contractors never have access to your Sourcegraph or the code, user data, or application data stored in it (excluding any manual intervention, such as e-mailing logs for support purposes).
 
-We maintain the following policies for sourcegraph.com data and any data provided via email or other support channels:
+We maintain the following policies for sourcegraph.com data and any data provided via e-mail or other support channels:
 - Access to all internal systems is protected by multi-factor authentication. Access is restricted to those who require it to perform their job, and is regularly reviewed and revoked upon termination or when no longer needed.
 - All sourcegraph.com application and user access logs for Sourcegraph.com are stored centrally and monitored.
 - Company policy prevents customer data from being downloaded to portable devices, such as phones, that don't have device management software in place.

--- a/docs/security.md
+++ b/docs/security.md
@@ -18,7 +18,7 @@ Sourcegraph instances that host private code are typically deployed on-premise a
 
 Self-hosted Sourcegraph instances do not send any customer code to other servers.
 
-Additionally, other than the email address of the initial installer (for customer support, security, and product notification purposes), Sourcegraph never sends any private user data, such as usernames or email addresses, or other specific data to any other servers.
+Additionally, other than the email address of the initial installer (for customer support, security, and product notification purposes), Sourcegraph never sends any private user data, such as usernames or email addresses, or other specific data to any other servers, including to sourcegraph.com.
 
 Learn more in our [pings documentation](https://docs.sourcegraph.com/admin/pings).
 
@@ -31,6 +31,7 @@ Learn more in our [pings documentation](https://docs.sourcegraph.com/admin/pings
 When running Sourcegraph on your own infrastructure, all application logs are stored locally, and never shared with Sourcegraph. Sourcegraph employees and contractors never have access to your Sourcegraph instance, or any of its data, unless explicitly shared for troubleshooting purposes.
 
 We maintain the following policies for sourcegraph.com data and any data provided via email or other support channels:
+
 - Access to all internal systems is protected by multi-factor authentication. Access is restricted to those who require it to perform their job, and is regularly reviewed and revoked upon termination or when no longer needed.
 - Service, application, and access logs for sourcegraph.com are stored centrally by Sourcegraph and monitored.
 - Company policy prevents customer data from being downloaded to portable devices, such as phones, that don't have device management software in place.
@@ -39,7 +40,9 @@ We maintain the following policies for sourcegraph.com data and any data provide
 
 ## Network security
 
-When running Sourcegraph on your own infrastructure, you are protected by the network security policies enforced by your infrastructure environment. On sourcegraph.com, we maintain the following policies:
+When running Sourcegraph on your own infrastructure, you are protected by the network security policies enforced by your infrastructure environment. 
+
+On sourcegraph.com, we maintain the following policies:
 
 - All production systems are hosted on Google Cloud Platform (https://cloud.google.com/security/), where all storage volumes are encrypted at rest, and data is encrypted in-cloud during transport.
 - All external network communication between production services occurs over TLS.
@@ -50,7 +53,9 @@ When running Sourcegraph on your own infrastructure, you are protected by the ne
 
 ## Site security
 
-Sourcegraph supports HTTPS encryption when deployed on-premises.
+Sourcegraph supports HTTPS encryption when deployed you your own infrastructure.
+
+On sourcegraph.com, we maintain the following policies:
 
 - All traffic to sourcegraph.com is transmitted over HTTPS.
 - Our operations team monitors service availability 24x7x365. They investigate alerts and potential attacks 24x7x365, triaging and responding if necessary.

--- a/docs/security.md
+++ b/docs/security.md
@@ -26,11 +26,14 @@ Learn more in our [pings documentation](https://docs.sourcegraph.com/admin/pings
 
 [Sourcegraph can be configured to enforce repository permissions from code hosts.](https://docs.sourcegraph.com/admin/repo/permissions). Unit and integration tests protect the correctness of these permissions checks.
 
-## Customer data
+## Data access
 
+When you run Sourcegraph on your own infrastructure, all application and user access logs are stored locally only. Sourcegraph employees and contractors never have access to your Sourcegraph or the code, user data, or application data stored in it (excluding any manual intervention, such as e-mailing logs for support purposes).
+
+We maintain the following policies for sourcegraph.com data and any data provided via email or other support channels:
 - Access to all internal systems is protected by multi-factor authentication. Access is restricted to those who require it to perform their job, and is regularly reviewed and revoked upon termination or when no longer needed.
-- All application and user access logs are stored centrally and monitored.
-- Company policy prevents customer data from being downloaded to portable devices, such as laptops.
+- All sourcegraph.com application and user access logs for Sourcegraph.com are stored centrally and monitored.
+- Company policy prevents customer data from being downloaded to portable devices, such as phones, that don't have device management software in place.
 - Device management is in place for remote wiping of all devices.
 - Development laptops have encrypted hard drives.
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -28,36 +28,36 @@ Learn more in our [pings documentation](https://docs.sourcegraph.com/admin/pings
 
 ## Data access
 
-When you run Sourcegraph on your own infrastructure, all application and user access logs are stored locally only. Sourcegraph employees and contractors never have access to your Sourcegraph or the code, user data, or application data stored in it (excluding any manual intervention, such as e-mailing logs for support purposes).
+When running Sourcegraph on your own infrastructure, all application logs are stored locally, and never shared with Sourcegraph. Sourcegraph employees and contractors never have access to your Sourcegraph instance, or any of its data, unless explicitly shared for troubleshooting purposes.
 
 We maintain the following policies for sourcegraph.com data and any data provided via e-mail or other support channels:
 - Access to all internal systems is protected by multi-factor authentication. Access is restricted to those who require it to perform their job, and is regularly reviewed and revoked upon termination or when no longer needed.
-- All sourcegraph.com application and user access logs for Sourcegraph.com are stored centrally and monitored.
+- Service, application, and access logs for sourcegraph.com are stored centrally, by Sourcegraph and monitored.
 - Company policy prevents customer data from being downloaded to portable devices, such as phones, that don't have device management software in place.
-- Device management is in place for remote wiping of all devices.
-- Development laptops have encrypted hard drives.
+- Sourcegraph deploys Mobile Device management (MDM) for centralized management of remote devices.
+- Laptops have encrypted hard drives.
 
 ## Network security
 
-When you run Sourcegraph on your own infrastructure, you are protected by the network security policies enforced by your infrastructure environment. On sourcegraph.com, we maintain the following policies:
+When running Sourcegraph on your own infrastructure, you are protected by the network security policies enforced by your infrastructure environment. On sourcegraph.com, we maintain the following policies:
 
-- All production systems are hosted on Google Cloud Platform (https://cloud.google.com/security/), where all storage volumes are encrypted at rest.
-- All external network communication between production services occurs over HTTPS / TLS.
+- All production systems are hosted on Google Cloud Platform (https://cloud.google.com/security/), where all storage volumes are encrypted at rest, and data is encrypted in-cloud during transport.
+- All external network communication between production services occurs over TLS.
 - External access to production systems is restricted by firewall. Secrets that grant access to
-  compute resources are stored only on encrypted local drives or in a secret management service.
-- Our dedicated security team at Sourcegraph handles all security escalations, and is available 24/7.
-- Customer data can be deleted from all primary and backup systems within 7 days of request.
+  compute resources are stored only on encrypted local drives or a secret management service.
+- Our dedicated security team at Sourcegraph handles all security escalations, and is available 24x7x365.
+- Customer data can be permanently wiped from all primary and backup systems within 7 days of request.
 
 ## Site security
 
 Sourcegraph supports HTTPS encryption when deployed on-premises.
 
 - All traffic to sourcegraph.com is transmitted over HTTPS.
-- Monitoring services alert our 24/7 support team of potential attacks.
+- Our operations team monitors service availability 24x7x365. They investigate alerts and potential attacks 24x7x365, triaging and responding if necessary.
 
 ## Development
 
-Code reviews are mandatory for all code changes to our product. Security-sensitive pull requests must undergo [review by the proper security code owner](../handbook/engineering/code_reviews#security). Furthermore, we use Sourcegraph to provide critical context during code reviews (such as identifying dependencies of modified code).
+Code reviews are mandatory for all code changes to our product. Security-sensitive pull requests must undergo [review by the proper security code owner](../handbook/engineering/code_reviews#security). Furthermore, internally, we use our own product to provide critical context during code reviews (such as identifying dependencies of modified code).
 
 We use a number of static analysis tools to identify security risks in development, including the following:
 
@@ -66,8 +66,6 @@ We use a number of static analysis tools to identify security risks in developme
 - Code coverage tools to ensure unit test coverage
 - End to end tests to validate authentication workflows
 - Tools such as Dependabot and GitHub security advisories to identify security vulnerabilities in our code and in dependencies
-
-All development laptops have encrypted hard drives.
 
 ## Updates
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -53,7 +53,7 @@ On sourcegraph.com, we maintain the following policies:
 
 ## Site security
 
-Sourcegraph supports HTTPS encryption when deployed you your own infrastructure.
+Sourcegraph supports HTTPS encryption when deployed on your own infrastructure.
 
 On sourcegraph.com, we maintain the following policies:
 

--- a/docs/security.md
+++ b/docs/security.md
@@ -4,7 +4,7 @@ title: Security is core to everything we do
 permalink: security
 ---
 
-## We know that source code is one of your most sensitive assets. Every component of Sourcegraph was designed with security in mind. We've detailed our strict production security guidelines for customers below
+## We know that source code is one of your most sensitive assets. Every component of Sourcegraph was designed with security in mind. We've detailed our strict production security guidelines for customers below.
 
 We don't stop at keeping your code safe. When your team's developers use Sourcegraph, they can discover and use your own security best practices much more easily in your own code. Your team can also more easily enforce security standards during code review.
 
@@ -18,21 +18,21 @@ Sourcegraph instances that host private code are typically deployed on-premise a
 
 Self-hosted Sourcegraph instances do not send any customer code to other servers.
 
-Additionally, other than the email address of the initial installer (for customer support, security, and product notification purposes) Sourcegraph never sends any private user data, such as usernames or email addresses, or other specific data to any other servers.
+Additionally, other than the email address of the initial installer (for customer support, security, and product notification purposes), Sourcegraph never sends any private user data, such as usernames or email addresses, or other specific data to any other servers.
 
 Learn more in our [pings documentation](https://docs.sourcegraph.com/admin/pings).
 
 ## Code host ACLs
 
-[Sourcegraph can be configured to enforce repository permissions from code hosts.](https://docs.sourcegraph.com/admin/repo/permissions). Unit and integration tests protect the correctness of these permissions checks.
+[Sourcegraph can be configured to enforce repository permissions from code hosts](https://docs.sourcegraph.com/admin/repo/permissions). Unit and integration tests protect the correctness of these permissions checks.
 
 ## Data access
 
 When running Sourcegraph on your own infrastructure, all application logs are stored locally, and never shared with Sourcegraph. Sourcegraph employees and contractors never have access to your Sourcegraph instance, or any of its data, unless explicitly shared for troubleshooting purposes.
 
-We maintain the following policies for sourcegraph.com data and any data provided via e-mail or other support channels:
+We maintain the following policies for sourcegraph.com data and any data provided via email or other support channels:
 - Access to all internal systems is protected by multi-factor authentication. Access is restricted to those who require it to perform their job, and is regularly reviewed and revoked upon termination or when no longer needed.
-- Service, application, and access logs for sourcegraph.com are stored centrally, by Sourcegraph and monitored.
+- Service, application, and access logs for sourcegraph.com are stored centrally by Sourcegraph and monitored.
 - Company policy prevents customer data from being downloaded to portable devices, such as phones, that don't have device management software in place.
 - Sourcegraph deploys Mobile Device management (MDM) for centralized management of remote devices.
 - Laptops have encrypted hard drives.
@@ -64,7 +64,7 @@ We use a number of static analysis tools to identify security risks in developme
 - Language-specific linters
 - Notifications and alerts for risky code patterns using Sourcegraph saved searches
 - Code coverage tools to ensure unit test coverage
-- End to end tests to validate authentication workflows
+- End-to-end tests to validate authentication workflows
 - Tools such as Dependabot and GitHub security advisories to identify security vulnerabilities in our code and in dependencies
 
 ## Updates


### PR DESCRIPTION
Multiple prospects and customers have found this section of our privacy page confusing. It does not delineate between sourcegraph.com and on-premise data access (e.g. in relation to application logs). This update is intended simply to clarify, without changing the meaning or intention of any of the bullets. 