### PR TITLE
Document 2-week iterations for the web team

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -94,7 +94,7 @@ At the beginning of each iteration, the engineering manager will:
 - Schedule the retrospective meeting
 - Set up a Slack reminder three days before the retrospective meeting, asking teammates to write their discussion topics [in our retrospectives document](https://docs.google.com/document/d/1YW45Dksk0vIn7drhatwLyo6YbMMkS-naHcuShUi1OOw/edit#heading=h.dxt1jy5hsf1d)
 
-We do regular backlog triages together, where we go through the issues in our backlog.
+We do regular backlog triages together, where we go through [the issues in our backlog](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+label%3Ateam%2Fweb).
 This helps us resurface older issues, create shared awareness for existing deficiencies among everyone on our team and ensures no-longer-applicable issues are closed.
 To manage the load for these triages, a triage may have a specific theme, like "debt" or "performance".
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -39,7 +39,7 @@ We will tackle these medium-term goals in order, though expect to have some work
 
 ### Short term
 
-The web team's short-term goals are documented in [the tracking issue for the current milestone](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Atracking+label%3Ateam%2Fweb+is%3Aopen).
+See [iterations](#iterations).
 
 ## Tech stack
 
@@ -47,9 +47,18 @@ TypeScript, React, RxJS, GraphQL, Go.
 
 ## Processes
 
-### Planning
+### Iterations
 
-We do [planning](../tracking_issues.md#planning-a-milestone-with-a-tracking-issue) with [tracking issues](../tracking_issues.md).
+We plan our work in **2-week iterations**.
+We work on a single project in those 2 weeks as a team.
+
+Our goals for the current and past iterations can be found in our [iteration goals living Google Doc](https://docs.google.com/document/d/1n9WKjieKmd2YYkNrEsOfdmxRYUrbowLWjq05phLoQ6s/edit).
+
+The individual tasks and progress of the current iteration can be found as GitHub issues in our [GitHub project board](https://github.com/orgs/sourcegraph/projects/45?fullscreen=true), with estimate labels and assignees.
+At the beginning of an iteration, we fill the "Planned" column with all issues we want to accomplish by the end of the iteration and make sure they have estimates and assignees.
+Each issue should be as small as possible.
+Over the course of the iteration, we strive to close issues with small, iterative pull requests that we review and merge timely (generally a day).
+By the end of an iteration, all issues should be in the "Done" column and the board gets emptied.
 
 ### Updates
 
@@ -58,8 +67,9 @@ We do regular updates to communicate our progress to members of the team, and to
 #### Daily Slack updates
 
 Collaborating across timezones requires regular communication to keep each other updated on our progress, and coordinate work handoff if needed. We use daily Slack updates to achieve this.
+These updates are purely for coordination within the team (as opposed to for external stakeholders).
 
-Every day, Slackbot will post a reminder in the #web to write your daily update.
+Every day, Slackbot will post a reminder in the #web channel to write your daily update.
 
 **At the end of each working day**, you should post your update as a threaded response to the Slackbot message.
 
@@ -71,15 +81,9 @@ You should include in your update:
 
 **At the beginning of each working day**, you should read the updates thread for the previous working day, to learn what your teammates have been working on, and check if they need your help.
 
-#### Weekly updates in the tracking issue
-
-We use weekly [progress updates in the tracking issue](../tracking_issues.md#progress_updates) to inform external stakeholders of the progress of the team.
-
-Every Friday, Slackbot will post a reminder in #web to write your weekly progress update. You should post your update in the tracking issue for the current milestone by EOD Friday.
-
 ### Retrospectives
 
-After the 20th of each month, we hold a retrospective, to reflect on the past iteration. We use this retrospective to:
+After each iteration, we hold a retrospective, to reflect on the past iteration. We use this retrospective to:
 
 - Understand whether we accomplished the goals we set at the beginning of the iteration. If we didn't accomplish them, reflect on the reasons why.
 - Discuss things that didn't go well in the iteration, and identify action items to improve on these in the next iteration.
@@ -88,13 +92,11 @@ After the 20th of each month, we hold a retrospective, to reflect on the past it
 At the beginning of each iteration, the engineering manager will:
 
 - Schedule the retrospective meeting
-- Set up a Slack reminder three days before the retrospective meeting, asking teammates to write their discussion topics in the retrospective document
+- Set up a Slack reminder three days before the retrospective meeting, asking teammates to write their discussion topics [in our retrospectives document](https://docs.google.com/document/d/1YW45Dksk0vIn7drhatwLyo6YbMMkS-naHcuShUi1OOw/edit#heading=h.dxt1jy5hsf1d)
 
-The meeting notes for all past web team retrospectives can be found [here](https://docs.google.com/document/d/1YW45Dksk0vIn7drhatwLyo6YbMMkS-naHcuShUi1OOw/edit#heading=h.dxt1jy5hsf1d).
-
-We do monthly backlog triages together, where we go through the issues in the "To do" column of our [Project board](https://github.com/orgs/sourcegraph/projects/45) and decide which issues we should work on soon by moving them to the "Next" column.
+We do regular backlog triages together, where we go through the issues in our backlog.
+This helps us resurface older issues, create shared awareness for existing deficiencies among everyone on our team and ensures no-longer-applicable issues are closed.
 To manage the load for these triages, a triage may have a specific theme, like "debt" or "performance".
-This helps us resurface older issues, create shared awareness for existing deficiencies among everyone working on the web codebase and ensure all issues have estimates.
 
 ## Team syncs
 


### PR DESCRIPTION
As decided in our 3.20 retrospective we want to try 2-week iterations on the web team, to only have a single goal per iteration and everyone working on the same project per iteration, avoiding costly context switches within the iteration. Our first iteration starts next Monday (September 28).
We also want to ship smaller PRs and use smaller individual issues.
To accomodate the faster cycles and communicate our plans and progress better within the team, we're going to use a GitHub project board for each iteration instead of a tracking issue (we may still create tracking issues for _projects_ though). The prose goal description from the tracking issue is moved to a living Google doc.
We're also therefor dropping the weekly teammate updates on those, as we now have the weekly update for stakeholders on the mailing list and the daily update in Slack for ourselves.
Retrospectives are helt after each iteration instead of monthly.

I expect we'll refine this process more and add more details to the handbook as we figure things out to keep it in sync.