### PR TITLE
Add information security policy acknowledgement to onboarding

### DIFF
--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -19,3 +19,4 @@
 - [ ] Read the first page of [Sourcegraph's user documentation](https://docs.sourcegraph.com/user).
 - [ ] It might not be immediately necessary, but if you ever need to click a HubSpot link just ask for access in #sales.
 - [ ] Go through the [analytics onboarding](https://sourcegraph.looker.com/projects/sourcegraph_events/files/1_home.md). This onboarding is within Looker, so if you don't have an account you can ask for access in #analytics. 
+- [ ] Read Sourcegraph's [information security policy](https://about.sourcegraph.com/security) and acknowledge your acceptance: https://forms.gle/LUK1YtwAMJLhtRPi6.


### PR DESCRIPTION
This is only an initial outline of what we'll ultimately need in terms of new hire information security acknowledgement. While this will work for the near future, I'd love to ask for support from the @sourcegraph/security team in fleshing out an actual internal policy doc that is actually useful and relevant, while still being concise and avoiding a bunch of boilerplate.

Please let me know if you support the form I've added here for now!