### PR TITLE
Update product onboarding docs

### DIFF
--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -44,7 +44,7 @@ As you're working on these tasks:
     - Open a pull request as soon as you feel like you're ready for feedback or input on your code — you can make it a draft pull request if your code is still a work in progress.  
     - Favour splitting up your work in multiple pull requests every time it makes sense — shipping frequently is important.
     - Ask yourself what tests are appropriate for the change you're tackling, and add them!
-- If you need help, remember evryone is he to [answer any question](../people-ops/onboarding/index.md#everyone-is-here-to-support-you-as-you-onboard) — ask for help in your team's channel (or any appropriate channel), and add the answer to our docs or the handbook if you feel like it can help future teammates.
+- If you need help, remember everyone is here to [answer any question](../people-ops/onboarding/index.md#everyone-is-here-to-support-you-as-you-onboard) — ask for help in your team's channel (or any appropriate channel), and add the answer to our docs or the handbook if you feel like it can help future teammates.
 
 As you complete these tasks, share your accomplishments in #progress 🙂
 

--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -58,7 +58,7 @@ As you're working on these tasks:
     - Open a pull request as soon as you feel like you're ready for feedback or input on your code — you can make it a draft pull request if your code is still a work in progress.  
     - Favour splitting up your work in multiple pull requests every time it makes sense — shipping frequently is important.
     - Ask yourself what tests are appropriate for the change you're tackling, and add them!
-- If you need help, remember that there are [no stupid questions](#there_are_no_stupid_questions) — ask for help in your team's channel (or any appropriate channel), and add the answer to our docs or the handbook if you feel like it can help future teammates.
+- If you need help, remember that there are [no stupid questions](#there-are-no-stupid-questions) — ask for help in your team's channel (or any appropriate channel), and add the answer to our docs or the handbook if you feel like it can help future teammates.
 
 As you complete these tasks, share your accomplishments in #progress 🙂
 

--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -2,20 +2,6 @@
 
 Welcome! We're excited to have you join the team. This document outlines the structure of your first few weeks at Sourcegraph.
 
-## Guiding principles
-
-### There are no stupid questions
-
-Joining a new company can be overwhelming — there's a lot to learn! As you navigate your first few weeks at Sourcegraph, we want you to know that everyone on the team is here to help, and that there are **no stupid questions**.
-
-Every time you're curious or confused about something — just ask! When you do so, use [public discussion channels](../communication/team_chat.md#avoid_private_messages) as much as possible.
-
-### Think and act like an owner
-
-At Sourcegraph, we don't think of teammates as resources — we think of them as owners of their work, who constantly reevaluate how to use their talents to be as impactful as possible. We value your opinions and ideas. You should always feel empowered to identify potential improvements and act upon them, whether they be improvements to processes (like onboarding), our handbook and general documentation, our codebase and tooling, or our product.
-
-Never assume that a problem is somebody else's to fix!
-
 ## Getting set up
 
 You'll have to get some basics set up in your first few days:
@@ -58,7 +44,7 @@ As you're working on these tasks:
     - Open a pull request as soon as you feel like you're ready for feedback or input on your code — you can make it a draft pull request if your code is still a work in progress.  
     - Favour splitting up your work in multiple pull requests every time it makes sense — shipping frequently is important.
     - Ask yourself what tests are appropriate for the change you're tackling, and add them!
-- If you need help, remember that there are [no stupid questions](#there-are-no-stupid-questions) — ask for help in your team's channel (or any appropriate channel), and add the answer to our docs or the handbook if you feel like it can help future teammates.
+- If you need help, remember evryone is he to [answer any question](../people-ops/onboarding/index.md#everyone-is-here-to-support-you-as-you-onboard) — ask for help in your team's channel (or any appropriate channel), and add the answer to our docs or the handbook if you feel like it can help future teammates.
 
 As you complete these tasks, share your accomplishments in #progress 🙂
 

--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -8,9 +8,21 @@
 - [Product team](../../product/onboarding/index.md)
 - [Onboarding buddy program](../buddy-program.md)
 
-## For all new teammates
+## Guiding principles
 
-> NOTE: This list is incomplete because it includes only new steps added since the creation of the Sourcegraph handbook. Eventually all of the onboarding docs above will be migrated to this Sourcegraph handbook, then this list will be complete and this note can be removed.
+### Everyone is here to support you as you onboard
+
+Joining a new company can be overwhelming — there's a lot to learn! As you navigate your first few weeks at Sourcegraph, we want you to know that everyone on the team is here to help and will gladly drop anything to answer any question you have.
+
+Every time you're curious or confused about something — just ask! When you do so, use [public discussion channels](../communication/team_chat.md#avoid_private_messages) as much as possible.
+
+### Think and act like an owner
+
+At Sourcegraph, we don't think of teammates as resources — we think of them as owners of their work, who constantly reevaluate how to use their talents to be as impactful as possible. We value your opinions and ideas. You should always feel empowered to identify potential improvements and act upon them, whether they be improvements to processes (like onboarding), our handbook and general documentation, our codebase and tooling, or our product.
+
+Never assume that a problem is somebody else's to fix!
+
+## For all new teammates
 
 - Watch the [new team member intro from the CEO](https://www.youtube.com/watch?v=EVHUGZe5uts)
 - [Configure Google Calendar](https://calendar.google.com/calendar/r/settings)
@@ -24,6 +36,6 @@
 - Add a link to your team page bio to your Slack profile
 - Read the first page of [Sourcegraph's user documentation](https://docs.sourcegraph.com/user).
 - It might not be immediately necessary, but if you ever need to click a HubSpot link just ask for access in #sales.
-- Go through the [analytics onboarding](https://sourcegraph.looker.com/projects/sourcegraph_events/files/1_home.md). This onboarding is within Looker, so if you don't have an account you can ask for access in #analytics. 
+- Go through the [analytics onboarding](https://sourcegraph.looker.com/projects/sourcegraph_events/files/1_home.md). This onboarding is within Looker, so if you don't have an account you can ask for access in #analytics.
 - Read Sourcegraph's [information security policy](https://about.sourcegraph.com/security) and acknowledge your acceptance: https://forms.gle/LUK1YtwAMJLhtRPi6.
 - Watch Dan's [Sourcegraph Demo](https://drive.google.com/file/d/1VUZ0rnZQpNgjtGDI0tMC-h-OtL0Czz8H/view)

--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -14,7 +14,7 @@
 
 Joining a new company can be overwhelming — there's a lot to learn! As you navigate your first few weeks at Sourcegraph, we want you to know that everyone on the team is here to help and will gladly drop anything to answer any question you have.
 
-Every time you're curious or confused about something — just ask! When you do so, use [public discussion channels](../communication/team_chat.md#avoid_private_messages) as much as possible.
+Every time you're curious or confused about something — just ask! When you do so, use [public discussion channels](../../communication/team_chat.md#avoid_private_messages) as much as possible.
 
 ### Think and act like an owner
 

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -5,6 +5,7 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
 ## Manager checklist
 
 - Create onboarding Google doc and copy in this page to customize week 2-4 tasks and have a personal checklist for the new teammate.
+- Update onboarding doc Week 2-4 with initial projects.
 - Grant access to necessary services.
   - [Sourcegraph organization on GitHub](https://github.com/orgs/sourcegraph/people)
   - Invite to GitHub teams, including [@sourcegraph/everyone](https://github.com/orgs/sourcegraph/teams/everyone)

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -81,7 +81,7 @@ You'll find we have a strong base to work from, but we are in the early stages o
 
 - Set up Figma
    - Download [Figma](https://www.figma.com)
-   - Set nudge to 8px in preferences > nudge amount
+   - (Optional) Set nudge to 8px in preferences > nudge amount
    - Install Figma plugins:
       - [Data lab](https://www.figma.com/community/plugin/740286071386014712/Data-Lab) - populates layers with data. This helps us provide more accurate designs and avoid tedious text generation
       - [Data for design](https://drive.google.com/drive/folders/1Xw7t1rIWRTg3cJ1_v-A40FGKCLE9m9Pg?usp=sharing)
@@ -95,8 +95,8 @@ You'll find we have a strong base to work from, but we are in the early stages o
    - Take a moment to add some inspiring design to the Figma [styleboards](https://www.figma.com/files/project/10712517/Styleboards)
 - UserTesting.com
    - Get a tour of UserTesting.com from another designer on the team.
-   - Review a few [usability studies](https://drive.google.com/drive/folders/1qZEWiKSXIvtF8oEp5jGeUQdFcjd2KtVy?usp=sharing) to get an idea of how you will use the product
-   - As you learn the product, create a GitHub issue proposiing a usability study you would like to conduct and tag it with 'UX'
+   - Review a few [usability studies](https://drive.google.com/drive/folders/1qZEWiKSXIvtF8oEp5jGeUQdFcjd2KtVy?usp=sharing) to get an idea of how you will use the product.
+- As you learn the product, if you come across a quick win for better usability based on general heuritics, create a GitHub issue identifying the problem and proposing a quick solution, and tag it with 'UX'.
 - Suggest a tool you love to the team in the #design channel on Slack!
 - Storybook houses our React component library. We use [Chromatic](https://www.chromatic.com/library?appId=5f0f381c0e50750022dc6bf7) to easily access and collaborate on the components. You can access the React components library in two ways: 
    1. Log in to Chromatic with your GitHub account and open Sourcegraph library

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -83,11 +83,12 @@ You'll find we have a strong base to work from, but we are in the early stages o
    - Download [Figma](https://www.figma.com)
    - (Optional) Set nudge to 8px in preferences > nudge amount
    - Install Figma plugins:
+      - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet accessibility standards
+      - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the material design icons which can be searched and included with this plugin
+      - [Style organizer](https://www.figma.com/community/plugin/816627069580757929/Style-Organizer) - helps us manage color
       - [Data lab](https://www.figma.com/community/plugin/740286071386014712/Data-Lab) - populates layers with data. This helps us provide more accurate designs and avoid tedious text generation
       - [Data for design](https://drive.google.com/drive/folders/1Xw7t1rIWRTg3cJ1_v-A40FGKCLE9m9Pg?usp=sharing)
       - [Lorem Ipsum](https://www.figma.com/community/plugin/736000994034548392/Lorem-ipsum) - simple text generator
-      - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet accessibility standards
-      - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the material design icons which can be searched and included with this plugin
       - Suggest plugins to help make us more efficent!
    - Install the font SF PRO, which can be found in the [drive type folder](https://drive.google.com/drive/folders/15NibaPYH4F0L_isvKHsYTFpwquv6DnRs)
    - Review the [component library](https://www.figma.com/files/project/14326173/%F0%9F%93%9ADesign-system)

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -29,7 +29,7 @@ Remember:
 Onboarding buddy: TBD
 
 - Complete [general onboarding](../../people-ops/onboarding/index.md#for-all-new-teammates)
-- Review and internalize the [guiding principles](../../engineering/onboarding#guiding-principles) from the engineering onboarding page - these are principles to live by at Sourcegraph!
+- Review and internalize the [guiding principles](../../engineering/onboarding.md#guiding-principles) from the engineering onboarding page - these are principles to live by at Sourcegraph!
 - Write your 30-60-90 day objectives in your 1:1 doc with Christina
 
 ### Get to know the team
@@ -44,7 +44,7 @@ Onboarding buddy: TBD
 
 ### Set up the basics
 
-- [Configure your GitHub notifications.](./github-notifications/index.md)
+- [Configure your GitHub notifications.](../../engineering/github-notifications/index.md)
 - Familiarize yourself with our [team chat](../../communication/team_chat.md) and join team channels on Slack, as well as any other channels you find interesting. [Product team chat documentation](../../communication/team_chat.md#product).
 - Set up your [local development environment](https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/local_development.md#step-1-install-dependencies). If you encounter any issues, ask for help in Slack and then update the documentation to reflect the resolution (so the next person that we hire doesn't run into the same problem).
    - You will need to run Sourcegraph locally to test and validate work that engineering is doing, to provide early feedback, or to review the UX of recently implemented work.

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -26,7 +26,7 @@ Remember:
    - If you see a "request permission" page for some doc or other resource, it is a mistake. Just ask to be granted access to it (and mention it to Noemi so the next person starting is granted access to that system).
 - Unlike at many companies, it is OK (and important) to call out when we did something poorly or when something doesn't go well (e.g., a sales pitch falls flat). That helps us be real and do it better in the future.
 
-Onboarding buddy: TBD
+[Onboarding buddy](https://about.sourcegraph.com/handbook/people-ops/buddy-program): You will be paired up with an “onboarding buddy” in order to become better acquainted with Sourcegraph team and culture. A buddy will be your go-to person for questions (in addition to your manager and the People Ops team).
 
 - Complete [general onboarding](../../people-ops/onboarding/index.md#for-all-new-teammates)
 - Review and internalize the [guiding principles](../../engineering/onboarding.md#guiding-principles) from the engineering onboarding page - these are principles to live by at Sourcegraph!

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -23,13 +23,13 @@ Remember:
 
 - Sourcegraph is an [open company](../../../company/open_source_open_company.md). Everything here at Sourcegraph is public unless there is a very good reason for it to be private.
    - Good reasons for things to be private: sensitive customer information, sensitive personal information
-   - If you see a "request permission" page for some doc or other resource, it is a mistake. Just ask to be granted access to it (and mention it to Noemi so the next person starting is granted access to that system).
+   - If you see a "request permission" page for some doc or other resource, it is a mistake. Just ask to be granted access to it (and make a PR to update the handbook so the next person starting is granted access to that system).
 - Unlike at many companies, it is OK (and important) to call out when we did something poorly or when something doesn't go well (e.g., a sales pitch falls flat). That helps us be real and do it better in the future.
 
-[Onboarding buddy](https://about.sourcegraph.com/handbook/people-ops/buddy-program): You will be paired up with an “onboarding buddy” in order to become better acquainted with Sourcegraph team and culture. A buddy will be your go-to person for questions (in addition to your manager and the People Ops team).
+**[Onboarding buddy](https://about.sourcegraph.com/handbook/people-ops/buddy-program)**: You will be paired up with an “onboarding buddy” in order to become better acquainted with Sourcegraph team and culture. A buddy will be your go-to person for questions (in addition to your manager and the People Ops team).
 
 - Complete [general onboarding](../../people-ops/onboarding/index.md#for-all-new-teammates)
-- Review and internalize the [guiding principles](../../engineering/onboarding.md#guiding-principles) from the engineering onboarding page - these are principles to live by at Sourcegraph!
+   - Keep the [guiding principles](../../engineering/onboarding.md#guiding-principles) from the general onboarding page in mind - we are here to support you and you should act like an owner!
 - Write your 30-60-90 day objectives in your 1:1 doc with Christina
 
 ### Get to know the team

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -1,9 +1,10 @@
 # Product team onboarding
 
-Welcome to Sourcegraph! As a member of the product team, it is your job to be the voice of the user, and to balance that with the goals of the company.
+Welcome to Sourcegraph! As a member of the product team, it is your job to be the voice of the user, and to balance that with the goals of the company. For all [roles on the product team](../roles/index.md), you will have a very similar first week. Weeks 2-4 will vary depending on your role and areas of focus, but the high level goals for each week will be the same. 
 
 ## Manager checklist
 
+- Create onboarding Google doc and copy in this page to customize week 2-4 tasks and have a personal checklist for the new teammate.
 - Grant access to necessary services.
   - [Sourcegraph organization on GitHub](https://github.com/orgs/sourcegraph/people)
   - Invite to GitHub teams, including [@sourcegraph/everyone](https://github.com/orgs/sourcegraph/teams/everyone)
@@ -11,62 +12,103 @@ Welcome to Sourcegraph! As a member of the product team, it is your job to be th
   - Productboard
   - UserTesting.com
 - Schedule a recurring [1-1](../../leadership/1-1.md).
-- Schedule daily check-ins for the first week at Sourcegraph to keep up with your onboarding and to create space for answering any questions that might come up.
+- Schedule daily check-ins for the first week at Sourcegraph to keep up with onboarding and to create space for answering any questions that might come up.
 
-## Product team member checklist
+## Week 1 - Getting started
 
-- Get to know our team and learn about Sourcegraph (company and product)
-- Finish [general onboarding tasks](../../people-ops/onboarding/index.md#for-all-new-teammates)
-  - Set up your email filters, especially for GitHub and feedback
-- Get to know the product
-  - Complete the "Getting set up" section of the [Engineering onboarding tasks](../../engineering/onboarding/index.md#getting-set-up).
-    - You will need to run Sourcegraph locally to test/validate work that engineering is doing, to provide early/often feedback.
-  - Review [product resources](../index.md#resources)
-  - [Products](https://about.sourcegraph.com/product)
-  - Learn how the Customer Engineering team gives demos and talks about the product in the [product demo recording](https://drive.google.com/file/d/1idbCnce5MIvtAV0GOOwgB68zQJB2WmZ9/view).
-  - Read about [search queries](https://docs.sourcegraph.com/user/search) and perform your first searches.
-  - Work through the questions from the [Sales Onboarding Quiz](../../sales/onboarding/quiz.md) to make sure you understand key concepts. Feel free to skip any obvious answers and discuss any questions you have or knowledge gaps with your manager.
-- Get to know our customers
-  - Reach out to the Sales/CE teams and ask to be added to as many customer calls as you can this week.
-  - Feedback
-    - [HubSpot](https://app.hubspot.com/forms/2762526/a86bbac5-576d-4ca0-86c1-0c60837c3eab/submissions)
-    - [Productboard](https://sourcegraph.productboard.com/insights/shared-inbox)
-- Understand our goals
-  - [Sourcegraph master plan](../../../company/strategy.md)
-  - [Sourcegraph direction (1 year plan)](../../../direction/index.md)
-  - [Goals](../../../company/goals/index.md)
+Your objective is to get to know the team and learn as much about Sourcegraph (the company and product) as possible. It is your responsibility to be proactive in your onboarding, and it is the team's #1 priority to support you and help set you up for success. Everyone will drop what they're doing to help you. We are so excited to have you on the team and can't wait to get to know you better!
 
-## Product designer onboarding
+Remember:
 
-After completing the product team checklist above, use the following resources to get up to speed on design at Sourcegraph.
+- Sourcegraph is an [open company](../../../company/open_source_open_company.md). Everything here at Sourcegraph is public unless there is a very good reason for it to be private.
+   - Good reasons for things to be private: sensitive customer information, sensitive personal information
+   - If you see a "request permission" page for some doc or other resource, it is a mistake. Just ask to be granted access to it (and mention it to Noemi so the next person starting is granted access to that system).
+- Unlike at many companies, it is OK (and important) to call out when we did something poorly or when something doesn't go well (e.g., a sales pitch falls flat). That helps us be real and do it better in the future.
+
+Onboarding buddy: TBD
+
+- Complete [general onboarding](../../people-ops/onboarding/index.md#for-all-new-teammates)
+- Review and internalize the [guiding principles](../../engineering/onboarding#guiding-principles) from the engineering onboarding page - these are principles to live by at Sourcegraph!
+- Write your 30-60-90 day objectives in your 1:1 doc with Christina
+
+### Get to know the team
+
+- Schedule 1-1s with each person on the [Product team](../index.md#members)
+- Schedule 1-1s with each person on the engineering team you'll be working most closely with (ask Christina if you're not sure who this is)
+- Get up to speed on what your team is working on
+   - Team handbook page(s), to learn about the team and its internal processes
+   - Sourcegraph user docs
+   - Team sync docs - review recent meeting notes for context
+   - Current tracking issue(s)
+
+### Set up the basics
+
+- [Configure your GitHub notifications.](./github-notifications/index.md)
+- Familiarize yourself with our [team chat](../../communication/team_chat.md) and join team channels on Slack, as well as any other channels you find interesting. [Product team chat documentation](../../communication/team_chat.md#product).
+- Set up your [local development environment](https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/local_development.md#step-1-install-dependencies). If you encounter any issues, ask for help in Slack and then update the documentation to reflect the resolution (so the next person that we hire doesn't run into the same problem).
+   - You will need to run Sourcegraph locally to test and validate work that engineering is doing, to provide early feedback, or to review the UX of recently implemented work.
+- [Add Sourcegraph as a browser search engine](https://docs.sourcegraph.com/integration/browser_search_engine). Add another entry for our internal instance: `https://sourcegraph.sgdev.org/search?q=%s`. This also ensures you have access to our internal instance.
+
+### Get to know the product
+
+- Review [product resources](../index.md#resources)
+- Learn how the Customer Engineering team gives demos and talks about the product in the [product demo recording](https://drive.google.com/file/d/1idbCnce5MIvtAV0GOOwgB68zQJB2WmZ9/view).
+- Read about [search queries](https://docs.sourcegraph.com/user/search) and perform your first searches.
+- Work through the questions from the [Sales Onboarding Quiz](../../sales/onboarding/quiz.md) to make sure you understand key concepts. Feel free to skip any obvious answers and discuss any questions you have or knowledge gaps with your manager.
+
+### Get to know our customers
+
+- Reach out to the Sales/CE teams and ask to be added to as many customer calls as you can in your first few weeks.
+- Familiarize yourself with customer feedback channels
+   - [HubSpot](https://app.hubspot.com/forms/2762526/a86bbac5-576d-4ca0-86c1-0c60837c3eab/submissions) surveys
+   - [Productboard](https://sourcegraph.productboard.com/insights/shared-inbox)
+   - Twitter
+   - Slack #feedback channel
+
+### Understand company and team goals
+
+- [Sourcegraph master plan](../../../company/strategy.md)
+- [Sourcegraph direction (1 year plan)](../../../direction/index.md)
+- [Company goals](../../../company/goals/index.md)
+- [Product team goals](../goals.md)
+
+### Set up your design environment
+
+If you are a designer on the team, use the following resources to get up to speed on design at Sourcegraph.
 
 You'll find we have a strong base to work from, but we are in the early stages of creating our program. Your input will be critical to our success, so take notes about everything you experience while onboarding. We'll use them to help us improve our process and the product!
 
-- Tools
-  - Figma
-    - Download [Figma](https://www.figma.com)
-    - Set nudge to 8px in preferences > nudge amount
-    - Install Figma plugins:
-       - [Data lab](https://www.figma.com/community/plugin/740286071386014712/Data-Lab) - populates layers with data. This helps us provide more accurate designs and avoid tedious text generation
-       - [Data for design](https://drive.google.com/drive/folders/1Xw7t1rIWRTg3cJ1_v-A40FGKCLE9m9Pg?usp=sharing)
-       - [Lorem Ipsum](https://www.figma.com/community/plugin/736000994034548392/Lorem-ipsum) - simple text generator
-       - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet accessibility standards
-       - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the matrial design icons which can be searched and included with this plugin
-       - Suggest plugins to help make us more efficent!
-     - Install the font SF PRO, which can be found in the [drive type folder](https://drive.google.com/drive/folders/15NibaPYH4F0L_isvKHsYTFpwquv6DnRs)
-     - Review the [component library](https://www.figma.com/file/BkY8Ak997QauG0Iu2EqArv/Sourcegraph-Components?node-id=0%3A1&viewport=4848%2C895%2C0.5811631679534912)
-     - Review the [style guide](https://www.figma.com/file/Y4JDvoFnCmY1JIQIWdiOJh/styleguide__components?node-id=0%3A1&viewport=153%2C791%2C0.0701417475938797) which we are transitioning to the component library
-    - Review the [Project Tools](https://www.figma.com/file/8qNcDzOXLj1hcOM76WDPN9/Project-Tools?node-id=0%3A1)
-    - Take a moment to add some inspiring design to a Figma styleboard
-   - UserTesting.com
-     - Get a tour of UserTesting.com
-      - Review a few [usability studies](https://drive.google.com/drive/folders/1qZEWiKSXIvtF8oEp5jGeUQdFcjd2KtVy?usp=sharing) to get an idea of how you will use the product
-      - As you learn the product, create a GitHub issue proposiing a usability study you would like to conduct and tag it with 'UX'
-    - Suggest a tool you love on Slack in #design!
-- Set up your [local development environment](https://github.com/sourcegraph/sourcegraph/blob/master/doc/dev/local_development.md#step-1-install-dependencies)
-  - You'll use this environment to review the UX of builds and to gain access to unreleased features 
-  - Storybook houses our React component library
-    - From the root of your local environment run storybook: `yarn storybook` to see how our designs transformed into React components
+- Set up Figma
+   - Download [Figma](https://www.figma.com)
+   - Set nudge to 8px in preferences > nudge amount
+   - Install Figma plugins:
+      - [Data lab](https://www.figma.com/community/plugin/740286071386014712/Data-Lab) - populates layers with data. This helps us provide more accurate designs and avoid tedious text generation
+      - [Data for design](https://drive.google.com/drive/folders/1Xw7t1rIWRTg3cJ1_v-A40FGKCLE9m9Pg?usp=sharing)
+      - [Lorem Ipsum](https://www.figma.com/community/plugin/736000994034548392/Lorem-ipsum) - simple text generator
+      - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet accessibility standards
+      - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the matrial design icons which can be searched and included with this plugin
+      - Suggest plugins to help make us more efficent!
+   - Install the font SF PRO, which can be found in the [drive type folder](https://drive.google.com/drive/folders/15NibaPYH4F0L_isvKHsYTFpwquv6DnRs)
+   - Review the [component library](https://www.figma.com/file/BkY8Ak997QauG0Iu2EqArv/Sourcegraph-Components?node-id=0%3A1&viewport=4848%2C895%2C0.5811631679534912)
+   - Review the [style guide](https://www.figma.com/file/Y4JDvoFnCmY1JIQIWdiOJh/styleguide__components?node-id=0%3A1&viewport=153%2C791%2C0.0701417475938797) which we are transitioning to the component library
+   - Review the [Project Tools](https://www.figma.com/file/8qNcDzOXLj1hcOM76WDPN9/Project-Tools?node-id=0%3A1)
+   - Take a moment to add some inspiring design to a Figma styleboard
+- UserTesting.com
+   - Get a tour of UserTesting.com from another designer on the team.
+   - Review a few [usability studies](https://drive.google.com/drive/folders/1qZEWiKSXIvtF8oEp5jGeUQdFcjd2KtVy?usp=sharing) to get an idea of how you will use the product
+   - As you learn the product, create a GitHub issue proposiing a usability study you would like to conduct and tag it with 'UX'
+- Suggest a tool you love to the team in the #design channel on Slack!
+- Storybook houses our React component library. From the root of your local development environment run storybook: `yarn storybook` to see how our designs transformed into React components.
 - Explore and favorite the [Google Drive design folder](https://drive.google.com/drive/folders/1xBRaw_2Ulccd_2ts0Wcq4Rgs6LuVblLU?usp=sharing)
 - Review the [Potential UX projects document](https://docs.google.com/document/d/1LemO13R3f0Ku88WK8tFr7_Qo4teDA0Bebs8Y2TGkS3U/edit)
-  - Use this document to record issues you'd like to work on as you discover them during your onboarding
+   - Use this document to record issues you'd like to work on as you discover them during your onboarding
+
+## Week 2-3 - initial projects
+
+- The goal is to give you a handful of projects that will help you familiarize yourself with the product, and get some quick wins in your first weeks.
+- If you see something that you think would be a great project for you to tackle as you’re onboarding, let’s talk about it!
+- We are excited to get you meatier projects, and also want to make sure you have adequate ramp-up time :)
+
+## Week 4 - start a larger project
+
+- Let’s talk about your strengths, interests, areas you’re excited about, as well as what will help drive the team and company goals!

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -87,19 +87,20 @@ You'll find we have a strong base to work from, but we are in the early stages o
       - [Data for design](https://drive.google.com/drive/folders/1Xw7t1rIWRTg3cJ1_v-A40FGKCLE9m9Pg?usp=sharing)
       - [Lorem Ipsum](https://www.figma.com/community/plugin/736000994034548392/Lorem-ipsum) - simple text generator
       - [A11y - Color Contrast Checker](https://www.figma.com/community/plugin/733159460536249875/A11y---Color-Contrast-Checker) - handy tool to check if your designs meet accessibility standards
-      - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the matrial design icons which can be searched and included with this plugin
+      - [Iconify](https://www.figma.com/community/plugin/735098390272716381/Iconify) - We use the material design icons which can be searched and included with this plugin
       - Suggest plugins to help make us more efficent!
    - Install the font SF PRO, which can be found in the [drive type folder](https://drive.google.com/drive/folders/15NibaPYH4F0L_isvKHsYTFpwquv6DnRs)
-   - Review the [component library](https://www.figma.com/file/BkY8Ak997QauG0Iu2EqArv/Sourcegraph-Components?node-id=0%3A1&viewport=4848%2C895%2C0.5811631679534912)
-   - Review the [style guide](https://www.figma.com/file/Y4JDvoFnCmY1JIQIWdiOJh/styleguide__components?node-id=0%3A1&viewport=153%2C791%2C0.0701417475938797) which we are transitioning to the component library
+   - Review the [component library](https://www.figma.com/files/project/14326173/%F0%9F%93%9ADesign-system)
    - Review the [Project Tools](https://www.figma.com/file/8qNcDzOXLj1hcOM76WDPN9/Project-Tools?node-id=0%3A1)
-   - Take a moment to add some inspiring design to a Figma styleboard
+   - Take a moment to add some inspiring design to the Figma [styleboards](https://www.figma.com/files/project/10712517/Styleboards)
 - UserTesting.com
    - Get a tour of UserTesting.com from another designer on the team.
    - Review a few [usability studies](https://drive.google.com/drive/folders/1qZEWiKSXIvtF8oEp5jGeUQdFcjd2KtVy?usp=sharing) to get an idea of how you will use the product
    - As you learn the product, create a GitHub issue proposiing a usability study you would like to conduct and tag it with 'UX'
 - Suggest a tool you love to the team in the #design channel on Slack!
-- Storybook houses our React component library. From the root of your local development environment run storybook: `yarn storybook` to see how our designs transformed into React components.
+- Storybook houses our React component library. We use [Chromatic](https://www.chromatic.com/library?appId=5f0f381c0e50750022dc6bf7) to easily access and collaborate on the components. You can access the React components library in two ways: 
+   1. Log in to Chromatic with your GitHub account and open Sourcegraph library
+   1. from the root of your local development environment run storybook: `yarn storybook`.
 - Explore and favorite the [Google Drive design folder](https://drive.google.com/drive/folders/1xBRaw_2Ulccd_2ts0Wcq4Rgs6LuVblLU?usp=sharing)
 - Review the [Potential UX projects document](https://docs.google.com/document/d/1LemO13R3f0Ku88WK8tFr7_Qo4teDA0Bebs8Y2TGkS3U/edit)
    - Use this document to record issues you'd like to work on as you discover them during your onboarding

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -2,18 +2,27 @@
 
 Welcome to Sourcegraph! As a member of the product team, it is your job to be the voice of the user, and to balance that with the goals of the company. For all [roles on the product team](../roles/index.md), you will have a very similar first week. Weeks 2-4 will vary depending on your role and areas of focus, but the high level goals for each week will be the same. 
 
+**[Onboarding buddy](../../people-ops/buddy-program.md)**: You will be paired up with an “onboarding buddy” in order to become better acquainted with Sourcegraph team and culture. A buddy will be your go-to person for questions (in addition to your manager and the People Ops team).
+
 ## Manager checklist
 
 - Create onboarding Google doc and copy in this page to customize week 2-4 tasks and have a personal checklist for the new teammate.
 - Update onboarding doc Week 2-4 with initial projects.
 - Grant access to necessary services.
-  - [Sourcegraph organization on GitHub](https://github.com/orgs/sourcegraph/people)
-  - Invite to GitHub teams, including [@sourcegraph/everyone](https://github.com/orgs/sourcegraph/teams/everyone)
-  - Figma
-  - Productboard
-  - UserTesting.com
+   - [Sourcegraph organization on GitHub](https://github.com/orgs/sourcegraph/people)
+   - Invite to GitHub teams, including [@sourcegraph/everyone](https://github.com/orgs/sourcegraph/teams/everyone)
+   - Figma
+   - Productboard
+   - UserTesting.com
 - Schedule a recurring [1-1](../../leadership/1-1.md).
 - Schedule daily check-ins for the first week at Sourcegraph to keep up with onboarding and to create space for answering any questions that might come up.
+- Create a 1-1 doc and add initial discussion items
+   - Onboarding doc - YAYYYYYYY WELCOME!!!!! 🎉
+      - Your onboarding doc is to help outline the projects and tasks you have over your first 30 days.
+      - This 1:1 doc will be where we take notes on discussions, set goals, and make sure you’re on track.
+   - Weekly 1:1 - do you have a preference of time/day of the week?
+   - 1-1 meetings - what format do you like? What is most helpful to you for these meetings?
+   - How do you like to receive feedback?
 
 ## Week 1 - Getting started
 
@@ -26,7 +35,7 @@ Remember:
    - If you see a "request permission" page for some doc or other resource, it is a mistake. Just ask to be granted access to it (and make a PR to update the handbook so the next person starting is granted access to that system).
 - Unlike at many companies, it is OK (and important) to call out when we did something poorly or when something doesn't go well (e.g., a sales pitch falls flat). That helps us be real and do it better in the future.
 
-**[Onboarding buddy](https://about.sourcegraph.com/handbook/people-ops/buddy-program)**: You will be paired up with an “onboarding buddy” in order to become better acquainted with Sourcegraph team and culture. A buddy will be your go-to person for questions (in addition to your manager and the People Ops team).
+### Day 1
 
 - Complete [general onboarding](../../people-ops/onboarding/index.md#for-all-new-teammates)
    - Keep the [guiding principles](../../engineering/onboarding.md#guiding-principles) from the general onboarding page in mind - we are here to support you and you should act like an owner!


### PR DESCRIPTION
This change reflects the format of the Google doc I typically create for new team members on the product team. This moves the "template" to the handbook and is intended to be copied into a customized doc for each new hire.