### PR TITLE
Engineering leadership status updates

### DIFF
--- a/handbook/engineering/leadership/index.md
+++ b/handbook/engineering/leadership/index.md
@@ -79,6 +79,8 @@ Engineering managers send an update to engineering-leadership-status@sourcegraph
 - What are the plans for this week?
 - What issues should my peer-team/manager be aware of?
 
+If you have sensitive information to communicate, please send a separate email directly to the relevant people.
+
 ## Book recommendations
 
 Here are some books that multiple people on the team have read and recommend. If you haven't read these, [use your education budget](../../people-ops/travel.md#professional-development-and-education) and read them!

--- a/handbook/engineering/leadership/index.md
+++ b/handbook/engineering/leadership/index.md
@@ -73,7 +73,7 @@ Our long term vision is to build an organization that attracts and retains the b
 
 We have a 1hr sync with product and engineering every Tuesday at 9am PT ([meeting notes](https://docs.google.com/document/d/10fEh3Cw0ENKjFYDP-4OoLZbOZTVAtMpifc2WM_1mGVU/edit)).
 
-Engineering managers send an update to engineering-leadership-status@sourcegraph.com by 10am PT every Monday (sending it earlier, like EOD Friday is ok too). The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
+Engineering managers send an update to engineering-leadership-status@sourcegraph.com by 12pm (noon) PT every Monday (sending it earlier, like EOD Friday is ok too). The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
 
 - What important things happened last week?
 - What are the plans for this week?

--- a/handbook/engineering/leadership/index.md
+++ b/handbook/engineering/leadership/index.md
@@ -73,7 +73,7 @@ Our long term vision is to build an organization that attracts and retains the b
 
 We have a 1hr sync with product and engineering every Tuesday at 9am PT ([meeting notes](https://docs.google.com/document/d/10fEh3Cw0ENKjFYDP-4OoLZbOZTVAtMpifc2WM_1mGVU/edit)).
 
-Engineering managers send an update to engineering-leadership-status@sourcegraph.com by 12pm (noon) PT every Monday (sending it earlier, like EOD Friday is ok too). The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
+Engineering managers send an update to [engineering-leadership-status@sourcegraph.com](https://groups.google.com/a/sourcegraph.com/g/engineering-leadership-status) by 12pm (noon) PT every Monday (sending it earlier, like EOD Friday is ok too). The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
 
 - What important things happened last week?
 - What are the plans for this week?

--- a/handbook/engineering/leadership/index.md
+++ b/handbook/engineering/leadership/index.md
@@ -77,7 +77,7 @@ Engineering managers send an update to engineering-leadership-status@sourcegraph
 
 - What important things happened last week?
 - What are the plans for this week?
-- What issues should my peer-team/manager be aware of?
+- What should my peer-team/manager be aware of?
 
 If you have sensitive information to communicate, please send a separate email directly to the relevant people.
 

--- a/handbook/engineering/leadership/index.md
+++ b/handbook/engineering/leadership/index.md
@@ -69,6 +69,16 @@ Our long term vision is to build an organization that attracts and retains the b
 - Owner: TBD.
 - Status: Not started. Needs more discussion.
 
+## Communication
+
+We have a 1hr sync with product and engineering every Tuesday at 9am PT ([meeting notes](https://docs.google.com/document/d/10fEh3Cw0ENKjFYDP-4OoLZbOZTVAtMpifc2WM_1mGVU/edit)).
+
+Engineering managers send an update to engineering-leadership-status@sourcegraph.com by 10am PT every Monday (sending it earlier, like EOD Friday is ok too). The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
+
+- What important things happened last week?
+- What are the plans for this week?
+- What issues should my peer-team/manager be aware of?
+
 ## Book recommendations
 
 Here are some books that multiple people on the team have read and recommend. If you haven't read these, [use your education budget](../../people-ops/travel.md#professional-development-and-education) and read them!


### PR DESCRIPTION
I can't sustain attending each team's weekly meeting, but I still need to know what is going on. I also don't think it will work for me to subscribe and follow each team's tracking issue each month because the updates there are too granular.

My proposal is for each EM to send a weekly email as documented, but I am open to other feedback and suggestions.

