### PR TITLE
trying an experiment with adding my goals to my handbook page

### DIFF
--- a/company/team/index.md
+++ b/company/team/index.md
@@ -417,7 +417,7 @@ To add yourself to this page, copy the following template, paste it at the end o
 
 ## Joel Kwartler (he/him)
 
-- Product Manager
+- Product Manager ([Current Goals](https://docs.google.com/document/d/1W9XAQ7eEu4GcuDgFFqhAhmbq8VmkATh4gzfS_dBxoyc))
 - Los Angeles, CA, USA 🇺🇸
 - Name pronunciation: [ʤoʊl kwɔrtlɜr](http://ipa-reader.xyz/?text=%CA%A4o%CA%8Al%20kw%C9%94rtl%C9%9Cr&voice=Joey)
 - [joel@sourcegraph.com](mailto:joel@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/joelkwartler), [Github](https://github.com/Joelkw)


### PR DESCRIPTION
Since I spent some time my first week documenting goals for myself, I think it makes sense to share these so people can check what I'm working on if they ever have questions for me, are able to help, or are wondering why I'm asking about something. It'll also help set expectations around the web/code insights split I'll be doing.

We seem to list goals in public places, so I converted any private info (hubspot links) and have a link added to my team page. I'm also putting a short link in my slack bio since there's not (and no need for) a habit of people going to the team page for info about you personally. Open to thoughts if this is the right place!

I'm not sure how often it makes sense to update these, or at what level of detail – I'll see how/if they get used first. 