### PR TITLE
deployments: update k8s.sgdev.org, refresh other documentation

### DIFF
--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -104,9 +104,9 @@ This deployment runs the single-image version of Sourcegraph. It does not have a
 🚨 This deployment contains private code - do not use it for demos!
 
 - [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfood?project=sourcegraph-dev)
- ```
- gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
- ```
+  ```
+  gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
+  ```
 - [Kubernetes configuration](https://github.com/sourcegraph/infrastructure/tree/master/kubernetes/dogfood)
 
 ## Kubernetes

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -2,9 +2,9 @@
 
 We maintain multiple [deployments](#deployment-basics) of Sourcegraph:
 
-- [sourcegraph.com](#sourcegraphcom) is our production deployment for open source code.
-- [sourcegraph.sgdev.org](#sourcegraphsgdevorg) is our private deployment of Sourcegraph that contains our private code.
-- [k8s.sgdev.org](#k8ssgdevorg) is a dogfood deployment that replicates the scale of our largest customers.
+- [sourcegraph.com](#sourcegraph-com) is our production deployment for open source code.
+- [sourcegraph.sgdev.org](#sourcegraph-sgdev-org) is our private deployment of Sourcegraph that contains our private code.
+- [k8s.sgdev.org](#k8s-sgdev-org) is a dogfood deployment that replicates the scale of our largest customers.
 
 Also on this page:
 
@@ -18,9 +18,9 @@ Changes to `sourcegraph/sourcegraph` are automatically built as [images](#images
 
 * Automatically updated in [`deploy-sourcegraph`](#deploy-sourcegraph) via [Renovate](#renovate), which runs deployment checks on the new images and merges the changes.
   * `sourcegraph-bot` will mention your pull request in the `deploy-sourcegraph` change - you will be able to find a link in your pull request.
-* `deploy-sourcegraph` changes are [automatically deployed in k8s.sgdev.org](#k8ssgdevorg), our Kubernetes dogfooding environment.
+* `deploy-sourcegraph` changes are [automatically deployed in k8s.sgdev.org](#k8s-sgdev-org), our Kubernetes dogfooding environment.
   * `sourcegraph-bot` will mention the relevant `deploy-sourcegraph` pull request in the `deploy-sourcegraph-dogfood-k8s-2` change.
-* [Sourcegraph Cloud](#sourcegraphcom) will eventually pick up the same changes on a schedule via [Renovate](#renovate)
+* [Sourcegraph Cloud](#sourcegraph-com) will eventually pick up the same changes on a schedule via [Renovate](#renovate)
 
 ### Images
 
@@ -111,7 +111,7 @@ This deployment runs the single-image version of Sourcegraph. It does not have a
 
 ## Kubernetes
 
-This section contains tips and advice for interacting with our Kubernetes deployments (most notably [sourcegraph.com](#sourcegraphcom) and [k8s.sgdev.org](#k8ssgdevorg)).
+This section contains tips and advice for interacting with our Kubernetes deployments (most notably [sourcegraph.com](#sourcegraph-com) and [k8s.sgdev.org](#k8s-sgdev-org)).
 
 ### How to set up access to Kubernetes
 
@@ -398,7 +398,7 @@ Sourcegraph Kubernetes deployments typically start off as [deploy-sourcegraph](h
 There is automation in place to drive automatic updates for certain deployments from `deploy-sourcegraph`:
 
 * the ["Renovate downstream"](https://github.com/sourcegraph/sourcegraph/actions?query=workflow%3A%22Renovate+downstream%22) workflow performs a manual [Renovate run](#renovate) on `deploy-sourcegraph` as soon as [Sourcegraph images are published](#images).
-* the ["Dispatch Update"](https://github.com/sourcegraph/deploy-sourcegraph/actions?query=workflow%3A%22Dispatch+update%22) workflow notifies deployments like [k8s.sgdev.org](#k8ssgdevorg) to perform a merge from `deploy-sourcegraph`.
+* the ["Dispatch Update"](https://github.com/sourcegraph/deploy-sourcegraph/actions?query=workflow%3A%22Dispatch+update%22) workflow notifies deployments like [k8s.sgdev.org](#k8s-sgdev-org) to perform a merge from `deploy-sourcegraph`.
 
 For documentation about developing `deploy-sourcegraph` and cutting releases, refer to the [repository's `README.dev.md`](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/README.dev.md).
 
@@ -410,7 +410,7 @@ We have two Sourcegraph Kubernetes cluster installations that we manage ourselve
 * [deploy-sourcegraph-dogfood-k8s-2](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2)
 
 This section describes how to merge changes from [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) 
-(referred to as upstream) into `deploy-sourceegraph-dot-com`. The `deploy-sourcegraph-dogfood-k8s-2` configuration is [automatically updated with the latest `deploy-sourcegraph` changes](#k8ssgdevorg).
+(referred to as upstream) into `deploy-sourceegraph-dot-com`. The `deploy-sourcegraph-dogfood-k8s-2` configuration is [automatically updated with the latest `deploy-sourcegraph` changes](#k8s-sgdev-org).
 
 The process is similar to the [process](https://docs.sourcegraph.com/admin/install/kubernetes/configure#fork-this-repository) 
 we recommend our customers use to merge changes from upstream. The differences in process originate from the dual purpose
@@ -431,7 +431,7 @@ These steps ensure that the diff between [deploy-sourcegraph-dot-com](https://gi
 In order to mimic the same workflow that we tell our customers to follow:
 
 - Customizations / documentation changes that **apply to all customers (not just sourcegraph.com)** should be:
-    1. Merged into [`deploy-sourcegraph@master`](https://github.com/sourcegraph/deploy-sourcegraph/tree/master) (note that this will also [automatically update k8s.sgdev.org](#k8ssgdevorg))
+    1. Merged into [`deploy-sourcegraph@master`](https://github.com/sourcegraph/deploy-sourcegraph/tree/master) (note that this will also [automatically update k8s.sgdev.org](#k8s-sgdev-org))
     1. Pulled into [`deploy-sourcegraph-dot-com@master`](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/tree/master):
           ```shell
           git checkout master

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -30,13 +30,17 @@ For pushing custom images, refer to [building Docker images for specific branche
 
 ### Renovate
 
-Renovate is a tool for updating dependencies. [`deploy-sourcegraph-*`](#deploy-sourcegraph) repositories with Renovate configured check for updated Docker images about every hour. If it finds new Docker images then it opens and merges a PR ([Sourcegraph.com example](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Aapp%2Frenovate)) to update the image tags in the deployment configuration. This is usually accompanied by a CI job that deploys the updated images to the appropriate deployment.'
+Renovate is a tool for updating dependencies. [`deploy-sourcegraph-*`](#deploy-sourcegraph) repositories with Renovate configured check for updated Docker images about every hour. If it finds new Docker images then it opens and merges a PR ([Sourcegraph.com example](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Aapp%2Frenovate)) to update the image tags in the deployment configuration. This is usually accompanied by a CI job that deploys the updated images to the appropriate deployment.
+
+### Infrastructure
+
+The cloud resources (including clusters, DNS configuration, etc.) on which are deployments run should be configured in the [infrastructure repository](https://github.com/sourcegraph/infrastructure), even though Kubernetes deployments are managed by various `deploy-sourcegraph-*` repositories.
 
 ## sourcegraph.com
 
 [![Build status](https://badge.buildkite.com/ef1289610fdd05b606bf1e57a034af2365c7b09c95ac6121f9.svg)](https://buildkite.com/sourcegraph/deploy-sourcegraph-dot-com)
 
-This deployment is also colloquially referred to as "Sourcegraph Cloud", "Cloud", and "dot-com".
+This deployment is also colloquially referred to as "Sourcegraph Cloud", "Cloud", and "dot-com". It is the public deployment available to the public at [sourcegraph.com/search](https://sourcegraph.com/search).
 
 - [dot-com cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-f/cloud?project=sourcegraph-dev)
   ```
@@ -72,30 +76,16 @@ git push origin release
 
 [Buildkite](https://buildkite.com/sourcegraph/deploy-sourcegraph-dot-com/) will deploy the working commit to sourcegraph.com.
 
-🚨You also need to disable auto-deploys to prevent Renovate from automatically merging in image digest updates so that the site doesn't roll-forward.
+🚨 You also need to disable auto-deploys to prevent Renovate from automatically merging in image digest updates so that the site doesn't roll-forward.
 
   1. Go to [renovate.json](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/renovate.json) and remove the `"extends:["default:automergeDigest"]` entry for the "Sourcegraph Docker images" group ([example](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/commit/0eb16fd9e3ddfcf3a3c75ccdda0e7eddabf19c7a)).
   1. Once you have fixed the issue in the `master` branch of [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph), re-enable auto-deploys by reverting your change to [renovate.json](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/renovate.json) from step 1.
-
-## sourcegraph.sgdev.org
-
-[![Build status](https://badge.buildkite.com/aea3b210380714ff4e0c5429beae87bb318e7fd53603acdecf.svg)](https://buildkite.com/sourcegraph/infrastructure)
-
-This deployment runs the single-image version of Sourcegraph. It is deployed by the [infrastructure repository](https://github.com/sourcegraph/infrastructure).
-
-🚨 This deployment contains private code - do not use it for demos!
-
-- [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfood?project=sourcegraph-dev)
- ```
- gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
- ```
-- [Kubernetes configuration](https://github.com/sourcegraph/infrastructure/tree/master/kubernetes/dogfood)
 
 ## k8s.sgdev.org
 
 [![Build status](https://badge.buildkite.com/65c9b6f836db6d041ea29b05e7310ebb81fa36741c78f207ce.svg?branch=release)](https://buildkite.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2)
 
-This deployment dogfoods the latest changes in [`deploy-sourcegraph`](https://github.com/sourcegraph/deploy-sourcegraph), and by extension, `sourcegraph/sourcegraph`, via automated updates - learn more in [deployment basics](#deployment-basics).
+This deployment is also colloquially referred to as "dogfood", "dogfood-k8s", or just "k8s". It deploys the latest changes in [`deploy-sourcegraph`](https://github.com/sourcegraph/deploy-sourcegraph), and by extension, `sourcegraph/sourcegraph`, via automated updates - learn more in [deployment basics](#deployment-basics).
 
 - [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-f/dogfood?project=sourcegraph-dogfood)
   ```
@@ -104,6 +94,20 @@ This deployment dogfoods the latest changes in [`deploy-sourcegraph`](https://gi
 - [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2)
 
 Updates from `deploy-sourcegraph` are performed upon [notification from upstream](#deploy-sourcegraph) by the ["Update from deploy-sourcegraph"](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/actions?query=workflow%3A%22Update+from+deploy-sourcegraph%22) workflow.
+
+## sourcegraph.sgdev.org
+
+[![Build status](https://badge.buildkite.com/aea3b210380714ff4e0c5429beae87bb318e7fd53603acdecf.svg)](https://buildkite.com/sourcegraph/infrastructure)
+
+This deployment runs the single-image version of Sourcegraph. It does not have a separate deployment configuration repository, and is deployed by the [infrastructure repository](https://github.com/sourcegraph/infrastructure).
+
+🚨 This deployment contains private code - do not use it for demos!
+
+- [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-a/dogfood?project=sourcegraph-dev)
+ ```
+ gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
+ ```
+- [Kubernetes configuration](https://github.com/sourcegraph/infrastructure/tree/master/kubernetes/dogfood)
 
 ## Kubernetes
 

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -230,7 +230,7 @@ For more informatino see the [GKE documentation](https://cloud.google.com/kubern
 
 ### Kubernetes backups
 
-Snapshots of all Kubernetes resources are taken periodically and pushed to https://github.com/sourcegraph/kube-backup/.
+Snapshots of all Kubernetes resources are taken periodically and pushed to [kube-backup](https://github.com/sourcegraph/kube-backup).
  
 ## Testing
 
@@ -420,7 +420,7 @@ and the docker images are automatically updated to the latest builds.
 1. [`deploy-sourcegraph-dot-com@release`](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/tree/release) _only_ contains the customizations required to deploy/document sourcegraph.com from the base deployment of Sourcegraph. 
    - This is the default branch for this repository, since all customizations to sourcegraph.com should be merged into this branch (like we tell our customers to).
 
-These steps ensure that the diff between https://github.com/sourcegraph/deploy-sourcegraph-dot-com and https://github.com/sourcegraph/deploy-sourcegraph is as small as possible so that the changes are easy to review.  
+These steps ensure that the diff between [deploy-sourcegraph-dot-com](https://github.com/sourcegraph/deploy-sourcegraph-dot-com) and [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) is as small as possible so that the changes are easy to review.  
 
 In order to mimic the same workflow that we tell our customers to follow:
 

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -34,7 +34,7 @@ Renovate is a tool for updating dependencies. [`deploy-sourcegraph-*`](#deploy-s
 
 ### Infrastructure
 
-The cloud resources (including clusters, DNS configuration, etc.) on which are deployments run should be configured in the [infrastructure repository](https://github.com/sourcegraph/infrastructure), even though Kubernetes deployments are managed by various `deploy-sourcegraph-*` repositories.
+The cloud resources (including clusters, DNS configuration, etc.) on which are deployments run should be configured in the [infrastructure repository](https://github.com/sourcegraph/infrastructure), even though Kubernetes deployments are managed by various `deploy-sourcegraph-*` repositories. For information about how our infrastructure is organized, refer to [Environments](./environments.md).
 
 ## sourcegraph.com
 

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -93,6 +93,7 @@ This deployment is also colloquially referred to as "dogfood", "dogfood-k8s", or
   gcloud container clusters get-credentials dogfood --zone us-central1-f --project sourcegraph-dogfood
   ```
 - [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2)
+- [Infrastructure configuration](https://github.com/sourcegraph/infrastructure/tree/master/dogfood)
 
 Updates from `deploy-sourcegraph` are performed upon [notification from upstream](#deploy-sourcegraph) by the ["Update from deploy-sourcegraph"](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/actions?query=workflow%3A%22Update+from+deploy-sourcegraph%22) workflow.
 
@@ -109,7 +110,6 @@ This deployment runs the single-image version of Sourcegraph. It does not have a
   gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
   ```
 - [Kubernetes configuration](https://github.com/sourcegraph/infrastructure/tree/master/kubernetes/dogfood)
-- [Infrastructure configuration](https://github.com/sourcegraph/infrastructure/tree/master/dogfood)
 
 ## Kubernetes
 

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -391,7 +391,7 @@ And the end of the build you can find the name of the newly built Docker image.
 
 ## deploy-sourcegraph
 
-![Renovate downstream](https://github.com/sourcegraph/sourcegraph/workflows/Renovate%20downstream/badge.svg) ![Dispatch update](https://github.com/sourcegraph/deploy-sourcegraph/workflows/Dispatch%20update/badge.svg)
+![Renovate downstream](https://github.com/sourcegraph/sourcegraph/workflows/Renovate%20downstream/badge.svg) [![master build status](https://badge.buildkite.com/018ed23ed79d7297e7dd109b745597c58d875323fb06e81786.svg?branch=master)](https://buildkite.com/sourcegraph/deploy-sourcegraph) ![Dispatch update](https://github.com/sourcegraph/deploy-sourcegraph/workflows/Dispatch%20update/badge.svg)
 
 Sourcegraph Kubernetes deployments typically start off as [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) forks. Learn more about how we advise customers to deploy Sourcegraph in Kubernetes in our [admin installation documentation](https://docs.sourcegraph.com/admin/install/kubernetes).
 
@@ -399,6 +399,8 @@ There is automation in place to drive automatic updates for certain deployments 
 
 * the ["Renovate downstream"](https://github.com/sourcegraph/sourcegraph/actions?query=workflow%3A%22Renovate+downstream%22) workflow performs a manual [Renovate run](#renovate) on `deploy-sourcegraph` as soon as [Sourcegraph images are published](#images).
 * the ["Dispatch Update"](https://github.com/sourcegraph/deploy-sourcegraph/actions?query=workflow%3A%22Dispatch+update%22) workflow notifies deployments like [k8s.sgdev.org](#k8ssgdevorg) to perform a merge from `deploy-sourcegraph`.
+
+For documentation about developing `deploy-sourcegraph` and cutting releases, refer to the [repository's `README.dev.md`](https://github.com/sourcegraph/deploy-sourcegraph/blob/master/README.dev.md).
 
 ### Merging changes from [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) 
 

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -47,6 +47,7 @@ This deployment is also colloquially referred to as "Sourcegraph Cloud", "Cloud"
   gcloud container clusters get-credentials cloud --zone us-central1-f --project sourcegraph-dev
   ```
 - [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dot-com)
+- [Infrastructure configuration](https://github.com/sourcegraph/infrastructure/tree/master/cloud)
 
 ### Deploying to sourcegraph.com
 
@@ -108,6 +109,7 @@ This deployment runs the single-image version of Sourcegraph. It does not have a
   gcloud container clusters get-credentials dogfood --zone us-central1-a --project sourcegraph-dev
   ```
 - [Kubernetes configuration](https://github.com/sourcegraph/infrastructure/tree/master/kubernetes/dogfood)
+- [Infrastructure configuration](https://github.com/sourcegraph/infrastructure/tree/master/dogfood)
 
 ## Kubernetes
 

--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -16,11 +16,11 @@ Also on this page:
 
 Changes to `sourcegraph/sourcegraph` are automatically built as [images](#images), which are then:
 
-* Automatically updated in [`deploy-sourcegraph`](#deploy-sourcegraph), which runs deployment checks on the new images and merges the changes.
+* Automatically updated in [`deploy-sourcegraph`](#deploy-sourcegraph) via [Renovate](#renovate), which runs deployment checks on the new images and merges the changes.
   * `sourcegraph-bot` will mention your pull request in the `deploy-sourcegraph` change - you will be able to find a link in your pull request.
-* `deploy-sourcegraph` changes are automatically deployed in [k8s.sgdev.org](#k8ssgdevorg), our full dogfooding environment.
+* `deploy-sourcegraph` changes are [automatically deployed in k8s.sgdev.org](#k8ssgdevorg), our Kubernetes dogfooding environment.
   * `sourcegraph-bot` will mention the relevant `deploy-sourcegraph` pull request in the `deploy-sourcegraph-dogfood-k8s-2` change.
-* [Sourcegraph Cloud](#sourcegraphcom) will eventually pick up the same changes on a schedule.
+* [Sourcegraph Cloud](#sourcegraphcom) will eventually pick up the same changes on a schedule via [Renovate](#renovate)
 
 ### Images
 


### PR DESCRIPTION
Refreshes deployment documentation as part of https://github.com/sourcegraph/sourcegraph/issues/13792 (https://github.com/orgs/sourcegraph/projects/83)

**Rendered: https://github.com/sourcegraph/about/blob/update-k8s-documentation/handbook/engineering/deployments.md**