### PR TITLE
Check off the first of the campaigns goals

### DIFF
--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -43,7 +43,9 @@ Users provide the code to make the change, we provide the plumbing to turn it in
 
 The short-term goal and primary focus of the team is to *deliver campaigns to all users*. Our milestones toward that goal:
 
-1. Someone on the Campaigns team makes one meaningful change to at least two repositories.
+1. ~Someone on the Campaigns team makes one meaningful change to at least two repositories.~
+   - First change: https://github.com/sourcegraph/sourcegraph/pull/13811
+   - Second change: https://github.com/sourcegraph/src-cli/pull/311
 1. A Sourcegraph engineer (not on this team) makes one meaningful change to at least two repositories.
 1. ~~Reach out to one customer, summarizing the changes in the new Campaigns workflow, to give them a heads-up.~~ **Done!**
 1. ~~After we hear from that customer, we reach out to two other customers, as in previous step.~~ **Done!**

--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -43,7 +43,7 @@ Users provide the code to make the change, we provide the plumbing to turn it in
 
 The short-term goal and primary focus of the team is to *deliver campaigns to all users*. Our milestones toward that goal:
 
-1. ~Someone on the Campaigns team makes one meaningful change to at least two repositories.~
+1. ~~Someone on the Campaigns team makes one meaningful change to at least two repositories.~~ **Done!**
    - First change: https://github.com/sourcegraph/sourcegraph/pull/13811
    - Second change: https://github.com/sourcegraph/src-cli/pull/311
 1. A Sourcegraph engineer (not on this team) makes one meaningful change to at least two repositories.


### PR DESCRIPTION
I think these can now be checked off. Yes, technically it wasn't a single engineer that made a change in two repositories, but since we do have something like a mono repo, that is not _that_ easy.

---

~What about the other goals? We did reach out to customers through https://github.com/sourcegraph/customer/issues/92 so how to we reflect those results in here?~