### PR TITLE
reorganize deployment docs for more per-deployment details

### DIFF
--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -10,6 +10,7 @@ Also on this page:
 
 - [Kubernetes](#kubernetes)
 - [Testing](#testing)
+- [deploy-sourcegraph](#deploy-sourcegraph)
 
 ## Deployment basics
 
@@ -21,7 +22,7 @@ For pushing custom images, refer to [building Docker images for specific branche
 
 ### Renovate
 
-Renovate is a tool for updating dependencies. [`deploy-sourcegraph-*`](#merging-changes-from-deploy-sourcegraph) repositories with Renovate configured check for updated Docker images about every hour. If it finds new Docker images then it opens and merges a PR ([Sourcegraph.com example](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Aapp%2Frenovate)) to update the image tags in the deployment configuration. This is usually accompanied by a CI job that deploys the updated images to the appropriate deployment.
+Renovate is a tool for updating dependencies. [`deploy-sourcegraph-*`](#deploy-sourcegraph) repositories with Renovate configured check for updated Docker images about every hour. If it finds new Docker images then it opens and merges a PR ([Sourcegraph.com example](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Aapp%2Frenovate)) to update the image tags in the deployment configuration. This is usually accompanied by a CI job that deploys the updated images to the appropriate deployment.
 
 ## sourcegraph.com
 
@@ -407,7 +408,11 @@ This will trigger two builds on Buildkite for these branches:
 
 And the end of the build you can find the name of the newly built Docker image.
 
-## Merging changes from [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) 
+## deploy-sourcegraph
+
+Sourcegraph Kubernetes deployments typically start off as [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) forks. Learn more about how we advise customers to deploy Sourcegraph in Kubernetes in our [admin installation documentation](https://docs.sourcegraph.com/admin/install/kubernetes).
+
+### Merging changes from [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) 
 
 We have two Sourcegraph Kubernetes cluster installations that we manage ourselves:
  

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -3,7 +3,7 @@
 We maintain multiple deployments of Sourcegraph:
 
 - [sourcegraph.com](#sourcegraphcom) is our production deployment for open source code.
-- [sourcegraph.sgdev.org](#sourcegraphsgdevcom) is our private deployment of Sourcegraph that contains our private code.
+- [sourcegraph.sgdev.org](#sourcegraphsgdevorg) is our private deployment of Sourcegraph that contains our private code.
 - [k8s.sgdev.org](#k8ssgdevorg) is a dogfood deployment that replicates the scale of our largest customers.
 
 ## Deployment basics
@@ -62,7 +62,9 @@ git push origin release
   1. Once you have fixed the issue in the `master` branch of [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph), re-enable auto-deploys by reverting your change to [renovate.json](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/renovate.json) from step 1.
 
 
-## sourcegraph.sgdev.com
+## sourcegraph.sgdev.org
+
+🚨 This deployment contains private code - do not use it for demos!
 
 - [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfood?project=sourcegraph-dev)
  ```

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -2,36 +2,41 @@
 
 We maintain multiple deployments of Sourcegraph:
 
-- [sourcegraph.com](https://sourcegraph.com) is our production deployment for open source code.
-  - [dot-com cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-f/cloud?project=sourcegraph-dev)
-    ```
-    gcloud container clusters get-credentials cloud --zone us-central1-f --project sourcegraph-dev
-    ```
-  - [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dot-com)
-- [sourcegraph.sgdev.org](https://sourcegraph.sgdev.org) is our private deployment of Sourcegraph that contains our private code.
-  - [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfood?project=sourcegraph-dev)
-    ```
-    gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
-    ```
-  - [Kubernetes configuration](https://github.com/sourcegraph/infrastructure/tree/master/kubernetes/dogfood)
-- [k8s.sgdev.org](https://k8s.sgdev.org) is a dogfood deployment that replicates the scale of our largest customers.
-  - [dogfood-full-k8s cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfood-full-k8s?project=sourcegraph-dev)
-    ```
-    gcloud container clusters get-credentials dogfood-full-k8s --zone us-central1-a --project sourcegraph-dev
-    ```
-  - [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s)
+- [sourcegraph.com](#sourcegraphcom) is our production deployment for open source code.
+- [sourcegraph.sgdev.org](#sourcegraphsgdevcom) is our private deployment of Sourcegraph that contains our private code.
+- [k8s.sgdev.org](#k8ssgdevorg) is a dogfood deployment that replicates the scale of our largest customers.
 
-## Deploying to sourcegraph.com
+## Deployment basics
 
-Every commit to `master` in [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph) pushes updated Docker images for all of our services to [Docker Hub](https://hub.docker.com/u/sourcegraph/) as part of our [CI pipeline](https://buildkite.com/sourcegraph/sourcegraph) (i.e. if CI is green, then Docker images have been pushed).
+### Images
 
-Renovate checks for updated Docker images about every hour. If it finds new Docker images then it [opens and merges a PR](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Aapp%2Frenovate) to update the image tags in [deploy-sourcegraph-dot-com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com). The [Renovate dashboard](https://app.renovatebot.com/dashboard#github/sourcegraph/deploy-sourcegraph-dot-com) shows logs for previous runs and allows you to predict when the next run will happen.
+Each Sourcegraph service is provided as a Docker image. Every commit to `master` in [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph) pushes updated Docker images for all of our services to [Docker Hub](https://hub.docker.com/u/sourcegraph/) as part of our [CI pipeline](https://buildkite.com/sourcegraph/sourcegraph) (i.e. if CI is green, then Docker images have been pushed).
+
+For pushing custom images, refer to [building Docker images for specific branches](#building-docker-images-for-a-specific-branch).
+
+### Renovate
+
+Renovate is a tool for updating dependencies. `deploy-sourcegraph-*` repositories with Renovate configured check for updated Docker images about every hour. If it finds new Docker images then it opens and merges a PR ([Sourcegraph.com example](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Aapp%2Frenovate)) to update the image tags in the deployment configuration. This is usually accompanied by a CI job that deploys the updated images to the appropriate deployment.
+
+## sourcegraph.com
+
+This deployment is also colloquially referred to as "Sourcegraph Cloud", "Cloud", and "dot-com".
+
+- [dot-com cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-f/cloud?project=sourcegraph-dev)
+  ```
+  gcloud container clusters get-credentials cloud --zone us-central1-f --project sourcegraph-dev
+  ```
+- [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dot-com)
+
+### Deploying to sourcegraph.com
 
 Every commit to the `release` branch (the default branch) on [deploy-sourcegraph-dot-com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com) deploys the Kubernetes YAML in this repository to our dot-com cluster [in CI](https://buildkite.com/sourcegraph/deploy-sourcegraph-dot-com/builds?branch=release) (i.e. if CI is green then the latest config in the `release` branch is deployed).
 
+Deploys on sourcegraph.com are currently [handled by Renovate](#renovate). The [Renovate dashboard](https://app.renovatebot.com/dashboard#github/sourcegraph/deploy-sourcegraph-dot-com) shows logs for previous runs and allows you to predict when the next run will happen.
+
 If you want to expedite a deploy, you can manually create and merge a PR that updates the Docker image tags in [deploy-sourcegraph-dot-com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com). You can find the desired Docker image tags by looking at the output of the Docker build step in [CI on sourcegraph/sourcegraph `master` branch](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=master) or by looking at [Docker Hub](https://hub.docker.com/u/sourcegraph/).
 
-## Rolling back sourcegraph.com
+### Rolling back sourcegraph.com
 
 To roll back soucegraph.com, push a new commit to the `release` branch in [deploy-sourcegraph-dot-com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com) that reverts the image tags and configuration to the desired state.
 
@@ -55,6 +60,23 @@ git push origin release
 
   1. Go to [renovate.json](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/renovate.json) and remove the `"extends:["default:automergeDigest"]` entry for the "Sourcegraph Docker images" group ([example](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/commit/0eb16fd9e3ddfcf3a3c75ccdda0e7eddabf19c7a)).
   1. Once you have fixed the issue in the `master` branch of [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph), re-enable auto-deploys by reverting your change to [renovate.json](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/renovate.json) from step 1.
+
+
+## sourcegraph.sgdev.com
+
+- [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfood?project=sourcegraph-dev)
+ ```
+ gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
+ ```
+- [Kubernetes configuration](https://github.com/sourcegraph/infrastructure/tree/master/kubernetes/dogfood)
+
+## k8s.sgdev.org
+
+- [dogfood-full-k8s cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfood-full-k8s?project=sourcegraph-dev)
+  ```
+  gcloud container clusters get-credentials dogfood-full-k8s --zone us-central1-a --project sourcegraph-dev
+  ```
+- [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s)
 
 ## Deploying and rolling back other clusters
 

--- a/handbook/engineering/on_call/index.md
+++ b/handbook/engineering/on_call/index.md
@@ -8,7 +8,7 @@ We have an ops on-call rotation managed through [OpsGenie](https://opsgenie.com)
 1.  Acknowledge pages promptly. If you do not acknowledge within 10 minutes, someone else will get paged.
 1.  Identify the issue and collect information that might be useful for preventing the problem in the future (e.g. if a disk was full, what was it full with?).
     - This frequently involves running kubectl commands against our production cluster.
-    - Make sure you have [setup access to kubernetes](https://about.sourcegraph.com/handbook/engineering/deployments#how-to-setup-access-to-kubernetes) and know [how to perform operations](https://about.sourcegraph.com/handbook/engineering/deployments#kubectl-cheatsheet) like: looking at logs for a service, restarting a service, getting a command shell in a running pod (e.g. to look at what is on disk).
+    - Make sure you have [setup access to kubernetes](https://about.sourcegraph.com/handbook/engineering/deployments#how-to-set-up-access-to-kubernetes) and know [how to perform operations](https://about.sourcegraph.com/handbook/engineering/deployments#kubectl-cheatsheet) like: looking at logs for a service, restarting a service, getting a command shell in a running pod (e.g. to look at what is on disk).
 1.  Take steps to resolve the issue (e.g. if a disk was full, delete any data that is safe to delete to resolve the immediate issue) if you can.
     - Don't mark pages as "resolved". Wait for the underlying alert to auto resolve.
     - If you have unsuccessfully attempted to figure out how to resolve a page, the page hasn't auto resolved (many do), and the issue appears important (e.g. impacts users), then get help from someone else. Prefer to contact people who you know are already awake/working.


### PR DESCRIPTION
current work on a [refreshed dogfood environment to replace k8s.sgdev.org](https://github.com/orgs/sourcegraph/projects/83) and a potential [demo environment](https://github.com/sourcegraph/sourcegraph/issues/13604) will probably necessitate more documentation about the specifics of each deployment, how to use them, how to troubleshoot/debug them, etc.

This PR is a first step towards that by restructuring each deployment into a section instead of just a list item so that there is more room to add details, and lifts documentation that's true of all deployments (Docker images, general Renovate usage) into a separate section. I've tried to avoid making actual content changes in this PR - this is mostly just moving things around.

There are also a lot of top-level topics in this document which makes it rather hard to read - this PR also creates a few sections like "kubernetes", "testing", etc. to better group them

**rendered:** https://github.com/sourcegraph/about/blob/da9385f551c7c68c67115055b98e4c4fe60607df/handbook/engineering/deployments.md