### PR TITLE
Add 401k to list of benefits since it's not documented elsewhere

### DIFF
--- a/handbook/people-ops/benefits-and-perks.md
+++ b/handbook/people-ops/benefits-and-perks.md
@@ -42,6 +42,6 @@ Your paycheck automatically includes a fixed reimbursement for $75 of mobile pho
 
 Whether you are relocating to join us or just moving places after you have already joined, we give you a yearly $1,000 stipend for hiring professional movers to reduce the stress associated with moving.
 
-## 🏦 401k
+## 🏦 401(k)
 
-We offer a 401k for US-based employees with both traditional (pre-tax) and Roth options to help you save for retirement while saving on taxes. The 401k is administered by [Human Interest](https://humaninterest.com/) and has several low-fee Vanguard funds available as investment options.
+We offer a 401(k) for US-based employees with both traditional (pre-tax) and Roth options to help you save for retirement while saving on taxes. The 401k is administered by [Human Interest](https://humaninterest.com/) and has several low-fee Vanguard funds available as investment options.


### PR DESCRIPTION
I didn't know Sourcegraph offered a 401k until after going though the interview process. I think it's good to list it as it's a great benefit to have to help save for retirement.