### PR TITLE
Update backend and full-stack hiring processes

### DIFF
--- a/handbook/engineering/hiring/software-engineer-backend.md
+++ b/handbook/engineering/hiring/software-engineer-backend.md
@@ -36,11 +36,10 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 ## Interview process
 
 1. You [apply here](https://jobs.lever.co/sourcegraph/895e2b30-9fd7-4b09-bf16-0fa6f9613684/apply).
-1. We review your application.
-1. We schedule a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. We schedule a 1 hour interview with the hiring manager of one of the teams you expressed preference for. You'll talk about your past work and accomplishments in depth, how you worked with others, decisions you made and what you'd do differently today.
+   - Read through [our handbook](https://github.com/sourcegraph/about) to learn more about how we operate and to find answers to common questions that you might have. We leave 10 minutes at the end of this interview for you to ask any additional questions.
 1. You complete a 2-hour [coding exercise in Go](software-engineer-coding-exercise.md#go-coding-exercise) that we designed to measure your understanding of concurrency and error handling.
    - Will be reviewed by 2 engineers chosen by the hiring manager of the team you expressed preference for.
-1. We schedule a 1 hour **Technical Experience** interview with the hiring manager of one of the teams you expressed preference for. You'll talk about your past work and accomplishments.
 1. We schedule additional interviews across multiple days.
    - 1h **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
      - Will interview with 2 of the following:
@@ -51,7 +50,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
        - [Alan Harris](../../../company/team/index.md#alan-harris-he-him)
        - [Stefan Hengl](../../../company/team/index.md#stefan-hengl-he-him)
    - 1h **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
-     - Will interview with 2 of the following:
+     - Will interview with the Product Manager of the team you expressed preference for and 1 other of:
        - [Christina Forney](../../../company/team/index.md#christina-forney-she-her)
        - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
        - [Eric Broody-Moore](../../../company/team/index.md#eric-brody-moore)

--- a/handbook/engineering/hiring/software-engineer-backend.md
+++ b/handbook/engineering/hiring/software-engineer-backend.md
@@ -35,14 +35,31 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 
 ## Interview process
 
-1. You [apply here](https://jobs.lever.co/sourcegraph/895e2b30-9fd7-4b09-bf16-0fa6f9613684).
-1. We set up a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. You [apply here](https://jobs.lever.co/sourcegraph/895e2b30-9fd7-4b09-bf16-0fa6f9613684/apply).
+1. We review your application.
+1. We schedule a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
 1. You complete a 2-hour [coding exercise in Go](software-engineer-coding-exercise.md#go-coding-exercise) that we designed to measure your understanding of concurrency and error handling.
-1. We schedule 4 hours of remote interviews over video chat across multiple days.
-   - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
-   - **Technical experience:** We ask you about your past work and accomplishments.
-   - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
-   - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
+   - Will be reviewed by 2 engineers chosen by the hiring manager of the team you expressed preference for.
+1. We schedule a 1 hour **Technical Experience** interview with the hiring manager of one of the teams you expressed preference for. You'll talk about your past work and accomplishments.
+1. We schedule additional interviews across multiple days.
+   - 1h **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
+     - Will interview with 2 of the following:
+       - [Stephen Gutekanst](../../../company/team/index.md#stephen-gutekanst)
+       - [Thorsten Ball](../../../company/team/index.md#thorsten-ball-he-him)
+       - [Eric Fritz](../../../company/team/index.md#eric-fritz-he-him)
+       - [Ryan Slade](../../../company/team/index.md#ryan-slade-he-him)
+       - [Alan Harris](../../../company/team/index.md#alan-harris-he-him)
+       - [Stefan Hengl](../../../company/team/index.md#stefan-hengl-he-him)
+   - 1h **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
+     - Will interview with 2 of the following:
+       - [Christina Forney](../../../company/team/index.md#christina-forney-she-her)
+       - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
+       - [Eric Broody-Moore](../../../company/team/index.md#eric-brody-moore)
+       - [Pooja Jain](../../../company/team/index.md#pooja-jain-she-her)
+       - [Dan Adler](../../../company/team/index.md#dan-adler-he-him)
+   - 30m **VP Engineering**
+   - 30m **CTO**
+   - 30m **CEO**
 1. We check your references.
 1. We make you a job offer.
 

--- a/handbook/engineering/hiring/software-engineer-coding-exercise.md
+++ b/handbook/engineering/hiring/software-engineer-coding-exercise.md
@@ -41,8 +41,6 @@ This exercise is designed to give you an opportunity to demonstrate your skills 
 - You can look up documentation on the internet while you are coding.
 - After three hours, you will email us your solution as a zip file and we will get back to you on next steps within 2 business days.
 
-If we decide to move forward, we will schedule a Technical Discussion interview to go over your solution and how you'd extend it with some additional requirements in mind.
-
 ## FAQ
 
 ### Why do you do a coding exercise?

--- a/handbook/engineering/hiring/software-engineer-full-stack.md
+++ b/handbook/engineering/hiring/software-engineer-full-stack.md
@@ -41,16 +41,15 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 ## Interview process
 
 1. You [apply here](https://jobs.lever.co/sourcegraph/cea553ce-ace7-4b44-8828-8d421e5e7e9c/apply).
-1. We review your application.
-1. We set up a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. We schedule a 1 hour interview with the hiring manager of one of the teams you expressed preference for. You'll talk about your past work and accomplishments in depth, how you worked with others, decisions you made and what you'd do differently today.
+   - Read through [our handbook](https://github.com/sourcegraph/about) to learn more about how we operate and to find answers to common questions that you might have. We leave 10 minutes at the end of this interview for you to ask any additional questions.
 1. You complete a 3-hour [coding exercise](software-engineer-coding-exercise.md#full-stack-coding-exercise) that we designed for you to be able to demonstrate your skills in building a small web application end-to-end.
    - Will be reviewed by 2 engineers chosen by the hiring manager of the team you expressed preference for.
-1. We schedule a 1 hour interview with the hiring manager of one of the teams you expressed preference for. You'll talk about your past work and accomplishments.
 1. We schedule additional interviews across multiple days.
    - 1h **Technical discussion:** We discuss your solution to the coding exercise, give you additional requirements and ask how you'd solve for those. We'll dive deeper into your technical knowledge.
      - Will interview with the same 2 engineers that reviewed your code exercise.
    - 1h **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
-     - Will interview with 2 of the following:
+     - Will interview with the Product Manager of the team you expressed preference for and 1 other of:
        - [Christina Forney](../../../company/team/index.md#christina-forney-she-her)
        - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
        - [Eric Broody-Moore](../../../company/team/index.md#eric-brody-moore)

--- a/handbook/engineering/hiring/software-engineer-full-stack.md
+++ b/handbook/engineering/hiring/software-engineer-full-stack.md
@@ -12,23 +12,23 @@ The following engineering teams are currently hiring for this role:
 
 We are looking for a full stack engineer who has strong fundamentals in good software development techniques, design patterns and best practices. In your career you have worked with and refactored existing code bases. You are both productive and pragmatic because you believe software is only useful if it is used. Collaborating with small high performing teams, you have built and deployed production-ready software that delivers value to customers.
 
-* Strong working knowledge with API design and architecture.
-* Experience building and testing end-to-end applications (e.g. unit testing, integration and e2e testing).
-* Good knowledge of Git in particular and other version control systems in general.
-* Experience building single page applications or progressive web apps and Web APIs.
-* Understanding of core web technologies (HTTP, HTML, CSS, JavaScript)
-* Strong experience with at least one web framework such as React, Angular, Vue.js, Polymer or Closure.
-* Strong experience in at least one server side language such as Go, Java, Python, PHP, Ruby.
-* Experience in SQL, Postgres or other transactional, relational databases. Able to model and design schemas.
-* Have worked with containers in production environments.
+- Strong working knowledge with API design and architecture.
+- Experience building and testing end-to-end applications (e.g. unit testing, integration and e2e testing).
+- Good knowledge of Git in particular and other version control systems in general.
+- Experience building single page applications or progressive web apps and Web APIs.
+- Understanding of core web technologies (HTTP, HTML, CSS, JavaScript)
+- Strong experience with at least one web framework such as React, Angular, Vue.js, Polymer or Closure.
+- Strong experience in at least one server side language such as Go, Java, Python, PHP, Ruby.
+- Experience in SQL, Postgres or other transactional, relational databases. Able to model and design schemas.
+- Have worked with containers in production environments.
 
 ## Nice-to-haves
 
-* Direct experience with any one of these technologies: ES6+, Go, GraphQL, TypeScript, Docker, Kubernetes.
-* Experience working on small high-performing teams, preferably tech startups.
-* Comfortable using a cloud computing platform such as AWS, GCP or Azure.
-* Published blog posts and/or tech talks about your work.
-* Contributions to open source projects.
+- Direct experience with any one of these technologies: ES6+, Go, GraphQL, TypeScript, Docker, Kubernetes.
+- Experience working on small high-performing teams, preferably tech startups.
+- Comfortable using a cloud computing platform such as AWS, GCP or Azure.
+- Published blog posts and/or tech talks about your work.
+- Contributions to open source projects.
 
 ## Learn more about us
 
@@ -41,16 +41,24 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 ## Interview process
 
 1. You [apply here](https://jobs.lever.co/sourcegraph/cea553ce-ace7-4b44-8828-8d421e5e7e9c/apply).
+1. We review your application.
 1. We set up a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
-1. We set up a 60-minute call with the hiring manager to discuss your technical experience including past work and accomplishments.
-1. We evaluate relevant technical skills that you have via an asynchronous coding exercise.
-   - We will give you an overview of the exercise in advance.
-   - We will send you the details at a time of your choosing and you will have up to 3 hours to work on the exercise.
-   - You will be able to use your own development environment and lookup documentation on the internet.
-1. We schedule 3 hours of remote interviews over video chat across multiple days.
-   - **Technical design discussion:** We review your coding exercise and have you walk us through how you would solve the problem.
-   - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
-   - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
+1. You complete a 3-hour [coding exercise](software-engineer-coding-exercise.md#full-stack-coding-exercise) that we designed for you to be able to demonstrate your skills in building a small web application end-to-end.
+   - Will be reviewed by 2 engineers chosen by the hiring manager of the team you expressed preference for.
+1. We schedule a 1 hour interview with the hiring manager of one of the teams you expressed preference for. You'll talk about your past work and accomplishments.
+1. We schedule additional interviews across multiple days.
+   - 1h **Technical discussion:** We discuss your solution to the coding exercise, give you additional requirements and ask how you'd solve for those. We'll dive deeper into your technical knowledge.
+     - Will interview with the same 2 engineers that reviewed your code exercise.
+   - 1h **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
+     - Will interview with 2 of the following:
+       - [Christina Forney](../../../company/team/index.md#christina-forney-she-her)
+       - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
+       - [Eric Broody-Moore](../../../company/team/index.md#eric-brody-moore)
+       - [Pooja Jain](../../../company/team/index.md#pooja-jain-she-her)
+       - [Dan Adler](../../../company/team/index.md#dan-adler-he-him)
+   - 30m **VP Engineering**
+   - 30m **CTO**
+   - 30m **CEO**
 1. We check your references.
 1. We make you a job offer.
 


### PR DESCRIPTION
This commit updates the hiring processes for backend and full stack roles.

Notable changes:

- Coding exercise for full stack comes after first 30 minute call with
the candidate, instead of directly scheduling a call with the hiring
manager.
- Coding exercise reviewers are chosen each time by the hiring manager
of the team the candidate expressed preference for.
- Interviewer roster change for the Architecture interview.