### PR TITLE
Add Sourcegraph.com org to onboarding

### DIFF
--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -35,6 +35,7 @@ Your manager should complete the following steps when you join:
 - Grant access to necessary services.
   - [Sourcegraph organization on GitHub](https://github.com/orgs/sourcegraph/people)
     - Invite to relevant GitHub teams, including [@sourcegraph/everyone](https://github.com/orgs/sourcegraph/teams/everyone).
+  - [Sourcegraph organization on Sourcegraph.com](https://sourcegraph.com/organizations/sourcegraph/members)
   - [LSIF organization on GitHub](https://github.com/orgs/lsif/people) (optional; recommended for Code Intelligence team members)
   - [Buildkite](https://buildkite.com/organizations/sourcegraph/users/new)
   - Google Cloud Platform ([prod](https://console.cloud.google.com/iam-admin/iam?project=sourcegraph-dev), [test](https://console.cloud.google.com/iam-admin/iam?project=sourcegraph-server))


### PR DESCRIPTION
Was previously not included as part of [general onboarding](https://about.sourcegraph.com/handbook/people-ops/onboarding#for-all-new-teammates) or engineer onboarding.