### PR TITLE
Loïc is engineering manager of the search team

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -42,6 +42,7 @@
 /handbook/engineering/distribution @sourcegraph/distribution
 /handbook/engineering/security @sourcegraph/security
 /handbook/engineering/web @sourcegraph/web
+/handbook/engineering/search @sourcegraph/search
 /handbook/engineering/languages/go.md @sourcegraph/cloud
 /handbook/engineering/languages/typescript.md @sourcegraph/web
 /handbook/engineering/languages/terraform.md @sourcegraph/distribution

--- a/company/team/index.md
+++ b/company/team/index.md
@@ -119,7 +119,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 ## Loïc Guychard
 
-- Software engineer, manager
+- Engineering manager, search
 - Brest, Brittany, France 🇫🇷
 - [loic@sourcegraph.com](mailto:loic@sourcegraph.com), [lguychard](https://github.com/lguychard), [LinkedIn](https://www.linkedin.com/in/lo%C3%AFc-guychard-749b8152/)
 - Loïc loves oceanside living and long bike rides. He started his career as a linguist, before transitioning to software engineering while working at Dashlane.

--- a/handbook/engineering/leadership/index.md
+++ b/handbook/engineering/leadership/index.md
@@ -7,7 +7,7 @@ This page documents the engineering leadership team.
 - [Beyang Liu](../../../company/team/index.md#beyang-liu), CTO
 - [Nick Snyder](../../../company/team/index.md#nick-snyder-he-him), [VP Engineering](../roles.md#vp-engineering)
   - [Tomás Senart](../../../company/team/index.md#tomás-senart), [Engineering Manager](../roles.md#engineering-manager), [Cloud](../cloud/index.md)
-  - [Loïc Guychard](../../../company/team/index.md#loïc-guychard), [Engineering Manager](../roles.md#engineering-manager), [Web](../campaigns/index.md)
+  - [Loïc Guychard](../../../company/team/index.md#loïc-guychard), [Engineering Manager](../roles.md#engineering-manager), [Search](../search/index.md)
   - [Gonzalo Peci](../../../company/team/index.md#gonzalo-peci-hehim), [Engineering Manager](../roles.md#engineering-manager), [Distribution](../distribution/index.md)
   - [Chayim Kirshen](../../../company/team/index.md#chayim-kirshen-he-him), [Engineering Manager](../roles.md#engineering-manager), [Security](../security/index.md)
   - [Aida DeWitt](../../../company/team/index.md#aida-dewitt-she-her), [Engineering Manager](../roles.md#engineering-manager), [Code Intelligence](../code-intelligence/index.md)

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -16,11 +16,11 @@ Our current goals are documented in the [search team's current tracking issue](h
 ## Members
 
 - [Pooja Jain](../../../company/team/index.md#) ([Product Manager](../../product/roles/product_manager.md)) is focused on search, [Christina Forney](../../../company/team/index.md#christina-forney-she-her) is supporting.
-- [Farhan Attamimi](../../../company/team/index.md#farhan-attamimi)
-- [Rijnard van Tonder](../../../company/team/index.md#rijnard-van-tonder)
-- [Stefan Hengl](../../../company/team/index.md#stefan-hengl-he-him)
-- [Juliana Peña](../../../company/team/index.md#juliana-peña-she-her)
-- [Loïc Guychard](../../../company/team/index.md#loïc-guychard) is interested in being the [engineering manager](../roles.md#engineering-manager) for this team but is currently focusing his efforts on the [web team](../web/index.md). [Nick Snyder](../../../company/team/index.md#nick-snyder-he-him) will be more involved in the meantime.
+- [Loïc Guychard](../../../company/team/index.md#loïc-guychard) ([Engineering Manager](../roles.md#engineering-manager))
+  - [Farhan Attamimi](../../../company/team/index.md#farhan-attamimi)
+  - [Rijnard van Tonder](../../../company/team/index.md#rijnard-van-tonder)
+  - [Stefan Hengl](../../../company/team/index.md#stefan-hengl-he-him)
+  - [Juliana Peña](../../../company/team/index.md#juliana-peña-she-her)
 
 ## On-call
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -78,7 +78,7 @@ Before web team syncs, teammates and stakeholders should write down under "Discu
 ## Members
 
 - [J.K.](../../../company/team/index.md#todo)([Product Manager](../../product/roles/product_manager.md)) is starting on 2020-09-14. [Christina Forney](../../../company/team/index.md#christina-forney-she-her) is involved in the meantime.
-- We are hiring an [Engineering Manager](../roles.md#engineering-manager) for this team. In the meantime, [Felix Becker](../../../company/team/index.md#felix-becker) will run team syncs, goal setting, iteration planning, retrospectives and team status updates.
+- We are hiring an [Engineering Manager for this team](../hiring/engineering-manager-web.md). In the meantime, [Felix Becker](../../../company/team/index.md#felix-becker) will run team syncs, goal setting, iteration planning, retrospectives and team status updates.
   - [Felix Becker](../../../company/team/index.md#felix-becker)
   - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
   - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -92,5 +92,3 @@ We are growing the web team by hiring [frontend engineers](https://github.com/so
 - Extensions and integrations
     - **Sourcegraph extensions** empower users to integrate Sourcegraph with any third-party service providing useful information about code (code coverage, exception tracking, tracing, code quality). They are consistently supported across all code host integrations and the Sourcegraph UI. Through extensions, Sourcegraph surfaces high-level [**code insights**](https://docs.google.com/document/d/1EHzor6I1GhVVIpl70mH-c10b1tNEl_p1xRMJ9qHQfoc/edit) to engineering leaders, empowering data-driven decisions.
     - The **browser extension** and code host **native integrations** are a breeze to set up, and add compelling value when reading or reviewing code. Enabling native code host integrations for all users is a no-brainer for site admins.
-
-Loïc is interested to be the manager of the [Search team](../search/index.md) so we are [hiring an engineering manager for this team](https://github.com/sourcegraph/careers/blob/master/job-descriptions/engineering-manager-web.md) to replace him.

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -78,7 +78,7 @@ Before web team syncs, teammates and stakeholders should write down under "Discu
 ## Members
 
 - [J.K.](../../../company/team/index.md#todo)([Product Manager](../../product/roles/product_manager.md)) is starting on 2020-09-14. [Christina Forney](../../../company/team/index.md#christina-forney-she-her) is involved in the meantime.
-- [Loïc Guychard](../../../company/team/index.md#loïc-guychard) ([Engineering Manager](../roles.md#engineering-manager))
+- We are hiring an [Engineering Manager](../roles.md#engineering-manager) for this team. In the meantime, [Felix Becker](../../../company/team/index.md#felix-becker) will run team syncs, goal setting, iteration planning, retrospectives and team status updates.
   - [Felix Becker](../../../company/team/index.md#felix-becker)
   - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
   - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)


### PR DESCRIPTION
We have decided to make my planned move to the search team effective immediately, for the following reasons:
- @nicksnyder has been doing interim engineering management on the search team, but does not have the bandwidth to be as involved as a dedicated EM, yet the search team would benefit from having a dedicated EM (for instance to actively help with goal-setting and hiring).
- @sourcegraph/web is a smaller team, with clear short and [medium-term goals](https://github.com/sourcegraph/about/pull/1433). With @felixfbecker helping with project management responsibilities, we trust that this team can be self-sufficient until we hire a dedicated EM.
- This move also gets us closer to our desired end state, and makes it clearer why we are hiring an EM for the web team specifically: because it doesn't have a dedicated EM.

What changes today:
- I will move into an active EM role on the search team.
- I will move into a passive observer role on the web team: I will keep having 1:1s with web team members and attending team syncs, but will no longer run them, or be actively involved in web team discussions / dev work.
- @felixfbecker will own project management responsibilities for the web team (as documented in this PR).
- We will heavily prioritize hiring a dedicated EM for the web team.