### PR TITLE
add page for repo data on dot com, how to add repos to index

### DIFF
--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -52,6 +52,7 @@ This deployment is also colloquially referred to as "Sourcegraph Cloud", "Cloud"
 - [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dot-com)
 - [Infrastructure configuration](https://github.com/sourcegraph/infrastructure/tree/main/cloud)
 - Alerts: `#alerts-cloud` and [OpsGenie](./incidents/on_call.md)
+- [How to update repository data](./distribution/repository_data_on_sourcegraph_dot_com.md)
 
 #### Deploying to sourcegraph.com
 

--- a/handbook/engineering/distribution/repository_data_on_sourcegraph_dot_com.md
+++ b/handbook/engineering/distribution/repository_data_on_sourcegraph_dot_com.md
@@ -12,7 +12,7 @@ To force indexing a repository that is not indexed, do the following:
   - First get the ID of the database pod:
 
 ```
-$ get pods --all-namespaces | grep "prod.*pgsql"
+$ kubectl get pods --all-namespaces | grep "prod.*pgsql"
 prod            pgsql-XXXXXXXXXX-XXXXXX      2/2     Running     0          19d
 ```
   - `kubectl -n prod exec -it pgsql-XXXXXXXXXX-XXXXXX /bin/sh` - connect to the machine

--- a/handbook/engineering/distribution/repository_data_on_sourcegraph_dot_com.md
+++ b/handbook/engineering/distribution/repository_data_on_sourcegraph_dot_com.md
@@ -1,0 +1,29 @@
+# Repository data on Sourcegraph.com
+
+Repositories are typically indexed for better search performance. We index many
+GitHub repositories on Sourcegraph.com, but not all of them. To find out whether
+a repository is indexed for search, visit `https://sourcegraph.com/github.com/MY/REPO/-/settings/index`
+
+## How to add a repository search index
+
+To force indexing a repository that is not indexed, do the following:
+
+- Connect to the machine
+  - First get the ID of the database pod:
+
+```
+$ get pods --all-namespaces | grep "prod.*pgsql"
+prod            pgsql-XXXXXXXXXX-XXXXXX      2/2     Running     0          19d
+```
+  - `kubectl -n prod exec -it pgsql-XXXXXXXXXX-XXXXXX /bin/sh` - connect to the machine
+
+- `psql -U sg` - connect to the database on the machine
+
+- Find the ID of the repository to index:
+
+```
+$ select repo.id from repo where repo.name LIKE 'github.com/the/repo';
+12345678
+```
+
+- `INSERT INTO default_repos(repo_id) VALUES (12345678);` - add the ID to the table


### PR DESCRIPTION
There's a recurring use case/request for how to add custom repositories to index on Sourcegraph.com. It's not documented. This PR is a best effort to document how to do it currently.

Please check the commands for accuracy @daxmc99 (is it still OK to use `kubectl` instead of `gcloud`? is there an alternative `gcloud` command?)

Please check that this page lives in a sensible place @sourcegraph/distribution 