### PR TITLE
Add additional information about internal services

### DIFF
--- a/handbook/engineering/distribution/internal_infrastructure.md
+++ b/handbook/engineering/distribution/internal_infrastructure.md
@@ -2,15 +2,33 @@
 
 ## Code host testing instances
 
-We maintain a collection of code hosts for testing purposes.
+We maintain a collection of code hosts for testing purposes defined in our [infrastructure/dogfood](https://github.com/sourcegraph/infrastructure/tree/main/dogfood/kubernetes/tooling) cluster.
 
-- GitHub Enterprise: https://ghe.sgdev.org ([credentials on 1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/bw4nttlfqve3rc6xqzbqq7l7pm))
-  - [Notes about ghe.sgdev.org](github_enterprise_testing_instance.md)
-- Bitbucket Server: https://bitbucket.sgdev.org ([credentials on 1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/6owvzrgxfva3hn5jxe2253qbwi))
+### GitHub Enterprise
 
-## Getting access to our Kubernetes clusters
+URL: https://ghe.sgdev.org
 
-See [kubernetes/README.md in the infrastructure repository](https://github.com/sourcegraph/infrastructure/blob/master/kubernetes/README.md).
+Credentials: [1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/bw4nttlfqve3rc6xqzbqq7l7pm)
+
+_[Additional information about ghe.sgdev.org](github_enterprise_testing_instance.md)_
+
+### Bitbucket Server
+
+URL: https://bitbucket.sgdev.org
+
+Credentials: [1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/6owvzrgxfva3hn5jxe2253qbwi)
+
+### Phabricator
+
+URL: http://phabricator.sgdev.org/
+
+Credentials: [1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/bmanarlwknhl5p635wkgxfyd2i)
+
+### Gitolite
+
+Git URL: gitolite.sgdev.org
+
+Credentials: [1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/i5bm6syw45w2c33cvfrrlt4fhu)
 
 ## Customer environment replicas
 

--- a/handbook/engineering/distribution/internal_infrastructure.md
+++ b/handbook/engineering/distribution/internal_infrastructure.md
@@ -1,5 +1,9 @@
 # Internal infrastructure
 
+## Sourcegraph deployments
+
+Internal deployments are documented in the [deployments](../deployments.md).
+
 ## Code host testing instances
 
 We maintain a collection of code hosts for testing purposes defined in our [infrastructure/dogfood](https://github.com/sourcegraph/infrastructure/tree/main/dogfood/kubernetes/tooling) cluster.


### PR DESCRIPTION
Related issue: https://github.com/sourcegraph/sourcegraph/issues/13917

Some of the [tooling](https://github.com/sourcegraph/infrastructure/tree/main/dogfood/kubernetes/tooling) where not described in our documentation, this adds a reference about them and a link to their definition.