### PR TITLE
Remove arbitrary 'asdf' wordings from the footer of the podcast page

### DIFF
--- a/website/src/pages/podcast.tsx
+++ b/website/src/pages/podcast.tsx
@@ -67,7 +67,6 @@ export const Page: React.FunctionComponent<PageProps<{ allMarkdownRemark: any }>
         posts={data.allMarkdownRemark.edges.filter((post: any) => post.node.frontmatter.published === true)}
         location={location}
     >
-        <div className="d-flex flex-column align-items-center">asdf</div>
     </PostsListPage>
 )
 const a = () => (


### PR DESCRIPTION
I found that there was a `asdf` word written at the bottom of the [podcast page](https://about.sourcegraph.com/podcast/), which I presume is placed unintentionally. Should my assumption turn out to be wrong, I will delete this particular PR. Thank you so much for the amazing podcast and looking forward to more of its episodes! 🙂 
![Screen Shot 2020-08-29 at 10 24 36 AM](https://user-images.githubusercontent.com/7043511/91628752-1958ea80-e9ed-11ea-94cf-805ce64d21ca.png)
