### PR TITLE
Add how we reference customers to onboarding

### DIFF
--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -53,7 +53,7 @@ Never assume that a problem is somebody else's to fix!
   - Read the first page of [Sourcegraph's user documentation](https://docs.sourcegraph.com/user).
   - Go through the [analytics onboarding](https://sourcegraph.looker.com/projects/sourcegraph_events/files/1_home.md). This onboarding is within Looker, so if you don't have an account you can ask for access in #analytics.
   - Watch Dan's [Sourcegraph Demo](https://drive.google.com/file/d/1VUZ0rnZQpNgjtGDI0tMC-h-OtL0Czz8H/view)
-  - Learn how we can (and cannot) [reference our customers externally](../../sales#customer)
+  - Learn how we can (and cannot) [reference our customers externally](../../sales/index.md#customer)
 
 ## Team specific onboarding
 

--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -46,13 +46,14 @@ Never assume that a problem is somebody else's to fix!
   - If you are not familiar with Git, complete the [Git introduction](git_intro.md).
   - Add yourself to the [team page](../../../company/team/index.md).
      - Add a link to your team page bio to your Slack profile
-  - Read Sourcegraph's [information security policy](https://about.sourcegraph.com/security) and acknowledge your acceptance: https://forms.gle/LUK1YtwAMJLhtRPi6.
+- Read Sourcegraph's [information security policy](https://about.sourcegraph.com/security) and acknowledge your acceptance: https://forms.gle/LUK1YtwAMJLhtRPi6.
 - Learn about Sourcegraph
   - Read the [Sourcegraph values](../../../company/values.md).
   - Read the [Sourcegraph strategy](../../../company/strategy.md).
   - Read the first page of [Sourcegraph's user documentation](https://docs.sourcegraph.com/user).
   - Go through the [analytics onboarding](https://sourcegraph.looker.com/projects/sourcegraph_events/files/1_home.md). This onboarding is within Looker, so if you don't have an account you can ask for access in #analytics.
   - Watch Dan's [Sourcegraph Demo](https://drive.google.com/file/d/1VUZ0rnZQpNgjtGDI0tMC-h-OtL0Czz8H/view)
+  - Learn how we can (and cannot) [reference our customers externally](../../sales#customer)
 
 ## Team specific onboarding
 


### PR DESCRIPTION
Based on [this thread](https://sourcegraph.slack.com/archives/CQAGQKC4A/p1596140127205200) (two months later..)

Also, I think the info sec policy shouldn't be under handbook so moved it, lmk if I'm wrong 😄 