### PR TITLE
Add working with Figma presentation link

### DIFF
--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -85,6 +85,7 @@ There will be plenty for you to read and learn about when you're not working on 
 - Read through the rest of the engineering handbook to learn more about how we operate.
 - Read how we choose and continually update our [goals](../../company/goals/index.md).
 - Read how we plan and keep each other up to date with [tracking issues](./tracking_issues.md).
+- Frontend engineers should watch [Figma for Sourcegraphers](https://drive.google.com/file/d/1zzUKDJN5XUwvKF8LfKZqQb7gK9NpK1Wx/view?usp=sharing) to learn about how design and engineering work together 
 
 ## Weeks 4-6
 


### PR DESCRIPTION
Adding a link to a presentation to help new users use Figma and understand how the design team preps files for engineering.