### PR TITLE
Clarify PM ownership for web/search

### DIFF
--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -133,7 +133,7 @@ _Updated 2020-09-11_
 
 ## Members
 
-- [Pooja Jain](../../../company/team/index.md#) ([Product Manager](../../product/roles/product_manager.md)) is focused on search, [Christina Forney](../../../company/team/index.md#christina-forney-she-her) is supporting.
+- [Pooja Jain](../../../company/team/index.md#) ([Product Manager](../../product/roles/product_manager.md))
 - [Loïc Guychard](../../../company/team/index.md#loïc-guychard) ([Engineering Manager](../roles.md#engineering-manager))
   - [Farhan Attamimi](../../../company/team/index.md#farhan-attamimi)
   - [Rijnard van Tonder](../../../company/team/index.md#rijnard-van-tonder)

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -108,7 +108,7 @@ Before web team syncs, teammates and stakeholders should write down under "Discu
 
 ## Members
 
-- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md)) is focused on code insights, [Christina Forney](../../../company/team/index.md#christina-forney-she-her) is supporting.
+- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md))
 - [J.P.](../../../company/team/index.md#todo) ([Engineering Manager](../roles.md#engineering-manager)) starting 2020-11-02. In the meantime, Felix will run team syncs, goal setting, iteration planning, retrospectives and team status updates.
   - [Felix Becker](../../../company/team/index.md#felix-becker)
   - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)


### PR DESCRIPTION
Clarifying that Joel is the PM for the web team, and Pooja is the PM for the search team and both have full product ownership and PM responsibilities for the respective teams.