### PR TITLE
#search -> #search-input to avoid css conflict with search team page

### DIFF
--- a/_resources/assets/layout.css
+++ b/_resources/assets/layout.css
@@ -122,10 +122,13 @@ a:hover {
 	margin-bottom: 0;
 	margin-right: 0.5rem;
 }
-#search, #search-button {
+
+#search-input,
+#search-button {
 	padding: 0.325rem;
 }
-#search {
+
+#search-input {
 	-webkit-appearance: textfield;
 	border: solid 1px var(--border-color);
 	border-radius: 0;

--- a/_resources/templates/root.html
+++ b/_resources/templates/root.html
@@ -16,7 +16,7 @@
 					<a href="/" id="logo"><img src="{{asset "sourcegraph-logo.svg"}}" /></a>
 					<nav>
 						<form id="search-form" method="get" action="/search">
-							<input type="text" id="search" name="q" value="{{block "query" .}}{{end}}" placeholder="Search handbook..." spellcheck="false" />
+							<input type="text" id="search-input" name="q" value="{{block "query" .}}{{end}}" placeholder="Search handbook..." spellcheck="false" />
 							<button id="search-button" type="submit">Search</button>
 						</form>
 						<a href="https://about.sourcegraph.com">About</a>


### PR DESCRIPTION
Should fix the weird formatting with the search team

![Screen Shot 2020-08-28 at 10 02 30 AM](https://user-images.githubusercontent.com/754768/91593781-9ca70d00-e915-11ea-8731-a87bcff6650a.png)
