### PR TITLE
website: address a11y issues from Lighthouse

### DIFF
--- a/website/src/components/BlogPosts.tsx
+++ b/website/src/components/BlogPosts.tsx
@@ -40,6 +40,7 @@ export default class BlogPosts extends React.Component<any, any> {
                                         <img
                                             className="blog-posts__post__image"
                                             src={post.node.frontmatter.heroImage}
+                                            aria-hidden="true"
                                         />
                                     </Link>
                                 </div>

--- a/website/src/components/BlogPosts.tsx
+++ b/website/src/components/BlogPosts.tsx
@@ -40,7 +40,7 @@ export default class BlogPosts extends React.Component<any, any> {
                                         <img
                                             className="blog-posts__post__image"
                                             src={post.node.frontmatter.heroImage}
-                                            aria-hidden="true"
+                                            alt={post.node.frontmatter.title}
                                         />
                                     </Link>
                                 </div>

--- a/website/src/components/BrowserInstallButtons.tsx
+++ b/website/src/components/BrowserInstallButtons.tsx
@@ -16,13 +16,13 @@ export class BrowserInstallButtons extends React.PureComponent<{}, {}> {
                         className="mr-2"
                     >
                         <button type="button" className="btn btn-primary align-items-center">
-                            <img height={25} className="pr-2" src="/integrations/chrome.svg" />
+                            <img height={25} className="pr-2" src="/integrations/chrome.svg" alt="Chrome" />
                             Chrome
                         </button>
                     </a>
                     <a onClick={this.trackInstallBrowserExtension} target="_blank" href={FIREFOX_STORE_URL}>
                         <button type="button" className="btn btn-primary align-items-center">
-                            <img height={25} className="pr-2" src="/integrations/firefox.svg" />
+                            <img height={25} className="pr-2" src="/integrations/firefox.svg" alt="Firefox" />
                             Firefox
                         </button>
                     </a>

--- a/website/src/components/EventsList.tsx
+++ b/website/src/components/EventsList.tsx
@@ -10,7 +10,11 @@ class Conferences extends React.Component {
                         <div className="col-md-6 col-lg-4 py-2">
                             <div className="card event__item">
                                 <a href={eventDetail.eventLink} rel="nofollow">
-                                    <img className="card-img-top img-fluid" src={eventDetail.eventImage} />
+                                    <img
+                                        className="card-img-top img-fluid"
+                                        src={eventDetail.eventImage}
+                                        alt={eventDetail.videoTitle}
+                                    />
                                 </a>
                                 <div className="card-body">
                                     <h6>LIVESTREAM</h6>
@@ -30,7 +34,11 @@ class Conferences extends React.Component {
                         <div className="col-md-6 col-lg-4 py-2">
                             <div className="card event__item">
                                 <a href={eventDetail.videoLink} rel="nofollow">
-                                    <img className="card-img-top img-fluid" src={eventDetail.videoImage} />
+                                    <img
+                                        className="card-img-top img-fluid"
+                                        src={eventDetail.videoImage}
+                                        alt={eventDetail.videoTitle}
+                                    />
                                 </a>
                                 <div className="card-body">
                                     <h6>VIDEO</h6>

--- a/website/src/components/FeaturedBlogPosts.tsx
+++ b/website/src/components/FeaturedBlogPosts.tsx
@@ -18,7 +18,11 @@ export const FeaturedBlogPosts: React.FunctionComponent<Props> = ({ posts }) => 
                     <div className="card">
                         <div className="text-center">
                             <a href={url}>
-                                <img className="blog-posts-home__thumbnail py-3 px-3" src={thumbnail} />
+                                <img
+                                    className="blog-posts-home__thumbnail py-3 px-3"
+                                    src={thumbnail}
+                                    aria-hidden="true"
+                                />
                             </a>
                         </div>
                         <div className="card-body">

--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -85,12 +85,22 @@ export const Footer: React.FunctionComponent<{ minimal?: boolean }> = ({ minimal
                             </Link>
                             <ul className="nav footer__social mt-1">
                                 <li className="nav-item">
-                                    <a href="https://github.com/sourcegraph" target="_blank" rel="nofollow noopener">
+                                    <a
+                                        href="https://github.com/sourcegraph"
+                                        target="_blank"
+                                        rel="nofollow noopener"
+                                        aria-label="GitHub"
+                                    >
                                         <GithubIcon />
                                     </a>
                                 </li>
                                 <li className="nav-item">
-                                    <a href="https://twitter.com/srcgraph" target="_blank" rel="nofollow noopener">
+                                    <a
+                                        href="https://twitter.com/srcgraph"
+                                        target="_blank"
+                                        rel="nofollow noopener"
+                                        aria-label="Twitter"
+                                    >
                                         <TwitterIcon />
                                     </a>
                                 </li>
@@ -99,6 +109,7 @@ export const Footer: React.FunctionComponent<{ minimal?: boolean }> = ({ minimal
                                         href="https://www.linkedin.com/company/4803356/"
                                         target="_blank"
                                         rel="nofollow noopener"
+                                        aria-label="LinkedIn"
                                     >
                                         <LinkedinIcon />
                                     </a>
@@ -108,6 +119,7 @@ export const Footer: React.FunctionComponent<{ minimal?: boolean }> = ({ minimal
                                         href="https://www.youtube.com/c/Sourcegraph/featured"
                                         target="_blank"
                                         rel="nofollow noopener"
+                                        aria-label="YouTube"
                                     >
                                         <YouTubeIcon />
                                     </a>

--- a/website/src/components/GetStarted.tsx
+++ b/website/src/components/GetStarted.tsx
@@ -39,6 +39,7 @@ export default class GetStarted extends React.PureComponent<GetStartedProps> {
                                     --volume ~/.sourcegraph/data:/var/opt/sourcegraph &#13;
                                     sourcegraph/server:3.18.0
                                     "
+                                    aria-label="A Docker run command to start a local Sourcegraph instance"
                                 />
                                 <span className="get-started__copytext">
                                     <ClipboardArrowLeftOutlineIcon

--- a/website/src/components/Jumbotron.tsx
+++ b/website/src/components/Jumbotron.tsx
@@ -30,6 +30,7 @@ export const Jumbotron: React.FunctionComponent<{
                     // tslint:disable-next-line: jsx-ban-props
                     style={{ width: '2rem', height: '2rem' }}
                     src="/sourcegraph/sourcegraph-mark.svg"
+                    aria-hidden="true"
                 />
             )}
             <h1 className={titleClassName}>{title}</h1>

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -55,7 +55,7 @@ export default class Layout extends React.PureComponent<LayoutProps> {
                     <meta name="description" content={metaProps.description} />
                     <link rel="icon" type="image/png" href={metaProps.icon} />
                     <link rel="icon" type="image/png" href={metaProps.image} />
-                    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0" />
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 
                     <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,600,700" rel="stylesheet" />
                     <link

--- a/website/src/components/NewsList.tsx
+++ b/website/src/components/NewsList.tsx
@@ -10,7 +10,7 @@ class News extends React.Component {
                     {NewsData.y2020.map((newsDetail, index) => (
                         <div className="row mb-4 news__item">
                             <div className="col-sm-4 col-lg-2 text-center">
-                                <img className="news__image" src={newsDetail.newsImage} />
+                                <img className="news__image" src={newsDetail.newsImage} alt={newsDetail.newsTitle} />
                             </div>
                             <div className="col-sm-10 col-lg-10 align-self-center">
                                 <p>
@@ -30,7 +30,7 @@ class News extends React.Component {
                     {NewsData.y2019.map((newsDetail, index) => (
                         <div className="row mb-4 news__item">
                             <div className="col-sm-4 col-lg-2 text-center">
-                                <img className="news__image" src={newsDetail.newsImage} />
+                                <img className="news__image" src={newsDetail.newsImage} alt={newsDetail.newsTitle} />
                             </div>
                             <div className="col-sm-10 col-lg-10 align-self-center">
                                 <p>

--- a/website/src/components/Sprinkles.tsx
+++ b/website/src/components/Sprinkles.tsx
@@ -6,7 +6,7 @@ const durationTime = 3200
 export default class Sprinkles extends React.Component<any, any> {
     public render(): JSX.Element | null {
         return (
-            <div>
+            <div aria-hidden="true">
                 <Plx
                     className="absolute sprink-1 w4 h4"
                     parallaxData={[

--- a/website/src/components/SprinklesHome.tsx
+++ b/website/src/components/SprinklesHome.tsx
@@ -6,7 +6,7 @@ const durationTime = 1600
 export default class SprinklesHome extends React.Component<any, any> {
     public render(): JSX.Element | null {
         return (
-            <div>
+            <div aria-hidden="true">
                 <Plx
                     className="absolute sprinkHome-1 w4 h4"
                     parallaxData={[

--- a/website/src/components/TestimonialCarousel.tsx
+++ b/website/src/components/TestimonialCarousel.tsx
@@ -43,7 +43,11 @@ export const TestimonialCarousel: React.FunctionComponent<Props> = ({
         <div className="row justify-content-center pt-5">
             <div className="testimonial-carousel col-sm-12 col-md-9 col-lg-7 text-center">
                 <div className="testimonial-carousel__testimonials">
-                    <img src="/case-studies/quote.svg" className="testimonial-carousel__quote-icon mb-5" alt="" />
+                    <img
+                        src="/case-studies/quote.svg"
+                        className="testimonial-carousel__quote-icon mb-5"
+                        aria-hidden="true"
+                    />
                     <Carousel controls={true}>
                         {testimonials.map(({ customer, logo, quote, author, cta }, i) => (
                             <div
@@ -52,7 +56,11 @@ export const TestimonialCarousel: React.FunctionComponent<Props> = ({
                                     customer
                                 ).toLowerCase()} carousel-item testimonial-carousel__testimonial`}
                             >
-                                <img src={logo} className="testimonial-carousel__logo d-inline-block mb-4" />
+                                <img
+                                    src={logo}
+                                    className="testimonial-carousel__logo d-inline-block mb-4"
+                                    alt={customer}
+                                />
                                 <blockquote className="testimonial-carousel__blockquote blockquote">
                                     <p className="mb-5">{quote}</p>
                                     {author && (

--- a/website/src/components/YouTube.tsx
+++ b/website/src/components/YouTube.tsx
@@ -4,6 +4,7 @@ import React from 'react'
 export const YouTube: React.FunctionComponent<{
     className?: string
     id: string
+    title: string
     autoplay?: boolean
     captions?: boolean
     start?: number
@@ -14,22 +15,27 @@ export const YouTube: React.FunctionComponent<{
 }> = ({
     className = '',
     id,
+    title,
     autoplay = false,
     captions = false,
     start = 0,
     end = 0,
     loop = false,
     controls = true,
-    branding = false
-
+    branding = false,
 }) => (
     <div className={`video-embed embed-responsive embed-responsive-16by9 ${className}`}>
         <iframe
             className="embed-responsive-item"
-            src={`https://www.youtube.com/embed/${id}?autoplay=${autoplay ? 1 : 0}&cc_load_policy=${captions ? 1 : 0}&start=${start}&end=${end}&loop=${loop ? 1 : 0}&controls=${controls ? 1 : 0}&modestbranding=${branding ? 1 : 0}&rel=0`}
+            src={`https://www.youtube.com/embed/${id}?autoplay=${autoplay ? 1 : 0}&cc_load_policy=${
+                captions ? 1 : 0
+            }&start=${start}&end=${end}&loop=${loop ? 1 : 0}&controls=${controls ? 1 : 0}&modestbranding=${
+                branding ? 1 : 0
+            }&rel=0`}
             allowFullScreen={true}
             allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
             frameBorder="0"
+            title={title}
         />
     </div>
 )

--- a/website/src/components/content/CaseStudyPage.tsx
+++ b/website/src/components/content/CaseStudyPage.tsx
@@ -83,7 +83,7 @@ export const CaseStudyJumbotron: React.FunctionComponent<{
 }> = ({ customer, logo, className = '', color = 'dark', children }) => (
     <div className={`jumbotron rounded-0 ${COLORS[color]} ${className}`}>
         <div className="container text-center pt-5 pb-3">
-            <img className="case-studies__logo" src={logo} />
+            <img className="case-studies__logo" src={logo} alt={customer} />
             <span className="case-studies__label d-block mt-1">
                 <span className="sr-only">{customer}</span> case study
             </span>

--- a/website/src/components/product/CustomerLogosSection.tsx
+++ b/website/src/components/product/CustomerLogosSection.tsx
@@ -152,10 +152,18 @@ export const CustomerLogosSection: React.FunctionComponent<{ className?: string 
                 >
                     {logo.link ? (
                         <a href={logo.link.url} target={logo.link.target} rel={logo.link.rel}>
-                            <img className="customer-logos-section__item-logo d-block mx-auto" src={logo.url} />
+                            <img
+                                className="customer-logos-section__item-logo d-block mx-auto"
+                                src={logo.url}
+                                alt={logo.name}
+                            />
                         </a>
                     ) : (
-                        <img className="customer-logos-section__item-logo d-block mx-auto" src={logo.url} />
+                        <img
+                            className="customer-logos-section__item-logo d-block mx-auto"
+                            src={logo.url}
+                            alt={logo.name}
+                        />
                     )}
                 </div>
             ))}

--- a/website/src/components/product/GitLabIntegrationSection.tsx
+++ b/website/src/components/product/GitLabIntegrationSection.tsx
@@ -29,6 +29,7 @@ export const GitLabIntegrationSection: React.FunctionComponent<{ className?: str
                             webkiallowfullscreen="true"
                             mozallowfullscreen="true"
                             allowFullScreen={true}
+                            title="Sourcegraph's new GitLab native integration"
                         />
                     </div>
                 </div>

--- a/website/src/components/product/IntegratesWithSection.tsx
+++ b/website/src/components/product/IntegratesWithSection.tsx
@@ -145,6 +145,7 @@ const IntegrationEntriesRow: React.FunctionComponent<{
                                     key={i}
                                     className="integrates-with-section__logo mx-2"
                                     src={iconUrl}
+                                    alt={description}
                                     title={description}
                                     style={width !== undefined ? { width: `${width}px` } : undefined}
                                 />
@@ -154,6 +155,7 @@ const IntegrationEntriesRow: React.FunctionComponent<{
                                 key={i}
                                 className="integrates-with-section__logo mx-2"
                                 src={iconUrl}
+                                alt={description}
                                 title={description}
                                 style={width !== undefined ? { width: `${width}px` } : undefined}
                             />

--- a/website/src/css/components/_Footer.scss
+++ b/website/src/css/components/_Footer.scss
@@ -131,13 +131,22 @@
         &__logo {
             background: url(/sourcegraph-reverse-logo.svg) no-repeat;
         }
+        &__nav-header {
+            opacity: 0.6;
+        }
         &__nav-header,
         &__nav-sections .nav-item > a {
             color: $light;
         }
-        &__nav-header,
-        &__nav-sections .nav-item > a:hover {
-            color: $light-6;
+        &__social,
+        &__postscript {
+            .nav-item > a {
+                color: rgba($light, 0.6);
+                &:hover { color: rgba($light, 0.8); }
+            }
+            .text-muted {
+                color: rgba($light, 0.6) !important;
+            }
         }
     }
 }

--- a/website/src/css/pages/_customers.scss
+++ b/website/src/css/pages/_customers.scss
@@ -3,6 +3,9 @@
         background: url('/customers-page-bg.svg') no-repeat;
         background-size: cover;
     }
+    &__see-how {
+        font-size: 1.25rem;
+    }
     .list-group-item {
         background-color: rgba(255, 255, 255, 0.75);
         display: flex;

--- a/website/src/css/pages/_podcast.scss
+++ b/website/src/css/pages/_podcast.scss
@@ -127,6 +127,12 @@
             font-weight: bold;
         }
     }
+
+    &__acknowledgements {
+        h2 {
+            font-size: 1.75rem;
+        }
+    }
 }
 .darkBackground {
     background-color: #000 !important;

--- a/website/src/pages/about.tsx
+++ b/website/src/pages/about.tsx
@@ -241,13 +241,13 @@ export default class About extends React.Component<any, any> {
                                 </h1>
                                 <div className="row align-items-center">
                                     <div className="col-md-3">
-                                        <img src={craft} />
+                                        <img src={craft} alt="Craft" />
                                     </div>
                                     <div className="col-md-3">
-                                        <img src={redpoint} />
+                                        <img src={redpoint} alt="Redpoint" />
                                     </div>
                                     <div className="col-md-3">
-                                        <img src={goldcrest} />
+                                        <img src={goldcrest} alt="Goldcrest Capital" />
                                     </div>
                                 </div>
                             </div>

--- a/website/src/pages/customers.tsx
+++ b/website/src/pages/customers.tsx
@@ -93,6 +93,7 @@ export default ((props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="Universal code search using regex with Sourcegraph"
                             ></iframe>
                         </div>
                     </div>
@@ -137,6 +138,7 @@ export default ((props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="Exploring code with Sourcegraph"
                             ></iframe>
                         </div>
                     </div>
@@ -185,6 +187,7 @@ export default ((props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="Searching for security vulnerabilities company-wide with Sourcegraph"
                             ></iframe>
                         </div>
                     </div>
@@ -230,6 +233,7 @@ export default ((props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="Sourcegraph and GitLab: Code reviews and code discovery in action"
                             ></iframe>
                         </div>
                         <p>Watch how Sid Sijbrandij (GitLab CEO) and Quinn Slack (Sourcegraph CEO) do code reviews.</p>
@@ -292,6 +296,7 @@ export default ((props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="Campaigns for large-scale code changes in Sourcegraph 3.16"
                             ></iframe>
                         </div>
                     </div>

--- a/website/src/pages/customers.tsx
+++ b/website/src/pages/customers.tsx
@@ -32,7 +32,9 @@ export default ((props: any) => (
                         </p>
                     </div>
                     <div className="col-lg-5 mt-lg-6 pt-4 mb-6">
-                        <h5 className="font-weight-normal">See how customers use Sourcegraph to</h5>
+                        <h2 className="font-weight-normal customers-page__see-how">
+                            See how customers use Sourcegraph to
+                        </h2>
                         <div className="list-group">
                             <Link to="#onboard" className="list-group-item list-group-item-action">
                                 Onboard everyone faster <ArrowRightIcon className="icon-inline ml-1" />

--- a/website/src/pages/customers.tsx
+++ b/website/src/pages/customers.tsx
@@ -106,7 +106,7 @@ export default ((props: any) => (
                             </p>
                             <footer className="blockquote-footer">Owen Kim, Senior Software Engineer, Convoy</footer>
                             <div className="d-flex justify-content-center my-4">
-                                <img src="/external-logos/convoy-logo.svg" width="110px" />
+                                <img src="/external-logos/convoy-logo.svg" width="110px" alt="Convoy" />
                             </div>
                             <Link to="/case-studies/convoy-improved-on-boarding">
                                 Developers at Convoy onboard faster with Sourcegraph{' '}
@@ -152,7 +152,7 @@ export default ((props: any) => (
                                     Ursula Robertson, Engineering Manager, SoFi
                                 </footer>
                                 <div className="d-flex justify-content-center my-3">
-                                    <img src="/external-logos/sofi-logo.svg" width="90px" />
+                                    <img src="/external-logos/sofi-logo.svg" width="90px" alt="SoFi" />
                                 </div>
                                 <Link to="/case-studies/sofi-moves-fast-on-hundreds-of-microservices/">
                                     SoFi adopts Sourcegraph to manage hundreds of microservices{' '}
@@ -199,7 +199,7 @@ export default ((props: any) => (
                                     Simon Law, Staff Software Engineer, Quantcast
                                 </footer>
                                 <div className="d-flex justify-content-center my-2">
-                                    <img src="/external-logos/quantcast-logo.svg" width="120px" />
+                                    <img src="/external-logos/quantcast-logo.svg" width="120px" alt="Quantcast" />
                                 </div>
                                 <Link to="/case-studies/quantcast-large-scale-refactoring/">
                                     Quantcast adopts Sourcegraph for large-scale refactoring{' '}
@@ -247,7 +247,12 @@ export default ((props: any) => (
                                 <footer className="blockquote-footer">
                                     Trent Grover, Director of Architecture, Workiva
                                 </footer>
-                                <img src="/external-logos/workiva-vector-logo.svg" width="120px" className="my-2" />
+                                <img
+                                    src="/external-logos/workiva-vector-logo.svg"
+                                    width="120px"
+                                    className="my-2"
+                                    alt="Workiva"
+                                />
                             </blockquote>
                         </div>
                     </div>
@@ -300,7 +305,7 @@ export default ((props: any) => (
                                 </p>
                                 <footer className="blockquote-footer">Aneesh Agrawal, Software Engineer, Lyft</footer>
                                 <div className="d-flex justify-content-center my-3">
-                                    <img src="/external-logos/lyft-logo.svg" width="60px" />
+                                    <img src="/external-logos/lyft-logo.svg" width="60px" alt="Lyft" />
                                 </div>
                                 <Link to="/case-studies/lyft-monolith-to-microservices">
                                     Lyft uses Sourcegraph to ensure production stability{' '}

--- a/website/src/pages/developer-platform/index.tsx
+++ b/website/src/pages/developer-platform/index.tsx
@@ -187,7 +187,11 @@ export default ((props: any) => (
                     </div>
                     <div className="col-md-12 col-lg-4 mb-3">
                         <h4>
-                            <img style={{ width: '17px', height: '17px' }} src="/sourcegraph/sourcegraph-mark.svg" />{' '}
+                            <img
+                                style={{ width: '17px', height: '17px' }}
+                                src="/sourcegraph/sourcegraph-mark.svg"
+                                aria-hidden="true"
+                            />{' '}
                             Sourcegraph
                             <br />
                             Used by Uber, Lyft, Yelp, and more

--- a/website/src/pages/developer-platform/index.tsx
+++ b/website/src/pages/developer-platform/index.tsx
@@ -230,6 +230,7 @@ export default ((props: any) => (
                         allow="encrypted-media"
                         allowFullScreen={true}
                         className="m-2"
+                        title="Dev Tools @Scale - Searching through code at scale, Jeroen Vaelen"
                     />
                     <iframe
                         width="560"
@@ -239,6 +240,7 @@ export default ((props: any) => (
                         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                         allowFullScreen={true}
                         className="m-2"
+                        title="Stanford Seminar - Google's Steve Yegge on GROK"
                     />
                     <iframe
                         width="560"
@@ -248,6 +250,7 @@ export default ((props: any) => (
                         allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                         allowFullScreen={true}
                         className="m-2"
+                        title="Project Grok - Steve Yegge - Emacs Conference 2013"
                     />
                 </div>
             </div>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -46,8 +46,16 @@ const Index: React.FunctionComponent = (props: any) => (
             </div>
             <ContentSection className="py-6 mt-3 d-none d-sm-block">
                 <div className="home__nested-screenshots">
-                    <img src="/screenshots/code-page-0.png" className="home__screenshot home__screenshot--main" />
-                    <img src="/screenshots/search-page-0.png" className="home__screenshot home__screenshot--nested" />
+                    <img
+                        src="/screenshots/code-page-0.png"
+                        className="home__screenshot home__screenshot--main"
+                        alt="Searching for code in the Sourcegraph search bar"
+                    />
+                    <img
+                        src="/screenshots/search-page-0.png"
+                        className="home__screenshot home__screenshot--nested"
+                        alt="Code results from a code search, including code coverage states"
+                    />
                 </div>
             </ContentSection>
             <CustomerLogosSection className="pt-5" />
@@ -75,7 +83,11 @@ const Index: React.FunctionComponent = (props: any) => (
                         </div>
                     </div>
                     <div className="col-lg-7 mt-5 pl-lg-4">
-                        <img src="/code-search-illustrated.svg" className="home__diagram w-150" />
+                        <img
+                            src="/code-search-illustrated.svg"
+                            className="home__diagram w-150"
+                            alt="Code search across multiple code hosts, including GitHub, GitLab, BitBucket, and Azure"
+                        />
                     </div>
                 </div>
             </ContentSection>

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -148,6 +148,7 @@ const Index: React.FunctionComponent = (props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="AND/OR operators for universal code search"
                             ></iframe>
                         </div>
                     </div>
@@ -163,6 +164,7 @@ const Index: React.FunctionComponent = (props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="Exploring code with Sourcegraph"
                             ></iframe>
                         </div>
                     </div>
@@ -207,6 +209,7 @@ const Index: React.FunctionComponent = (props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="Campaigns for large-scale code changes in Sourcegraph 3.16"
                             ></iframe>
                         </div>
                     </div>
@@ -222,6 +225,7 @@ const Index: React.FunctionComponent = (props: any) => (
                                 allowfullscreen=""
                                 allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
                                 frameborder="0"
+                                title="Product preview: code insights"
                             ></iframe>
                         </div>
                     </div>

--- a/website/src/pages/jobs.tsx
+++ b/website/src/pages/jobs.tsx
@@ -53,7 +53,11 @@ export default class JobsPage extends React.Component<any, any> {
                             <h1>Benefits</h1>
                             <div className="jobs__benefits-list">
                                 <div className="jobs__benefits-list-item">
-                                    <img className="jobs__benefits-list-item-icon" src="/jobs/medical.svg" />
+                                    <img
+                                        className="jobs__benefits-list-item-icon"
+                                        src="/jobs/medical.svg"
+                                        role="presentation"
+                                    />
                                     <div>
                                         <h3 className="jobs__benefits-list-item-title">Medical</h3>
                                         <p className="jobs__benefits-list-item-description">
@@ -63,7 +67,11 @@ export default class JobsPage extends React.Component<any, any> {
                                     </div>
                                 </div>
                                 <div className="jobs__benefits-list-item">
-                                    <img className="jobs__benefits-list-item-icon" src="/jobs/wellness.svg" />
+                                    <img
+                                        className="jobs__benefits-list-item-icon"
+                                        src="/jobs/wellness.svg"
+                                        role="presentation"
+                                    />
                                     <div>
                                         <h3 className="jobs__benefits-list-item-title">Wellness</h3>
                                         <p className="jobs__benefits-list-item-description">
@@ -74,7 +82,11 @@ export default class JobsPage extends React.Component<any, any> {
                                     </div>
                                 </div>
                                 <div className="jobs__benefits-list-item">
-                                    <img className="jobs__benefits-list-item-icon" src="/jobs/vacation.svg" />
+                                    <img
+                                        className="jobs__benefits-list-item-icon"
+                                        src="/jobs/vacation.svg"
+                                        role="presentation"
+                                    />
                                     <div>
                                         <h3 className="jobs__benefits-list-item-title">Vacation</h3>
                                         <p className="jobs__benefits-list-item-description">
@@ -84,7 +96,11 @@ export default class JobsPage extends React.Component<any, any> {
                                     </div>
                                 </div>
                                 <div className="jobs__benefits-list-item">
-                                    <img className="jobs__benefits-list-item-icon" src="/jobs/family.svg" />
+                                    <img
+                                        className="jobs__benefits-list-item-icon"
+                                        src="/jobs/family.svg"
+                                        role="presentation"
+                                    />
                                     <div>
                                         <h3 className="jobs__benefits-list-item-title">Family friendly</h3>
                                         <p className="jobs__benefits-list-item-description">

--- a/website/src/pages/podcast.tsx
+++ b/website/src/pages/podcast.tsx
@@ -320,12 +320,14 @@ export default class JobsPage extends React.Component<any, any> {
                                     />
                                 </div>
                             ))}
-			    <div className="acknowledgements">
-			         <h3>Acknowledgements</h3>
-				 <p>
-				   The voices in the intro segment of the show are (in order of appearance): Edsger Dijkstra, Dennis Ritchie, Grace Hopper, Steve Jobs, Jamie Zawinski, and Steve Ballmer.
-				 </p>
-			    </div>
+                            <div className="podcast__acknowledgements">
+                                <h2>Acknowledgements</h2>
+                                <p>
+                                    The voices in the intro segment of the show are (in order of appearance): Edsger
+                                    Dijkstra, Dennis Ritchie, Grace Hopper, Steve Jobs, Jamie Zawinski, and Steve
+                                    Ballmer.
+                                </p>
+                            </div>
                         </div>
                     </ContentSection>
                 </ContentPage>

--- a/website/src/pages/resources/abcs-book.tsx
+++ b/website/src/pages/resources/abcs-book.tsx
@@ -18,7 +18,7 @@ export default ((props: any) => (
             <div className="row justify-content-md-center">
                 <div className="col-small-12">
                     <p className="text-center">
-                        <img src="/other/abcs-book/our-abcs-hero.png" className="w-100 px-2 mb-3" />
+                        <img src="/other/abcs-book/our-abcs-hero.png" className="w-100 px-2 mb-3" role="presentation" />
                     </p>
                     <h1 className="text-center">Our ABCs: Always Be Coding children's book</h1>
                     <p className="text-center my-5">
@@ -60,7 +60,12 @@ export default ((props: any) => (
                             className="d-block"
                             id="abc-dlbook"
                         >
-                            <img src="/other/abcs-book/our-abcs.png" className="img-drop-shadow mb-0" width="350px" />
+                            <img
+                                src="/other/abcs-book/our-abcs.png"
+                                className="img-drop-shadow mb-0"
+                                width="350px"
+                                alt="Book cover: Our ABCs"
+                            />
                         </a>
                     </p>
                     <p className="text-center my-5">

--- a/website/src/pages/resources/abcs-book.tsx
+++ b/website/src/pages/resources/abcs-book.tsx
@@ -35,7 +35,7 @@ export default ((props: any) => (
             </div>
             <div className="row justify-content-md-center mt-3">
                 <div className="col-md-8">
-                    <YouTube id="6bCO63O4swI" />
+                    <YouTube id="6bCO63O4swI" title="Our ABCs: Always Be Coding children's book by Sourcegraph" />
                     <p className="mt-5">
                         At Sourcegraph, many of us have young children who we’re trying to provide fun new learning
                         experiences for at home.


### PR DESCRIPTION
This came out of the accessibility jam this morning.

This PR doesn't fix every issue on every page reported by [Lighthouse](https://developers.google.com/web/tools/lighthouse), but it does get us to a few key milestones:

1. All images have appropriate `alt`, `role`, or `aria-label` tags.
2. All iframes have appropriate `title` tags.
3. The homepage, customers, and pricing pages get perfect scores for accessibility on Lighthouse.
4. A couple of colours in the footer weren't correctly overridden on pages with dark backgrounds, resulting in extremely low contrast on headers and the copyright notice; these are fixed.
5. Users on touch platforms can now pinch-to-zoom, but still get the correct defaults if they do not do so for appropriate scaling and rotation.

This is very much low hanging fruit, but we have to start somewhere.