### PR TITLE
releases: remove manual changelog check, add new changelog workflow

### DIFF
--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -32,7 +32,7 @@ Arguments:
 
 ## $FOUR_WORKING_DAYS_BEFORE_RELEASE (4 work days before release): Branch cut
 
-- [ ] Run the ["Release(changelog)" workflow](TODO) to generate a pull request updating the changelog and merge it.
+- [ ] Run the ["Release(changelog)" workflow](https://github.com/sourcegraph/sourcegraph/actions?query=workflow%3ARelease%28changelog%29+) to generate a pull request updating the changelog and merge it.
 - [ ] Create the `$MAJOR.$MINOR` branch off the CHANGELOG commit in the previous step: `git branch $MAJOR.$MINOR && git push origin $MAJOR.$MINOR`.
 - [ ] Tag and announce the first release candidate:
   ```

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -32,7 +32,10 @@ Arguments:
 
 ## $FOUR_WORKING_DAYS_BEFORE_RELEASE (4 work days before release): Branch cut
 
-- [ ] Run the ["Release(changelog)" workflow](https://github.com/sourcegraph/sourcegraph/actions?query=workflow%3ARelease%28changelog%29+) to generate a pull request updating the changelog and merge it.
+- [ ] Update the changelog and merge the generated pull request:
+  ```
+  yarn run release changelog:cut $MAJOR.$MINOR.0
+  ```
 - [ ] Create the `$MAJOR.$MINOR` branch off the CHANGELOG commit in the previous step: `git branch $MAJOR.$MINOR && git push origin $MAJOR.$MINOR`.
 - [ ] Tag and announce the first release candidate:
   ```

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -32,13 +32,7 @@ Arguments:
 
 ## $FOUR_WORKING_DAYS_BEFORE_RELEASE (4 work days before release): Branch cut
 
-- [ ] Verify for each CHANGELOG item the following (if any item does not have these, disable it,
-  notify the owner, and remove it from the CHANGELOG):
-  - It has an owner attached to it
-  - It has undergone manual QA (and the QA was done on k8s.sgdev.org or at scale if the feature requires it).
-  - It is covered by the regression test suite
-- [ ] Add a new section `## $MAJOR.MINOR` to [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md#unreleased) immediately under `## Unreleased changes`. Add new empty sections under `## Unreleased changes` ([example](https://github.com/sourcegraph/sourcegraph/pull/2323)).
-- [ ] Commit this CHANGELOG edit to `main` using a PR. 
+- [ ] Run the ["Release(changelog)" workflow](TODO) to generate a pull request updating the changelog and merge it.
 - [ ] Create the `$MAJOR.$MINOR` branch off the CHANGELOG commit in the previous step: `git branch $MAJOR.$MINOR && git push origin $MAJOR.$MINOR`.
 - [ ] Tag and announce the first release candidate:
   ```


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/13872 - see issue for discussion

documents https://github.com/sourcegraph/sourcegraph/pull/14240 (https://github.com/sourcegraph/sourcegraph/issues/13873)