### PR TITLE
Formalizing a process for joining customer calls

### DIFF
--- a/handbook/ce/onboarding.md
+++ b/handbook/ce/onboarding.md
@@ -14,7 +14,7 @@ Welcome to Sourcegraph! This document will guide you through customer engineerin
   - [Looker](https://sourcegraph.looker.com/dashboards/94?Unique%20Server%20ID=&Site%20ID=&filter_config=%7B%22Unique%20Server%20ID%22:%5B%7B%22type%22:%22%3D%22,%22values%22:%5B%7B%22constant%22:%22%22%7D,%7B%7D%5D,%22id%22:2%7D%5D,%22Site%20ID%22:%5B%7B%22type%22:%22%3D%22,%22values%22:%5B%7B%22constant%22:%22%22%7D,%7B%7D%5D,%22id%22:3%7D%5D%7D)
   - Familiarize yourself with the [Weekly CE Sync Notes](https://docs.google.com/document/d/1c40u7Bh2vPIAHcz8qS_qLOt310MfjrGeHN5-W45nh4U/edit) and format 
     - Updates to be provided in order of priority 
-- Look at AE/CE calendars and join as many customer calls as possible 
+- [Join as many customer calls as possible](../sales/onboarding/joining_customer_calls.md)
   - Collect questions along the way (unfamiliar terms, use cases, etc.)
 - Watch [Dan's recorded demo](https://drive.google.com/file/d/1VUZ0rnZQpNgjtGDI0tMC-h-OtL0Czz8H/view?usp=sharing) 
 - Schedule a demo from the most recent CE hire before you

--- a/handbook/product/onboarding/index.md
+++ b/handbook/product/onboarding/index.md
@@ -69,7 +69,7 @@ Remember:
 
 ### Get to know our customers
 
-- Reach out to the Sales/CE teams and ask to be added to as many customer calls as you can in your first few weeks.
+- [Join as many customer calls as you can](../../sales/onboarding/joining_customer_calls.md) in your first few weeks.
 - Familiarize yourself with customer feedback channels
    - [HubSpot](https://app.hubspot.com/forms/2762526/a86bbac5-576d-4ca0-86c1-0c60837c3eab/submissions) surveys
    - [Productboard](https://sourcegraph.productboard.com/insights/shared-inbox)

--- a/handbook/sales/index.md
+++ b/handbook/sales/index.md
@@ -31,6 +31,8 @@ See [roles](./roles/index.md) page.
 - [How to request support (for customers)](../ce/support.md#how-to-get-support-for-customers)
 - [Creating and maintaining license keys for customers](../ce/license_keys.md)
 
+### [Team members who want to join calls](onboarding/joining_customer_calls.md)
+
 ## Definitions
 
 ### ARR

--- a/handbook/sales/onboarding/index.md
+++ b/handbook/sales/onboarding/index.md
@@ -7,8 +7,7 @@ See also [Sales onboarding logistics](https://docs.google.com/document/d/1un9fFP
 ## Week 1
 
 - Get familiar with the internal tools we use
-- Join all customer calls during this period that you can
-  - Watch the calendars of other sales team members and ask if you can add yourself (or be added) to each customer call
+- [Join all customer calls](joining_customer_calls.md) during this period that you can
 - Checkpoints
   - Pass a [quiz](quiz.md)
   - Deliver compelling 30-second pitches for the following [personas](../../marketing/personas.md):

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -10,7 +10,7 @@ While calendar events won't have one of these exact lables, knowing the types of
 1. **Installations or technical check-ins:** to walk through setting up Sourcegraph with a technical point of contact. These can be useful for learning what types of technical blockers users and admins encounter, and how we help solve them.
 1. **Trial check-in:** to discuss how things are going during a trial. These are often recurring weekly, and can be quite informal. These can be useful for getting a snapshot of a deal process, or to hear mid-flight product or process feedback.
 1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A." These can be useful for understanding how we help new end users understand Sourcegraph's value, and what sorts of questions new users ask."
-1. **Existing customer check-in:** to hear how things might be improved or learn about exciting ways a customer is using Sourcegraph. 
+1. **Existing customer check-in:** to hear how things might be improved or learn about exciting ways a customer is using Sourcegraph. These can vary significantly, so it can be worthwhile to check in with the team to understand context in advance.
 
 ## How to join calls to listen
 

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -9,7 +9,7 @@ While calendar events won't have one of these exact lables, knowing the types of
 1. **New prospect:** the first call with a prospect, who may not know much about Sourcegraph. Often named "Intro Call." These can be useful for understanding how we communicate the value of Sourcegraph to buyers and admins.
 1. **Installations or technical check-ins:** to walk through setting up Sourcegraph with a technical point of contact. These can be useful for learning what types of technical blockers users and admins encounter, and how we help solve them.
 1. **Trial check-in:** to discuss how things are going during a trial. These are often recurring weekly, and can be quite informal. These can be useful for getting a snapshot of a deal process, or to hear mid-flight product or process feedback.
-1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A.""
+1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A." These can be useful for understanding how we help new end users understand Sourcegraph's value, and what sorts of questions new users ask."
 1. **Existing customer check-in:** to hear how things might be improved or learn about exciting ways a customer is using Sourcegraph. 
 
 ## How to join calls to listen

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -8,7 +8,7 @@ While calendar events won't have one of these exact lables, knowing the types of
 
 1. **New prospect:** the first call with a prospect, who may not know much about Sourcegraph. Often named "Intro Call."
 1. **Installation:** to walk through setting up Sourcegraph with a technical point of contact.  
-1. **Trial check-in:** to discuss how things are going during a trial.
+1. **Trial check-in:** to discuss how things are going during a trial. These are often recurring weekly, and can be quite informal. These can be useful for getting a snapshot of a deal process, or to hear mid-flight product or process feedback.
 1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A.""
 1. **Existing customer check-in:** to hear how things might be improved or learn about exciting ways a customer is using Sourcegraph. 
 

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -7,7 +7,7 @@ Joining customer calls is a valuable part of any new team member's onboarding or
 While calendar events won't have one of these exact lables, knowing the types of calls will help you categorize calls so you can join the ones you'll find most helpful. 
 
 1. **New prospect:** the first call with a prospect, who may not know much about Sourcegraph. Often named "Intro Call." These can be useful for understanding how we communicate the value of Sourcegraph to buyers and admins.
-1. **Installation:** to walk through setting up Sourcegraph with a technical point of contact.  
+1. **Installations or technical check-ins:** to walk through setting up Sourcegraph with a technical point of contact. These can be useful for learning what types of technical blockers users and admins encounter, and how we help solve them.
 1. **Trial check-in:** to discuss how things are going during a trial. These are often recurring weekly, and can be quite informal. These can be useful for getting a snapshot of a deal process, or to hear mid-flight product or process feedback.
 1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A.""
 1. **Existing customer check-in:** to hear how things might be improved or learn about exciting ways a customer is using Sourcegraph. 

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -1,15 +1,15 @@
-# Joining customer calls
+# Joining customer and prospect calls
 
-Joining customer calls is a valuable part of any new team member's onboarding or ongoing work. It helps you quickly learn what customers are directly interested in, and how we communicate the product to them.
+Joining customer and prospect calls is a valuable part of any new team member's onboarding or ongoing work. It helps you quickly learn what customers or prospects are directly interested in, and how we communicate the product to them.
 
 ## Types of calls
 
 While calendar events won't have one of these exact lables, knowing the types of calls will help you categorize calls so you can join the ones you'll find most helpful. 
 
 1. **New prospect:** the first call with a prospect, who may not know much about Sourcegraph. Often named "Intro Call." These can be useful for understanding how we communicate the value of Sourcegraph to buyers and admins.
-1. **Installations or technical check-ins:** to walk through setting up Sourcegraph with a technical point of contact. These can be useful for learning what types of technical blockers users and admins encounter, and how we help solve them.
+1. **Installation or technical check-in:** to walk through setting up Sourcegraph with a technical point of contact. These can be useful for learning what types of technical blockers users and admins encounter, and how we help solve them.
 1. **Trial check-in:** to discuss how things are going during a trial. These are often recurring weekly, and can be quite informal. These can be useful for getting a snapshot of a deal process, or to hear mid-flight product or process feedback.
-1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A." These can be useful for understanding how we help new end users understand Sourcegraph's value, and what sorts of questions new users ask."
+1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all with a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A." These can be useful for understanding how we help new end users understand Sourcegraph's value, and what sorts of questions new users ask.
 1. **Existing customer check-in:** to hear how things might be improved or learn about exciting ways a customer is using Sourcegraph. These can vary significantly, so it can be worthwhile to check in with the team to understand context in advance.
 
 ## How to join calls to listen
@@ -22,4 +22,4 @@ You should feel comfortable asking to join any call – the call organizer will 
 
 ## How to join calls to speak
 
-If you want to speak directly with customers, you should first post in the #CE and #Sales channels what you'd like to talk about and with what (types of) customers. Then you'll work with the CE and Sales team members directly to set up new calls or join existing ones. 
+If you want to speak directly with customers or prospects, you should first post in the #CE and #Sales channels what you'd like to talk about and with what (types of) customers or prospects. Then you'll work with the CE and Sales team members directly to set up new calls or join existing ones. 

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -6,7 +6,7 @@ Joining customer calls is a valuable part of any new team member's onboarding or
 
 While calendar events won't have one of these exact lables, knowing the types of calls will help you categorize calls so you can join the ones you'll find most helpful. 
 
-1. **New prospect:** the first call with a prospect, who may not know much about Sourcegraph. Often named "Intro Call."
+1. **New prospect:** the first call with a prospect, who may not know much about Sourcegraph. Often named "Intro Call." These can be useful for understanding how we communicate the value of Sourcegraph to buyers and admins.
 1. **Installation:** to walk through setting up Sourcegraph with a technical point of contact.  
 1. **Trial check-in:** to discuss how things are going during a trial. These are often recurring weekly, and can be quite informal. These can be useful for getting a snapshot of a deal process, or to hear mid-flight product or process feedback.
 1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A.""

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -14,7 +14,7 @@ While calendar events won't have one of these exact lables, knowing the types of
 
 ## How to join calls to listen
 
-To join in on calls, you should first see which calls are happening that week and then slack message the event organizer to ask if you can join. Look at Sales or CE team members' calendars to find calls. 
+To join in on calls, you should first see which calls are happening that week and then Slack message the event organizer to ask if you can join. Look at Sales or CE team members' calendars to find calls. If the calendar invite was created by the prospect or customer, ask the Sales or CE team member before you add yourself.
 
 If you're working on a project and want to find calls about specific subjects, you can also post in the #CE and #Sales slack channels that you're looking for those calls.  
 

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -1,0 +1,25 @@
+# Joining customer calls
+
+Joining customer calls is a valuable part of any new team member's onboarding or ongoing work. It helps someone quickly learn what customers are directly interested in, and how we communicate the product to them.
+
+## Types of calls
+
+While calendar events won't have one of these exact lables, knowing the types of calls will help you categorize calls so you can join the ones you'll find most helpful. 
+
+1. **New prospect:** the first call with a prospect, who may not know much about Sourcegraph. Often named "Intro Call."
+1. **Installation:** to walk through setting up Sourcegraph with a technical point of contact.  
+1. **Trial check-in:** to discuss how things are going during a trial.
+1. **Training session:** a demo walkthrough of common use cases, an advanced tutorial, or a Q&A, all a customer's end users. Often have names like "Sourcegraph 101," "Webinar,"" "Demo," "Q&A.""
+1. **Existing customer check-in:** to hear how things might be improved or learn about exciting ways a customer is using Sourcegraph. 
+
+## How to join calls to listen
+
+To join in on calls, you should first see which calls are happening that week and then slack message the event organizer to ask if you can join. Everyone's calendars are public, so look at Sales or CE team members' calendars to find calls. 
+
+If you're working on a project and you want to make sure you're added to calls with specific subjects, you can also post in the #CE and #sales slack channels. 
+
+You should feel comfortable asking to join any call – it's up to the call organizer to let you know if you can't join for any reason. In return, it's expected that if you're "joining a call," it is only to silently observe. 
+
+## How to join calls to speak
+
+If you want to speak directly with customers, you should first post in the #CE and #sales channels what you'd like to talk about and with what (types of) customers. Then you'll work with the CE and Sales team members directly to set up or join existing calls in order to get what you need. 

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -22,4 +22,4 @@ You should feel comfortable asking to join any call – the call organizer will 
 
 ## How to join calls to speak
 
-If you want to speak directly with customers or prospects, you should first post in the #CE and #Sales channels what you'd like to talk about and with what (types of) customers or prospects. Then you'll work with the CE and Sales team members directly to set up new calls or join existing ones. 
+If you want to speak directly with customers or prospects, you should prepare a document with a list of questions, the account profile types you'd be interested in speaking with, and the purpose of the call. Share this document with the Sales and CE teams via Slack and work with them directly to set up or join calls. 

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -1,6 +1,6 @@
 # Joining customer calls
 
-Joining customer calls is a valuable part of any new team member's onboarding or ongoing work. It helps someone quickly learn what customers are directly interested in, and how we communicate the product to them.
+Joining customer calls is a valuable part of any new team member's onboarding or ongoing work. It helps you quickly learn what customers are directly interested in, and how we communicate the product to them.
 
 ## Types of calls
 
@@ -14,12 +14,12 @@ While calendar events won't have one of these exact lables, knowing the types of
 
 ## How to join calls to listen
 
-To join in on calls, you should first see which calls are happening that week and then slack message the event organizer to ask if you can join. Everyone's calendars are public, so look at Sales or CE team members' calendars to find calls. 
+To join in on calls, you should first see which calls are happening that week and then slack message the event organizer to ask if you can join. Look at Sales or CE team members' calendars to find calls. 
 
-If you're working on a project and you want to make sure you're added to calls with specific subjects, you can also post in the #CE and #sales slack channels. 
+If you're working on a project and want to find calls about specific subjects, you can also post in the #CE and #Sales slack channels that you're looking for those calls.  
 
-You should feel comfortable asking to join any call – it's up to the call organizer to let you know if you can't join for any reason. In return, it's expected that if you're "joining a call," it is only to silently observe. 
+You should feel comfortable asking to join any call – the call organizer will let you know if you can't join for any reason. If you're "joining a call," they'll expect that you will silently observe. 
 
 ## How to join calls to speak
 
-If you want to speak directly with customers, you should first post in the #CE and #sales channels what you'd like to talk about and with what (types of) customers. Then you'll work with the CE and Sales team members directly to set up or join existing calls in order to get what you need. 
+If you want to speak directly with customers, you should first post in the #CE and #Sales channels what you'd like to talk about and with what (types of) customers. Then you'll work with the CE and Sales team members directly to set up new calls or join existing ones. 

--- a/handbook/sales/onboarding/joining_customer_calls.md
+++ b/handbook/sales/onboarding/joining_customer_calls.md
@@ -16,7 +16,7 @@ While calendar events won't have one of these exact lables, knowing the types of
 
 To join in on calls, you should first see which calls are happening that week and then Slack message the event organizer to ask if you can join. Look at Sales or CE team members' calendars to find calls. If the calendar invite was created by the prospect or customer, ask the Sales or CE team member before you add yourself.
 
-If you're working on a project and want to find calls about specific subjects, you can also post in the #CE and #Sales slack channels that you're looking for those calls.  
+If you're working on a project and want to find calls about specific subjects, you can also post in the #CE and #Sales Slack channels that you're looking for those calls.  
 
 You should feel comfortable asking to join any call – the call organizer will let you know if you can't join for any reason. If you're "joining a call," they'll expect that you will silently observe. 
 


### PR DESCRIPTION
Sitting in on customer calls is super helpful for new team members! 

Which means it's also something that an ever-growing number people want to do. We (the product team) have already found that it's difficult to get added to as many calls as we'd like with the "post in slack asking to be added to calls" process. This is likely because that puts the burden on sales/ce team members to remember to add new folks to specific calls. 

I think the best thing to do is formally endorse company-wide the "look at someone else's calendar and then slack them directly to join" process that sales/ce have been using, since the work of finding specific calls then falls on the person who wants to join. The easiest way to do that is to put it in one place that all our mentions can link to. 

I've also added context for the types of calls, since I think it will help people looking to join calls. It's taken directly from this slack message from @dadlerj : https://sourcegraph.slack.com/archives/C0B2RU51Q/p1596472722151800?thread_ts=1596471941.151600&cid=C0B2RU51Q (the post he's replying to also alludes to the problem statement here about joining calls). 

Questions: 
- Is the list of "type of calls" correct enough? Do sales/CE folks have examples of event titles for some of the other types? 

Feel free to suggest a better directory location for this page if you have a preference.