### PR TITLE
clarify when weekly updates are to be sent

### DIFF
--- a/handbook/engineering/leadership/index.md
+++ b/handbook/engineering/leadership/index.md
@@ -76,7 +76,7 @@ We have a 1hr sync with product and engineering every Tuesday at 9am PT ([meetin
 
 ### Weekly updates
 
-Engineering managers send an update to [engineering-leadership-status@sourcegraph.com](https://groups.google.com/a/sourcegraph.com/g/engineering-leadership-status) on the same day every week; for most teams, this is by 12pm (noon) PT every Monday (sending it earlier is ok too). Anyone at the company can join the group to subscribe to these updates. The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
+Engineering managers send an update to [engineering-leadership-status@sourcegraph.com](https://groups.google.com/a/sourcegraph.com/g/engineering-leadership-status) on either Monday or Tuesday each week (suggestion: send after your weekly team meeting). Anyone at the company can join the group to subscribe to these updates. The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
 
 - What important things happened last week?
   - Include contact with customers (feedback collected, things shipped).

--- a/handbook/engineering/leadership/index.md
+++ b/handbook/engineering/leadership/index.md
@@ -76,7 +76,7 @@ We have a 1hr sync with product and engineering every Tuesday at 9am PT ([meetin
 
 ### Weekly updates
 
-Engineering managers send an update to [engineering-leadership-status@sourcegraph.com](https://groups.google.com/a/sourcegraph.com/g/engineering-leadership-status) by 12pm (noon) PT every Monday (sending it earlier, like EOD Friday is ok too). Anyone at the company can join the group to subscribe to these updates. The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
+Engineering managers send an update to [engineering-leadership-status@sourcegraph.com](https://groups.google.com/a/sourcegraph.com/g/engineering-leadership-status) on the same day every week; for most teams, this is by 12pm (noon) PT every Monday (sending it earlier is ok too). Anyone at the company can join the group to subscribe to these updates. The purpose of the update is to keep interested parties (including the VP of Engineering, and peer managers) informed of what is going on in each part of our organization. The format of this update is at the discretion of the sender, but it should be prose that generally answers the following questions:
 
 - What important things happened last week?
   - Include contact with customers (feedback collected, things shipped).


### PR DESCRIPTION
As the Campaigns team starts the week (and sprints) on Wednesday, this change allows them to report on Tuesday instead of Monday.