### PR TITLE
Remove possible focuses

### DIFF
--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -44,11 +44,6 @@ Company meeting is an effective way to:
 1. Inspiration of the week (message @dan to volunteer to present an inspiration)
 1. [#thanks](team_chat.md#thanks) summary
 1. Progress on our [goals](../../company/goals/index.md)
-1. **Possible focuses** (note: these are guidelines only, and @sqs will decide what each company meeting is in advance and will tag people with at least 2 working days' notice)
-   1. CEO: company pitch, vision, "are we on track?", open Q&A
-   1. Marketing, sales, customer engineering: what's working, what's not, biggest customer pains/wins
-   1. Product release (usually the closest meeting to the [20th](../engineering/releases/index.md#releases-are-monthly)): what will ship in the release
-   1. Product preview (usually the meeting after the [20th](../engineering/releases/index.md#releases-are-monthly)): what we're planning to build and ship in the next release
 1. All customer [bookings](../sales/index.md#booking) and churn since the previous company meeting
 1. New and expansion pipeline: include full table, discuss only significant changes since the previous company meeting
 1. Hiring: Open roles we're hiring for, offers extended/accepted/rejected


### PR DESCRIPTION
We haven't been doing these focuses for several weeks, so we should remove it. These were listed as potential focuses, but some of the bulleted items had suggested monthly timing that we are not following. 

Let me know if there are suggestions to improve wording here vs. removing entirely!