### PR TITLE
Add "Email to Salesforce" option to handbook

### DIFF
--- a/handbook/sales/records.md
+++ b/handbook/sales/records.md
@@ -4,3 +4,5 @@ The [source of truth for our communications with customers is Salesforce](../com
 
 - All emails interacting with a customer must be logged to Salesforce (either by using [Einstein Activity Capture](https://help.salesforce.com/articleView?id=einstein_sales_aac.htm&type=5) or by manually adding the email to the relevant object). To set up Einstein Activity Capture you can [read this article](https://help.salesforce.com/articleView?id=aac_enable.htm&type=5) or [watch this video](https://www.youtube.com/watch?v=yVO9XnsW2vA).
 - Notes from all phone calls with customers should be logged in Salesforce. The call notes should be logged to the Opportunity, rather than the Contact or Account.
+
+For non-Sales team members who want to log emails without fully connecting via Einstein Activity Capture, set up an [Email to Salesforce](https://help.salesforce.com/articleView?id=email_my_email_2_sfdc_setup.htm&type=5) email address and BCC it on client emails.


### PR DESCRIPTION
Add option to log emails without using Einstein. On the Ops, HR, Legal, Finance, etc. side I have a lot of sensitive emails that I'd prefer not to be auto-logged into Salesforce.