### PR TITLE
Fine-tune typography on blog posts

### DIFF
--- a/blogposts/2020/optimizing-a-code-intelligence-indexer.md
+++ b/blogposts/2020/optimizing-a-code-intelligence-indexer.md
@@ -15,7 +15,11 @@ We (Sourcegraph's [code intelligence team](https://about.sourcegraph.com/handboo
 
 Developers use [Sourcegraph](https://about.sourcegraph.com) for code search and navigation. When you're navigating code on Sourcegraph, you get hovers, definitions, and references to help you along the way. They're fast and cross-repository, can work on any branch or commit, and can be precise (with [LSIF](https://lsif.dev) set up in CI).
 
-[![Cross-repository jump to definition](https://sourcegraphstatic.com/precise-xrepo-j2d.gif)](https://sourcegraph.com/github.com/gorilla/mux/-/blob/route.go)
+<div>
+  <a href="https://sourcegraph.com/github.com/gorilla/mux/-/blob/route.go"  target="_blank">
+    <img src="https://sourcegraphstatic.com/precise-xrepo-j2d.gif" alt="Cross-repository jump to definition">
+  </a>
+</div>
 
 ## The problem: really big monorepos
 
@@ -53,15 +57,13 @@ Here's how we did it.
 
 We think the major inefficiency of the previous version of lsif-go is best illustrated by a likely familiar, but incredibly relevant, story by [Joel Spolsky](https://www.joelonsoftware.com/2001/12/11/back-to-basics/) about a simple worker named Shlemiel.
 
-<blockquote>
-  Shlemiel gets a job as a street painter, painting the dotted lines down the middle of the road. On the first day he takes a can of paint out to the road and finishes 300 yards of the road. "That’s pretty good!" says his boss, "you’re a fast worker!" and pays him a kopeck.
-  <br /><br />
-  The next day Shlemiel only gets 150 yards done. "Well, that’s not nearly as good as yesterday, but you’re still a fast worker. 150 yards is respectable," and pays him a kopeck.
-  <br /> <br />
-  The next day Shlemiel paints 30 yards of the road. "Only 30!" shouts his boss. "That’s unacceptable! On the first day you did ten times that much work! What’s going on?"
-  <br /><br />
-  "I can’t help it," says Shlemiel. "Every day I get farther and farther away from the paint can!"
-</blockquote>
+>Shlemiel gets a job as a street painter, painting the dotted lines down the middle of the road. On the first day he takes a can of paint out to the road and finishes 300 yards of the road. "That’s pretty good!" says his boss, "you’re a fast worker!" and pays him a kopeck.
+>
+>The next day Shlemiel only gets 150 yards done. "Well, that’s not nearly as good as yesterday, but you’re still a fast worker. 150 yards is respectable," and pays him a kopeck.
+>
+>The next day Shlemiel paints 30 yards of the road. "Only 30!" shouts his boss. "That’s unacceptable! On the first day you did ten times that much work! What’s going on?"
+>
+>"I can’t help it," says Shlemiel. "Every day I get farther and farther away from the paint can!"
 
 Shlemiel and lsif-go both spent a lot of time needlessly re-executing the same operations in a way that did not help progress the task. Because an operation of non-constant cost was snuck into the lower levels of the process - into a method that was itself called a non-constant number of times - they both found themselves in a process that is [accidentally quadratic](https://accidentallyquadratic.tumblr.com/).
 

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -51,6 +51,7 @@ module.exports = {
           `gatsby-remark-prismjs`,
           `gatsby-remark-autolink-headers`,
           `gatsby-remark-copy-linked-files`,
+          `gatsby-remark-unwrap-images`,
           {
             resolve: `gatsby-remark-images`,
             options: {

--- a/website/package.json
+++ b/website/package.json
@@ -24,6 +24,7 @@
     "gatsby-remark-images": "^3.3.29",
     "gatsby-remark-prismjs": "^3.5.11",
     "gatsby-remark-responsive-image": "^1.0.0-beta.5-alpha.fb30fcd6",
+    "gatsby-remark-unwrap-images": "^1.0.2",
     "gatsby-source-filesystem": "^2.3.29",
     "gatsby-transformer-json": "^2.4.11",
     "gatsby-transformer-remark": "^2.8.34",

--- a/website/src/components/blog/PodcastPost.tsx
+++ b/website/src/components/blog/PodcastPost.tsx
@@ -31,11 +31,11 @@ export const PodcastPost: React.FunctionComponent<Props> = ({
                 {guestsHTML && <p className="text-muted mb-0" dangerouslySetInnerHTML={{ __html: guestsHTML }}></p>}
             </header>
             {summaryHTML && (
-                <div className="card-body podcast-post__body pt-0" dangerouslySetInnerHTML={{ __html: summaryHTML }} />
+                <div className="card-body podcast-post__body pt-0 pb-0" dangerouslySetInnerHTML={{ __html: summaryHTML }} />
             )}
-            <div className="card-body border-top d-flex flex-wrap align-items-center">
+            <div className="card-body">
                 {audioHTML && (
-                    <div className="podcast-post__body mr-3" dangerouslySetInnerHTML={{ __html: audioHTML }} />
+                    <div className="podcast-post__body audio-container" dangerouslySetInnerHTML={{ __html: audioHTML }} />
                 )}
 
                 <div className="flex-1" />

--- a/website/src/css/components/blog/_BlogPost.scss
+++ b/website/src/css/components/blog/_BlogPost.scss
@@ -1,5 +1,6 @@
 .blog-post {
     overflow: hidden;
+    padding-bottom: 2rem;
 
     &__image {
         max-width: 100%;
@@ -21,9 +22,29 @@
             max-width: calc(100% - 10px);
             max-height: 100vh;
             box-shadow: 0 2px 18px 0 #0000001a, 0 6px 20px 0 #00000017;
-            margin: 40px auto;
+            margin: 3rem auto;
             display: block;
             border-style: none;
+        }
+
+        .gatsby-highlight {
+            margin: 3rem auto;
+        }
+
+        table,
+        video-embed,
+        .gatsby-highlight {
+            margin: 3rem auto;
+        }
+
+        blockquote {
+            max-width: 100%;
+            width: 40rem;
+            line-height: 1.8;
+            margin-left: auto;
+            margin-right: auto;
+            padding-left: 2rem;
+            padding-right: 0;
         }
     }
 }

--- a/website/src/css/components/blog/_BlogPost.scss
+++ b/website/src/css/components/blog/_BlogPost.scss
@@ -27,24 +27,11 @@
             border-style: none;
         }
 
-        .gatsby-highlight {
-            margin: 3rem auto;
-        }
-
         table,
         video-embed,
         .gatsby-highlight {
             margin: 3rem auto;
         }
 
-        blockquote {
-            max-width: 100%;
-            width: 40rem;
-            line-height: 1.8;
-            margin-left: auto;
-            margin-right: auto;
-            padding-left: 2rem;
-            padding-right: 0;
-        }
     }
 }

--- a/website/src/css/components/blog/_PodcastPost.scss
+++ b/website/src/css/components/blog/_PodcastPost.scss
@@ -4,4 +4,19 @@
             margin-bottom: 0;
         }
     }
+
+    .audio-container {
+        width: 40rem;
+        max-width: 100%;
+        margin: 2rem auto;
+
+        audio {
+            width: 100%;
+        }
+
+        p {
+            margin: 0;
+            display: flex;
+        }
+    }
 }

--- a/website/src/css/pages/_podcast.scss
+++ b/website/src/css/pages/_podcast.scss
@@ -112,7 +112,7 @@
     }
 
     &__player {
-        margin: 2em auto 2em auto;
+        margin: 3em auto;
         audio {
             filter: saturate(100%) invert(90%);
         }

--- a/website/src/css/templates/_PostTemplate.scss
+++ b/website/src/css/templates/_PostTemplate.scss
@@ -1,14 +1,66 @@
 .post-template {
     &__post {
         h1 {
-            font-size: 2rem;
+            font-size: 2.25rem;
+            margin-bottom: .75rem;
         }
+
         min-height: 60vh;
 
         &-title {
             &-link {
                 color: $body-color;
             }
+        }
+
+        p,
+        h2,
+        h3,
+        h4,
+        h5,
+        ul,
+        ol,
+        blockquote {
+            max-width: 100%;
+            width: 40rem;
+            margin-left: auto;
+            margin-right: auto;
+        }
+
+        p {
+            line-height: 1.8;
+            margin-bottom: 1.25rem;
+        }
+
+        h2 {
+            font-size: 1.5rem;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+        }
+
+        h3 {
+            font-size: 1.25rem;
+            margin-top: 2rem;
+            margin-bottom: 1rem;
+        }
+
+        ul, ol {
+            line-height: 1.8;
+            padding-left: 0;
+
+            li {
+                margin-left: 1rem;
+                padding-left: .5rem;
+                margin-bottom: .5rem;
+            }
+        }
+
+        blockquote {
+            line-height: 1.8;
+            padding-left: 2rem;
+            padding-right: 0;
+            margin-top: 3rem;
+            margin-bottom: 3rem;
         }
     }
 }


### PR DESCRIPTION
This is a quick set of improvements to typography and spacing for the blog posts. Changes only target the blog posts themselves. This will make our blog posts more readable for all users.

`gatsby-remark-images` has a nasty habit of wrapping `<img>` elements in `<p>` tags, which causes trouble with having a narrower paragraph elements without affecting the images. I've added `gatsby-remark-unwrap-images` to the `gatsby-config.js` to avoid this. As far as I can tell, this only affects the blog posts, which is what we want.

I've also made a couple of tiny formatting tweaks to @efritz 's latest blog post to un-hacky-workaround the `blockquote` formatting and make the linked image render properly. I checked through a handful of older blog posts and confirmed nothing appears broken.