### PR TITLE
Add cs.dev shortcut URL blog post + related styles

### DIFF
--- a/blogposts/2020/cs-dev.md
+++ b/blogposts/2020/cs-dev.md
@@ -1,0 +1,18 @@
+---
+title: "Search code quickly by going to `cs.dev/QUERY`."
+publishDate: 2020-08-25T07:00-07:00
+tags: [blog]
+slug: "cs.dev-shortcut-url-for-code-search"
+published: true
+style: short-inline-title
+---
+
+We made the [https://cs.dev shortcut URL service](https://github.com/sourcegraph/shortcut) so that you can jump to code search faster. Try typing these into your browser's URL bar:
+
+<br/><br/>
+
+`cs.dev/NewScanner`
+
+`cs.dev/repo:sourcegraph f:Dockerfile ca-cert`
+
+`cs.dev/lang:python import yaml`

--- a/website/src/components/blog/LinkPost.tsx
+++ b/website/src/components/blog/LinkPost.tsx
@@ -1,0 +1,48 @@
+import { Link } from 'gatsby'
+import * as React from 'react'
+import { PostComponentProps } from './postTypes'
+import remark from 'remark'
+import remarkHTML from 'remark-html'
+
+interface Props extends PostComponentProps {
+    post: PostComponentProps['post']
+}
+
+/**
+ * A blog post that consists of short text (with no headline, only an emphasized first sentence).
+ * This post always displays its full text and never hides it behind a "Read more" link.
+ */
+export const LinkPost: React.FunctionComponent<Props> = ({
+    post,
+    url,
+    className = '',
+    titleLinkClassName = '',
+    tag: Tag = 'div',
+}) => {
+    // Interpret title as Markdown, but without surrounding <p>...</p>.
+    const titleHTML = remark()
+        .use(remarkHTML)
+        .processSync(post.frontmatter.title)
+        .toString()
+        .replace(/^<p>/, '')
+        .replace(/<\/p>$/, '')
+
+    return (
+        <Tag className={`link-post ${className}`}>
+            <div className="card-body">
+                <h2
+                    className="font-size-base font-family-base link-post__html d-inline"
+                    dangerouslySetInnerHTML={{
+                        __html: titleHTML,
+                    }}
+                />
+                <div className="link-post__html d-inline" dangerouslySetInnerHTML={{ __html: post.html }} />
+            </div>
+            <div className="card-footer bg-unset border-top-0 pt-0">
+                <Link to={url} className={`text-muted ${titleLinkClassName}`}>
+                    {post.frontmatter.publishDate}
+                </Link>
+            </div>
+        </Tag>
+    )
+}

--- a/website/src/components/blog/postTypes.tsx
+++ b/website/src/components/blog/postTypes.tsx
@@ -3,9 +3,11 @@ import { BlogPost } from './BlogPost'
 import { ReleasePost } from './ReleasePost'
 import { PodcastPost } from './PodcastPost'
 import { PodcastSubscribeLinks } from '../podcast/PodcastSubscribeLinks'
+import { LinkPost } from './LinkPost'
 
 export enum PostType {
     BlogPost,
+    LinkPost,
     ReleasePost,
     PodcastPost,
 }
@@ -57,6 +59,7 @@ export interface PostComponentProps {
 
 export const POST_TYPE_TO_COMPONENT: Record<PostType, React.FunctionComponent<PostComponentProps>> = {
     [PostType.BlogPost]: BlogPost,
+    [PostType.LinkPost]: LinkPost,
     [PostType.ReleasePost]: ReleasePost,
     [PostType.PodcastPost]: PodcastPost,
 }
@@ -66,6 +69,8 @@ export const postType = (post: Post): PostType =>
         ? PostType.ReleasePost
         : post.frontmatter.tags?.includes('podcast')
         ? PostType.PodcastPost
+        : post.frontmatter.style === 'short-inline-title'
+        ? PostType.LinkPost
         : PostType.BlogPost
 
 export enum BlogType {

--- a/website/src/css/components/_PrismTheme.scss
+++ b/website/src/css/components/_PrismTheme.scss
@@ -1,21 +1,19 @@
 /**
- * prism.js tomorrow night eighties for JavaScript, CoffeeScript, CSS and HTML
- * Based on https://github.com/chriskempson/tomorrow-theme
- * @author Rose Pritchard
+ * GHColors theme by Avi Aryan (http://aviaryan.in)
+ * Inspired by Github syntax coloring
  */
 
 code[class*='language-'],
 pre[class*='language-'] {
-    color: #ccc;
-    background: none;
-    font-family: Consolas, Monaco, 'Andale Mono', 'Ubuntu Mono', monospace;
-    font-size: 1em;
+    color: #393a34;
+    font-family: 'Consolas', 'Bitstream Vera Sans Mono', 'Courier New', Courier, monospace;
+    direction: ltr;
     text-align: left;
     white-space: pre;
     word-spacing: normal;
     word-break: normal;
-    word-wrap: normal;
-    line-height: 1.5;
+    font-size: 0.9em;
+    line-height: 1.2em;
 
     -moz-tab-size: 4;
     -o-tab-size: 4;
@@ -25,98 +23,104 @@ pre[class*='language-'] {
     -moz-hyphens: none;
     -ms-hyphens: none;
     hyphens: none;
+}
 
+pre > code[class*='language-'] {
+    font-size: 1em;
+}
+
+pre[class*='language-']::-moz-selection,
+pre[class*='language-'] ::-moz-selection,
+code[class*='language-']::-moz-selection,
+code[class*='language-'] ::-moz-selection {
+    background: #b3d4fc;
+}
+
+pre[class*='language-']::selection,
+pre[class*='language-'] ::selection,
+code[class*='language-']::selection,
+code[class*='language-'] ::selection {
+    background: #b3d4fc;
 }
 
 /* Code blocks */
 pre[class*='language-'] {
     padding: 1em;
-    margin: .5em 0;
+    margin: 0.5em 0;
     overflow: auto;
-}
-
-:not(pre) > code[class*='language-'],
-pre[class*='language-'] {
-    background: #2d2d2d;
+    border: 1px solid #dddddd;
+    background-color: white;
 }
 
 /* Inline code */
 :not(pre) > code[class*='language-'] {
-    padding: .1em;
-    border-radius: .3em;
-    white-space: normal;
+    padding: 0.2em;
+    padding-top: 1px;
+    padding-bottom: 1px;
+    background: #f8f8f8;
+    border: 1px solid #dddddd;
 }
 
 .token.comment,
-.token.block-comment,
 .token.prolog,
 .token.doctype,
 .token.cdata {
-    color: #999;
-}
-
-.token.punctuation {
-    color: #ccc;
-}
-
-.token.tag,
-.token.attr-name,
-.token.namespace,
-.token.deleted {
-    color: #e2777a;
-}
-
-.token.function-name {
-    color: #6196cc;
-}
-
-.token.boolean,
-.token.number,
-.token.function {
-    color: #f08d49;
-}
-
-.token.property,
-.token.class-name,
-.token.constant,
-.token.symbol {
-    color: #f8c555;
-}
-
-.token.selector,
-.token.important,
-.token.atrule,
-.token.keyword,
-.token.builtin {
-    color: #cc99cd;
-}
-
-.token.string,
-.token.char,
-.token.attr-value,
-.token.regex,
-.token.variable {
-    color: #7ec699;
-}
-
-.token.operator,
-.token.entity,
-.token.url {
-    color: #67cdcc;
-}
-
-.token.important,
-.token.bold {
-    font-weight: bold;
-}
-.token.italic {
+    color: #999988;
     font-style: italic;
 }
 
-.token.entity {
-    cursor: help;
+.token.namespace {
+    opacity: 0.7;
 }
 
+.token.string,
+.token.attr-value {
+    color: #e3116c;
+}
+
+.token.punctuation,
+.token.operator {
+    color: #393a34; /* no highlight */
+}
+
+.token.entity,
+.token.url,
+.token.symbol,
+.token.number,
+.token.boolean,
+.token.variable,
+.token.constant,
+.token.property,
+.token.regex,
 .token.inserted {
-    color: green;
+    color: #36acaa;
+}
+
+.token.atrule,
+.token.keyword,
+.token.attr-name,
+.language-autohotkey .token.selector {
+    color: #00a4db;
+}
+
+.token.function,
+.token.deleted,
+.language-autohotkey .token.tag {
+    color: #9a050f;
+}
+
+.token.tag,
+.token.selector,
+.language-autohotkey .token.keyword {
+    color: #00009f;
+}
+
+.token.important,
+.token.function,
+.token.bold {
+    font-weight: bold;
+}
+
+.token.italic {
+    font-style: italic;
 }

--- a/website/src/css/components/blog/_LinkPost.scss
+++ b/website/src/css/components/blog/_LinkPost.scss
@@ -1,0 +1,17 @@
+.link-post {
+    overflow: hidden;
+
+    &__html {
+        // Allow title to be the first sentence of the post.
+        p:nth-child(1),
+        p:nth-child(2) {
+            display: inline;
+        }
+        code {
+            background-color: $light;
+            border: solid 1px $border-color;
+            padding: 2px;
+            margin: -2px 0;
+        }
+    }
+}

--- a/website/src/css/styles.scss
+++ b/website/src/css/styles.scss
@@ -241,6 +241,7 @@ table {
 }
 
 @import 'components/blog/BlogPost';
+@import 'components/blog/LinkPost';
 @import 'components/blog/PodcastPost';
 @import 'components/blog/PostsList';
 @import 'components/blog/ReleasePost';
@@ -305,4 +306,13 @@ body {
 }
 .bg-light-transparent {
     background-color: transparentize($light-11, 0.3);
+}
+.bg-unset {
+    background-color: unset;
+}
+.font-size-base {
+    font-size: $font-size-base !important;
+}
+.font-family-base {
+    font-family: $font-family-base !important;
 }

--- a/website/src/pages/blog.tsx
+++ b/website/src/pages/blog.tsx
@@ -41,6 +41,7 @@ export const pageQuery = graphql`
                             category
                             description
                         }
+                        style
                     }
                     html
                     excerpt(pruneLength: 300)

--- a/website/src/templates/PostTemplate.tsx
+++ b/website/src/templates/PostTemplate.tsx
@@ -63,6 +63,7 @@ export const pageQuery = graphql`
                     category
                     description
                 }
+                style
             }
             html
             excerpt


### PR DESCRIPTION
Also adds a new blog post template type: `style: short-inline-title` posts, where the title is just shown as a bold first sentence, and there is never a `Read more` link. This is for posts that don't need to be long.

(It's necessary to include the code changes with this PR because Gatsby complains that `style` is not a valid frontmatter property if the code changes are separate from the new content.)