### PR TITLE
move company meeting 2h earlier

### DIFF
--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -1,6 +1,6 @@
 # Company meeting
 
-1. Schedule: every Monday 10:30-11:00am PST/PDT (link in the calendar event)
+1. Schedule: every Monday 8:00-8:30am PST/PDT (link in the calendar event)
    - If Monday is a holiday, the meeting is held on the next non-holiday day.
    - There is no company meeting held between December 25 and December 31. The first company meeting of the year is held on the first non-holiday Monday of the year.
 1. The link to the slides is posted in #general each Thursday before.

--- a/handbook/communication/company_meeting.md
+++ b/handbook/communication/company_meeting.md
@@ -1,7 +1,7 @@
 # Company meeting
 
 1. Schedule: every Monday 8:00-8:30am PST/PDT (link in the calendar event)
-   - If Monday is a holiday, the meeting is held on the next non-holiday day.
+   - If Monday is a [holiday](../people-ops/holidays.md), the meeting is held on the next non-holiday day.
    - There is no company meeting held between December 25 and December 31. The first company meeting of the year is held on the first non-holiday Monday of the year.
 1. The link to the slides is posted in #general each Thursday before.
 1. We used to call this "team meeting", but now we call it "company meeting" because "team meeting" sounds like it's only for one specific team inside the company.

--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -34,7 +34,7 @@ The following places are not sources of truth. Treat documents and conversations
 
 ## Meetings
 
-- [Company meeting](company_meeting.md) (Mondays 10:30-11:00am PST/PDT)
+- [Company meeting](company_meeting.md) (Mondays 8:00-8:30am PST/PDT)
 - [Social calendar](../../company/remote/social_calendar.md) meetings
 
 ### Internal meetings

--- a/handbook/engineering/distribution/recurring_processes.md
+++ b/handbook/engineering/distribution/recurring_processes.md
@@ -94,7 +94,7 @@ The [engineering manager](../roles.md#engineering-manager) drives the [retrospec
 
 ### Company meeting
 
-As with everyone at Sourcegraph, we join the [weekly company meeting](https://about.sourcegraph.com/handbook/communication/company_meeting) on Mondays @ 10:30am PST (when timezone permits, watching the recording otherwise).
+As with everyone at Sourcegraph, we join the [weekly company meeting](https://about.sourcegraph.com/handbook/communication/company_meeting) (when timezone permits, watching the recording otherwise).
 
 ### Weekly Distribution team sync
 


### PR DESCRIPTION
We've added a lot more people outside of the California time zone in the last year. Moving the meeting 2h earlier is better for many people now.