### PR TITLE
Fix copy text on Docker install command to not include line feeds

### DIFF
--- a/website/src/components/GetStarted.tsx
+++ b/website/src/components/GetStarted.tsx
@@ -9,14 +9,20 @@ interface GetStartedProps {
 }
 
 export default class GetStarted extends React.PureComponent<GetStartedProps> {
-    public copyDockerInstall = () => {
-        const el = this.textArea
-        el.select()
+    public copyText = () => {
+        const copyText = document.getElementById('installText').textContent;
+        const textArea = document.createElement('textarea')
+        document.getElementById('installText').style.backgroundColor = '#ccedff';
+        textArea.textContent = copyText
+        document.body.append(textArea)
+        textArea.select()
         document.execCommand('copy')
+        document.body.removeChild(textArea)
+        // alert('Copied the text: ' + copyText);
     }
     public render(): JSX.Element | null {
         return (
-            <div className={`get-started mt-6 ${this.props.className || ''}`} id="get-started">
+            <div className={`get-started ${this.props.className || ''}`} id="get-started">
                 <div className="container">
                     <h1 className="display-2 font-weight-bold mb-5">Get started with Sourcegraph for free</h1>
                     <div className="row">
@@ -25,25 +31,14 @@ export default class GetStarted extends React.PureComponent<GetStartedProps> {
                             <p>
                                 <span className="h5">Quickstart:</span> Run this to launch Sourcegraph locally:
                             </p>
-                            <div className="get-started__installtext">
-                                <textarea
-                                    className="border boxshadow"
-                                    spellcheck="false"
-                                    rows="5"
-                                    onClick={() => this.copyDockerInstall()}
-                                    ref={textarea => (this.textArea = textarea)}
-                                    value="
-                                    docker run &#13;
-                                    --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm &#13;
-                                    --volume ~/.sourcegraph/config:/etc/sourcegraph &#13;
-                                    --volume ~/.sourcegraph/data:/var/opt/sourcegraph &#13;
-                                    sourcegraph/server:3.19.1
-                                    "
-                                    aria-label="A Docker run command to start a local Sourcegraph instance"
-                                />
+                            <div className="get-started__installtext border boxshadow" onClick={() => this.copyText()}>
+                                <span id="installText">docker run <br />
+                                    --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm <br />
+                                    --volume ~/.sourcegraph/config:/etc/sourcegraph <br />
+                                    --volume ~/.sourcegraph/data:/var/opt/sourcegraph <br />
+                                    sourcegraph/server:3.19.1</span>
                                 <span className="get-started__copytext">
                                     <ClipboardArrowLeftOutlineIcon
-                                        onClick={() => this.copyDockerInstall()}
                                         className="copytext icon-inline ml-1 medium"
                                     />
                                 </span>

--- a/website/src/css/components/_GetStarted.scss
+++ b/website/src/css/components/_GetStarted.scss
@@ -19,9 +19,18 @@
     }
     &__installtext {
         position: relative;
+        font-family: 'IBM Plex Mono';
+        font-size: 0.8rem;
+        width: 100%;
+        outline: none;
+        resize: none;
+        background-color: $light-12;
+        min-height: 150px;
+        padding: 1.5rem;
     }
     &__copytext {
         position: absolute;
+        top: 0;
         right: 0;
         margin: 2px;
         color: #0a65ea;
@@ -88,5 +97,10 @@
     }
     .btn-outline-primary:hover {
         background-color: #0745a1;
+    }
+    @media (max-width: 1023.98px) {
+        .get-started__local {
+            border-right: none!important;
+        }
     }
 }

--- a/website/src/css/pages/_get-started.scss
+++ b/website/src/css/pages/_get-started.scss
@@ -11,6 +11,14 @@
     }
     &__installtext {
         position: relative;
+        font-family: 'IBM Plex Mono';
+        font-size: 0.8rem;
+        width: 100%;
+        outline: none;
+        resize: none;
+        background-color: $light-11;
+        min-height: 150px;
+        padding: 1.5rem;
     }
     &__copytext {
         position: absolute;

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -256,7 +256,7 @@ const Index: React.FunctionComponent = (props: any) => (
                     </div>
                 </div>
             </ContentSection>
-            <GetStarted className="bg-gradient-green-blue" />
+            <GetStarted className="bg-gradient-green-blue mt-6" />
         </div>
     </Layout>
 )


### PR DESCRIPTION
Copy to clipboard from the textarea included line feeds.  Instead, use a div and select textContent which does not include the line feeds.