### PR TITLE
Add onboarding item: browser search engines

### DIFF
--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -24,6 +24,7 @@ You'll have to get some basics set up in your first few days:
 - [Configure your GitHub notifications.](./github-notifications/index.md)
 - Join #dev-announce, #dev-chat, and your team's channel on Slack, as well as any other channels you find interesting. [Team chat documentation](../communication/team_chat.md#engineering)
 - Set up your [local development environment](https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/local_development.md#step-1-install-dependencies). If you encounter any issues, ask for help in Slack and then update the documentation to reflect the resolution (so the next engineer that we hire doesn't run into the same problem).
+- [Add Sourcegraph as a browser search engine](https://docs.sourcegraph.com/integration/browser_search_engine). Add another entry for our internal instance: `https://sourcegraph.sgdev.org/search?q=%s`. This also ensures you have access to our internal instance.
 - Read through your team's handbook page, to learn about the team and its internal processes.
 
 ### Manager checklist


### PR DESCRIPTION
Added an item to the onboarding checklist for engineers: Add Sourcegraph as browser search engine, including one for our internal instance. (This will also ensure that new hires can access the internal instance.)