### PR TITLE
onboarding: ask for invite to Percy and Chromatic

### DIFF
--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -31,6 +31,7 @@ Your manager should complete the following steps when you join:
   - [HoneyComb.io](https://www.honeycomb.io/)
   - Ask Christina to send an invite to [Productboard](https://sourcegraph.productboard.com)
   - Ask a member of the Design team to invite as "Viewer" to [Figma](https://figma.com)
+  - Ask a frontend engineer to invite you to [Percy](https://percy.io/) (optional; recommended for frontend engineers)
 
 ## Weeks 1-3
 

--- a/handbook/engineering/onboarding.md
+++ b/handbook/engineering/onboarding.md
@@ -32,6 +32,7 @@ Your manager should complete the following steps when you join:
   - Ask Christina to send an invite to [Productboard](https://sourcegraph.productboard.com)
   - Ask a member of the Design team to invite as "Viewer" to [Figma](https://figma.com)
   - Ask a frontend engineer to invite you to [Percy](https://percy.io/) (optional; recommended for frontend engineers)
+  - Ask a frontend engineer to invite you to [Chromatic](https://www.chromatic.com/) (optional; recommended for frontend engineers)
 
 ## Weeks 1-3
 


### PR DESCRIPTION
Question: what do we call software engineers who work on the frontend?  Common titles: frontend developer, web developer, frontend engineer, software engineer - frontend. We use "software engineer - frontend" on the hiring page, but that wouldn't sound right here ("Ask a software engineer - frontend").

Edit: Added Chromatic as well