### PR TITLE
Keegan is on the search team

### DIFF
--- a/handbook/engineering/cloud/index.md
+++ b/handbook/engineering/cloud/index.md
@@ -165,10 +165,6 @@ By default, members of the team will provide a brief update about the goals they
   - [Alan Harris](../../../company/team/index.md#alan-harris-he-him)
   - [A. RS](../../../company/team/index.md#todo) starts on the 2nd of November.
 
-Other:
-
-- [Keegan Carruthers-Smith](../../../company/team/index.md#keegan-carruthers-smith) will not be isolating his work to a single team. Instead, he will serially choose tasks that he thinks are important to work on and he will post updates to the most relevant tracking issue on GitHub. This is an experiment for the next month and we will evaluate the outcome on 2020-08-17. Tomás will continue to be his manager during this experiment.
-
 ## Growth plan
 
 _Updated 2020-08-05_

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -139,6 +139,7 @@ _Updated 2020-09-11_
   - [Rijnard van Tonder](../../../company/team/index.md#rijnard-van-tonder)
   - [Stefan Hengl](../../../company/team/index.md#stefan-hengl-he-him)
   - [Juliana Peña](../../../company/team/index.md#juliana-peña-she-her)
+  - [Keegan Carruthers-Smith](../../../company/team/index.md#keegan-carruthers-smith)
 
 ## On-call
 


### PR DESCRIPTION
Keegan has effectively been working on search and performance for a while, and wants to continue doing so. Given this, we have agreed to document him as a member of the search team and Loïc will be his manager. This doesn't really change anything in practice since this has already been the state of affairs for multiple weeks.