### PR TITLE
Update customer issues process

### DIFF
--- a/handbook/ce/customer_issues.md
+++ b/handbook/ce/customer_issues.md
@@ -8,7 +8,13 @@ Customer support tickets should be translated to GitHub issues. In such cases, [
 new issue for the request](https://github.com/sourcegraph/customer/issues/new).
 
 Provide the appropriate context and add a label with the affected customer as `customer/$name`. Once its created, sharing it with the required [team](routing_questions.md).
-If necessary, link to the appropriate JIRA Service Desk ticket or HubSpot notes.
+If necessary, link to the appropriate JIRA Service Desk ticket or [HubSpot](#find-the-unique-company-url) notes.
+
+### General issues
+
+General issues are those that affect more users than those of a particular deployment. In such cases, create a [new issue for the request](https://github.com/sourcegraph/sourcegraph/issues/new/choose) describing it. If there was a previous [customer issue](##create-a-customer-issue), please link the issue in its description.
+
+Remove any potentially private information (e.g. individual people's names, company names, self-hosted Sourcegraph URLs, repo names, screenshots, etc.)
 
 ## Find the unique company URL
 

--- a/handbook/ce/customer_issues.md
+++ b/handbook/ce/customer_issues.md
@@ -4,7 +4,7 @@ Read [the support overview](index.md) before filing an issue.
 
 ## Create a customer issue
 
-Customer support tickets should be translated to GitHub issues. In such cases, [create a
+Customer support tickets should be translated to GitHub issues when they require an engineering team to be involved. In such cases, [create a
 new issue for the request](https://github.com/sourcegraph/customer/issues/new).
 
 Provide the appropriate context and add a label with the affected customer as `customer/$name`. Once its created, sharing it with the required [team](routing_questions.md).

--- a/handbook/ce/customer_issues.md
+++ b/handbook/ce/customer_issues.md
@@ -14,7 +14,7 @@ If necessary, link to the appropriate JIRA Service Desk ticket or [HubSpot](#fin
 
 General issues are those that affect more users than those of a particular deployment. In such cases, create a [new issue for the request](https://github.com/sourcegraph/sourcegraph/issues/new/choose) describing it. If there was a previous [customer issue](##create-a-customer-issue), please link the issue in its description.
 
-Remove any potentially private information (e.g. individual people's names, company names, self-hosted Sourcegraph URLs, repo names, screenshots, etc.)
+Remove any potentially private information from this new issue (e.g. individual people's names, company names, self-hosted Sourcegraph URLs, repo names, screenshots, etc.)
 
 ## Find the unique company URL
 

--- a/handbook/ce/filing_customer_issues.md
+++ b/handbook/ce/filing_customer_issues.md
@@ -4,21 +4,11 @@ Read [the support overview](index.md) before filing an issue.
 
 ## 1. Begin to create an issue
 
-Customer support tickets should be translated to issues when they require a non-SWAT engineering team to own resolution. In such cases, create a new tracking issue for the request, and link to the company's anonymous HubSpot URL at the top:
-
->Requested by $COMPANY_URL
-
-Do not use a custom markdown link for this. Link destinations are not searchable in GitHub issues—only the rendered text. Leaving the full URL visible in the text makes it possible to search a given company's HubSpot ID to find all issues related to them.
-
-Or, if multiple companies have requested the same thing:
-
->Requested by:
-> - $COMPANY_URL
-> - $COMPANY_URL
+Customer support tickets should be translated to GitHub issues. In such cases, [create a new issue for the request](https://github.com/sourcegraph/customer/issues/new).
 
 ## 2. Find the unique company URL
 
-Find the unique company URL by [searching for the company in HubSpot](https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=). 
+Find the unique company URL by [searching for the company in HubSpot](https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=).
 
 When you filter down and find the company, click on its name to see the company's page, and copy the URL (it should contain `/company/`).
 
@@ -33,4 +23,5 @@ It is encouraged to add a browser search shortcut for this to make it quick and 
 
 ## 3. Post the issue
 
-Finalize the issue by providing the appropriate context. Remove any potentially private information (e.g. individual people's names, company names, self-hosted Sourcegraph URLs, repo names, screenshots, etc.). If necessary, link to the appropriate JIRA Service Desk ticket or HubSpot notes.
+Finalize the issue by providing the appropriate context and labeling with the affected companies. Once its created, sharing it with the required [team](routing_questions.md).
+If necessary, link to the appropriate JIRA Service Desk ticket or HubSpot notes.

--- a/handbook/ce/filing_customer_issues.md
+++ b/handbook/ce/filing_customer_issues.md
@@ -2,11 +2,15 @@
 
 Read [the support overview](index.md) before filing an issue.
 
-## 1. Begin to create an issue
+## Create a customer issue
 
-Customer support tickets should be translated to GitHub issues. In such cases, [create a new issue for the request](https://github.com/sourcegraph/customer/issues/new).
+Customer support tickets should be translated to GitHub issues. In such cases, [create a
+new issue for the request](https://github.com/sourcegraph/customer/issues/new).
 
-## 2. Find the unique company URL
+Provide the appropriate context and add a label with the affected customer as `customer/$name`. Once its created, sharing it with the required [team](routing_questions.md).
+If necessary, link to the appropriate JIRA Service Desk ticket or HubSpot notes.
+
+## Find the unique company URL
 
 Find the unique company URL by [searching for the company in HubSpot](https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=).
 
@@ -20,8 +24,3 @@ It is encouraged to add a browser search shortcut for this to make it quick and 
   - **Search Engine**: HubSpot search
   - **Keyword**: `hs`
   - **URL**: https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s
-
-## 3. Post the issue
-
-Finalize the issue by providing the appropriate context and labeling with the affected customer name as `customer/$name`. Once its created, sharing it with the required [team](routing_questions.md).
-If necessary, link to the appropriate JIRA Service Desk ticket or HubSpot notes.

--- a/handbook/ce/filing_customer_issues.md
+++ b/handbook/ce/filing_customer_issues.md
@@ -23,5 +23,5 @@ It is encouraged to add a browser search shortcut for this to make it quick and 
 
 ## 3. Post the issue
 
-Finalize the issue by providing the appropriate context and labeling with the affected companies. Once its created, sharing it with the required [team](routing_questions.md).
+Finalize the issue by providing the appropriate context and labeling with the affected customer name as `customer/$name`. Once its created, sharing it with the required [team](routing_questions.md).
 If necessary, link to the appropriate JIRA Service Desk ticket or HubSpot notes.

--- a/handbook/ce/index.md
+++ b/handbook/ce/index.md
@@ -12,7 +12,7 @@ The Customer Engineering team is responsible for ensuring that all of Sourcegrap
   - [Sourcegraph office hours](training.md#sourcegraph-office-hours)
 - [Support](support.md)
   - [How to route questions from customers](routing_questions.md)
-  - [Filing customer issues](filing_customer_issues.md)
+  - [Filing customer issues](customer_issues.md)
 
 ## Goals
 

--- a/handbook/ce/support.md
+++ b/handbook/ce/support.md
@@ -4,7 +4,7 @@ This document is to help Sourcegraph teammates provide our customers with suppor
 
 ## How support works for customers
 
-Sourcegraph provides a dizzying number of ways to get in contact with us — from our [public issue tracker](https://github.com/sourcegraph/sourcegraph/issues), our [Contact Us page](https://about.sourcegraph.com/contact), email exchanges with your sales and support reps, to our social media accounts, there's no shortage of ways to get in contact. 
+Sourcegraph provides a dizzying number of ways to get in contact with us — from our [public issue tracker](https://github.com/sourcegraph/sourcegraph/issues), our [Contact Us page](https://about.sourcegraph.com/contact), email exchanges with your sales and support reps, to our social media accounts, there's no shortage of ways to get in contact.
 
 ### Recommended support path and SLAs
 
@@ -12,9 +12,9 @@ Any of the methods listed above will get our attention, but we only provide a su
 
 ### Support tickets vs. issues
 
-Because our code is open source, any user or customer can file an issue on our public issue tracker at any time (and we encourage it!). 
+Because our code is open source, any user or customer can file an issue on our public issue tracker at any time (and we encourage it!).
 
-However, we don't encourage customers with enterprise contracts to start the support process this way. In some cases, a support ticket (centered around one customer's needs or questions) will be translated into an issue (which should apply generally to the product itself). In fact, we may ask you to file an issue during the support conversation. Learn [how to file an issue for a customer](./filing_customer_issues.md) when necessary.
+However, we don't encourage customers with enterprise contracts to start the support process this way. In some cases, a support ticket (centered around one customer's needs or questions) will be translated into an issue (which should apply generally to the product itself). In fact, we may ask you to file an issue during the support conversation. Learn [how to file an issue for a customer](./customer_issues.md) when necessary.
 
 Beyond the conceptual difference, there are practical reasons to prefer starting support conversations via email:
 
@@ -130,4 +130,3 @@ In the past, we have provided support on private GitHub issue trackers and priva
 6. Your signature should now look something like this, and clicking the Sourcegraph logo should bring you to sourcegraph.com:
 
 ![image](https://user-images.githubusercontent.com/3173176/79911829-e450e180-83d5-11ea-9b9b-9c1cc1056740.png)
-

--- a/handbook/engineering/incidents.md
+++ b/handbook/engineering/incidents.md
@@ -6,7 +6,7 @@ This document describes how we deal with operational incidents.
 
 ## Identification
 
-An incident is anything that requires a time sensitive response. Here are some examples:
+An incident is any unplanned event that causes a service disruption. Here are some examples:
 
 - sourcegraph.com is down or a critical feature is broken (e.g. sign-in, search, code intel).
 - A customer reports that their own Sourcegraph instance is down or a critical feature is broken.
@@ -23,14 +23,14 @@ Incidents can be reported by anyone (e.g. customers, Sourcegraph teammates) by a
     - If you are not an engineer or are not available to triage the incident, then ask the on-call engineer to triage the incident.
         - You can find out who is on-call by typing `/genie whoisoncall` in Slack.
         - If you are not able to immediately get in contact with the on-call engineer, then manually create a new OpsGenie alert by typing `/genie <description of incident and link to Slack thread> with ops_team`.
-    
+
 ## Triage
 
 The goal of triage is to either quickly resolve the incident using basic procedures, or quickly identify the right owner.
 
-1. **Acknowledge ownership** of the incident in the relevant Slack thread in the #incidents channel (i.e. "I'm on it").
+1. **Acknowledge ownership** of the incident in the relevant Slack thread in the #dev-ops channel (i.e. "I'm on it").
 2. Attempt to resolve the incident by rolling back to a known good state instead of trying to identify and fix the exact issue. **Communicate your intentions in the Slack thread.**
-    - [Rollback sourcegraph.com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/README.info.md#how-to-rollback-sourcegraphcom) 
+    - [Rollback sourcegraph.com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/README.info.md#how-to-rollback-sourcegraphcom)
     - Revert a broken commit out of master. If a bad commit has already been deployed to sourcegraph.com and is causing problems, rollback the deploy _before_ reverting the commit in master.
         - Revert the commit in a branch and open a PR.
         - Tag the owner of the reverted commit as a reviewer of the PR.
@@ -52,7 +52,7 @@ The incident responder will need to select a Sourcegraph.com account to attach t
 
 ## Resolution owner
 
-The resolution owner is responsible for resolving the incident as quickly and safely as possible. 
+The resolution owner is responsible for resolving the incident as quickly and safely as possible.
 
 1. **Acknowledge ownership** of the incident in the relevant Slack thread in the #incidents channel (i.e. "I'm on it").
 2. **Communicate** intended next steps (e.g. "I plan to...") and post regular updates (e.g. "I tried ... which resulted in ...") in the Slack thread.
@@ -70,4 +70,3 @@ After the incident is resolved:
 1. Document the incident in the [ops log](https://docs.google.com/document/d/1dtrOHs5STJYKvyjigL1kMm6u-W0mlyRSyVxPfKIOfEw/edit).
 1. Create GitHub issues for any appropriate followup work.
 1. Schedule a [retrospective](../../retrospectives/index.md) if you think it would be valuable.
-

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -18,6 +18,7 @@
 - [Commit message guidelines](commit_messages.md)
 - [Ignoring editor config files in Git](ignoring_editor_config_files.md)
 - [Configuring Zoom to send recordings to Slack automatically](configuring_zoom_recordings_to_slack_automatically.md)
+- [Customer Issues](../ce/customer_issues.md)
 - [Incidents](incidents.md)
 - [Releases](releases/index.md)
   - [Release issue template](releases/release_issue_template.md)

--- a/handbook/support/filing_customer_issues.md
+++ b/handbook/support/filing_customer_issues.md
@@ -4,4 +4,4 @@ ignoreDisconnectedPageCheck: true
 
 # Support
 
-This documentation page has been moved to "Customer Engineering [filing customer issues](../ce/filing_customer_issues.md)". 
+This documentation page has been moved to "Customer Engineering [filing customer issues](../ce/customer_issues.md)".


### PR DESCRIPTION
I would like to ensure all customer issues are tracked and created in GitHub. Right now, some issues are created, some are in other tracking systems, which makes it difficult to analyze the types of issues we have, or how many there are, etc.

As most of our workflow is already in GitHub, I think it will be a good idea to continue to do it here, as we can benefit from adding issues to labels, projects and milestones, as well as cross-link them to PRs or other issues.
We could, for example, use labels to categorize issues.

The downside of using GitHub is that there is no out of the box tool to analyze the data for any MTTR or other types of report. Given those are not required at the moment, I dont think it will be a problem.

Relates to: https://github.com/sourcegraph/sourcegraph/issues/11904