### PR TITLE
Add big picture code intel links to onboarding

### DIFF
--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -117,7 +117,7 @@ Our team is growing and to help our new teammates have the best onboarding exper
 
 **First Tasks**: The team has marked issues we believe are good first issues in [Github](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+label%3A%22good+first+issue%22++label%3A%22team%2Fcode-intelligence%22), following the [starter task process](../onboarding.md#starter-tasks) work with the code intel engineering manager to select three issues that you think are good ones for you to work on in your first 4 weeks.
 
-**Technical Design Docs & Diagrams**: We know that a picture is worth a thousand words and we will create visual diagrams to supplement our written documentation for the most critical or complex components and processes. This material is great for async learning and can provide a better understanding of the parts that make up the big picture. Browse through available documentation and diagrams in the [code intel developer documentation](https://docs.sourcegraph.com/dev/codeintel/) and [code intel Google drive](https://drive.google.com/drive/folders/1vKcW5EM4RBIuF8ZFvPM0G1FRwl_03RXK) and learn how the Bundle Manager works or view Inter-service request diagrams.
+**Technical Design Docs & Diagrams**: We know that a picture is worth a thousand words and we will create visual diagrams to supplement our written documentation for the most critical or complex components and processes. This material is great for async learning and can provide a better understanding of the parts that make up the big picture. Check [code intel user documentation](https://docs.sourcegraph.com/user/code_intelligence) and [our journey with LSIF post](https://about.sourcegraph.com/blog/evolution-of-the-precise-code-intel-backend/) to understand the overall view. Browse through available documentation and diagrams in the [code intel developer documentation](https://docs.sourcegraph.com/dev/codeintel/) and [code intel Google drive](https://drive.google.com/drive/folders/1vKcW5EM4RBIuF8ZFvPM0G1FRwl_03RXK) and learn how the Bundle Manager works or view Inter-service request diagrams.
 
 ### Second Month
 
@@ -168,4 +168,4 @@ _Updated 2020-08-01_
 
 We are hiring for these roles:
 
-- +1 [Software Engineer - Code intelligence](https://github.com/sourcegraph/careers/blob/master/job-descriptions/software-engineer-code-intelligence.md)
+- +1 [Software Engineer - Code intelligence](https://about.sourcegraph.com/handbook/engineering/hiring/software-engineer-code-intelligence)


### PR DESCRIPTION
Added user code intel docs link and LSIF history blog post to onboarding docs for an easier general understanding
Also updated hiring status link to match the new URL