### PR TITLE
Add long and medium term goals for the web team

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -24,9 +24,20 @@ The web team's current focus is documented in [the tracking issue for the curren
 To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
 We will tackle these medium-term goals in order, though expect to have some work done in parallel as we progress. 
 
-1. Make the products that extensions are build on (web app, code host integrations) more consistent and improve discoverability.
-2. Bring the extensions platform into shape.
-3. Build out compelling use cases with the extensions platform.
+1. **Make the products that extensions are build on (web app, code host integrations) more consistent and improve discoverability.**
+   Our web app has accumulated a lot of design debt over time, which negatively impacts how we can use it as a vehicle to deliver extensions.
+   With areas like the repository page, user settings area (which extensions are configured through), navigation, command palette UI and the extension registry affected, it is hard to provide a good UX around extensions (the extension registry blends into goal (2)).
+   Our code host integrations, which are an implementation of our extension API, are a huge driver of adoption inside companies and multiply the value of extensions by bringing them into code review workflows, but are difficult to discover and setup.
+2. **Bring the extension platform into shape.**
+   Our extension platform includes the workflow around creating, installing and using extensions, the API exposed to developers and its documentation.
+   To grow adoption of extensions, these need to be solid, but they are currently lacking on multiple dimensions.
+   Some API areas like code insights are still in prototype phase and are still undocumented (this blends into goal (3)).
+   Our extension host is also currently implemented in a way that makes it difficult for us to maintain, evolve to enable more use cases and to  onboard new teammates into this area of the codebase.
+   Combining this with writing a few smaller extensions (part of goal (3)) allows us to dogfood the experience and inform us where the platform is lacking.
+3. **Build out compelling use cases with the extensions platform.**
+   This includes writing more extensions ourselves, but also extending the extension API with more capabilities to enable more use cases.
+   We have a long list of ideas and use cases customers shared with us that we can solve and/or enable customers to solve with extensions.
+   Some of these integrate Sourcegraph with more external services to suit the setups of more customers, others provide completely new value no other product provides.
 
 ## Tech stack
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -4,8 +4,6 @@ The web team owns the maintenance and expansion of our web application and code 
 
 This is a large ownership area, so the team creates a focused plan each iteration, by agreeing on an appropriately small set of [iteration goals](../../../company/goals/index.md). Each goal should have more than one teammate working on it.
 
-The web team's current focus is documented in [the tracking issue for the current milestone](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Atracking+label%3Ateam%2Fweb+is%3Aopen).
-
 ## Contact
 
 - #web channel or @web-team in Slack.
@@ -38,6 +36,10 @@ We will tackle these medium-term goals in order, though expect to have some work
    This includes writing more extensions ourselves, but also extending the extension API with more capabilities to enable more use cases.
    We have a long list of ideas and use cases customers shared with us that we can solve and/or enable customers to solve with extensions.
    Some of these integrate Sourcegraph with more external services to suit the setups of more customers, others provide completely new value no other product provides.
+
+### Short term
+
+The web team's short-term goals are documented in [the tracking issue for the current milestone](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Atracking+label%3Ateam%2Fweb+is%3Aopen).
 
 ## Tech stack
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -1,8 +1,8 @@
 # Web team
 
-The web team owns all work related to our web application and browser extensions that isn't already owned by one of the other mission based teams.
+The web team owns the maintenance and expansion of our web application and code host integrations as vehicles to deliver the value of [extensions](https://docs.sourcegraph.com/extensions) to our users.
 
-This is a large ownership area, so the team creates a focused plan each iteration, by agreeing on an appropriately small set of [goals](../../../company/goals/index.md). Each goal should have more than one teammate working on it.
+This is a large ownership area, so the team creates a focused plan each iteration, by agreeing on an appropriately small set of [iteration goals](../../../company/goals/index.md). Each goal should have more than one teammate working on it.
 
 The web team's current focus is documented in [the tracking issue for the current milestone](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Atracking+label%3Ateam%2Fweb+is%3Aopen).
 
@@ -13,7 +13,20 @@ The web team's current focus is documented in [the tracking issue for the curren
 
 ## Goals
 
-TODO
+### Long term
+
+***Deliver our users the full, unique value of [extensions](https://docs.sourcegraph.com/extensions).***
+
+**Outcome**: Our webapp, browser extensions and native integrations are great platforms to provide our users unique value through extensions. These platforms are well-maintained, consistent, easy to setup, well-documented, well-tested, performant, and show their power through convincing extensions built on top of them. The extensions platform and API provide powerful capabilities to extension developers and a great developer experience.
+
+### Medium term
+
+To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
+We will gradually transition our focus through these goals in the order they are defined here.
+
+1. Make the products extensions are build on (web app, code host integrations) more consistent and improve discoverability.
+2. Bring the extensions platform into shape.
+3. Build out compelling use cases with the extensions platform.
 
 ## Tech stack
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -15,7 +15,7 @@ The web team's current focus is documented in [the tracking issue for the curren
 
 ### Long term
 
-***Deliver our users the full, unique value of [extensions](https://docs.sourcegraph.com/extensions).***
+***Deliver the full, unique value of [extensions](https://docs.sourcegraph.com/extensions) to our users.***
 
 **Outcome**: Our webapp, browser extensions and native integrations are great platforms to provide our users unique value through extensions. These platforms are well-maintained, consistent, easy to setup, well-documented, well-tested, performant, and show their power through convincing extensions built on top of them. The extensions platform and API provide powerful capabilities to extension developers and a great developer experience.
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -24,7 +24,7 @@ The web team's current focus is documented in [the tracking issue for the curren
 To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
 We will gradually transition our focus through these goals in the order they are defined here.
 
-1. Make the products extensions are build on (web app, code host integrations) more consistent and improve discoverability.
+1. Make the products that extensions are build on (web app, code host integrations) more consistent and improve discoverability.
 2. Bring the extensions platform into shape.
 3. Build out compelling use cases with the extensions platform.
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -22,7 +22,7 @@ The web team's current focus is documented in [the tracking issue for the curren
 ### Medium term
 
 To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
-We will gradually transition our focus through these goals in the order they are defined here.
+We will tackle these medium-term goals in order, though expect to have some work done in parallel as we progress. 
 
 1. Make the products that extensions are build on (web app, code host integrations) more consistent and improve discoverability.
 2. Bring the extensions platform into shape.


### PR DESCRIPTION
Adds our team's long and medium term goals to the handbook.
For context on how we arrived on these goals, see [this document](https://docs.google.com/document/d/13RrkF5RZ411MNO0op4WxXv_63K34khu7wI3c6PyFyYw/edit#).

These goals will guide our short-term iteration goals and tell the story of why we are doing what we're doing.

In addition, I reworded the ownership section to be derived from our long-term goals instead of from what other teams _don't_ own (our ownership area doesn't change from this, it's just less ambiguous). This has been a point of confusion before. 