### PR TITLE
playbooks: add tip on pod failures, group general tips together

### DIFF
--- a/handbook/engineering/deployments.md
+++ b/handbook/engineering/deployments.md
@@ -156,30 +156,31 @@ This section contains tips and advice for interacting with our Kubernetes deploy
 1. Make sure that you have been granted access to our Google Cloud project: https://console.developers.google.com/project/sourcegraph-dev?authuser=0. You may need to change `authuser` to the index of your sourcegraph.com Google account.
 
 1. Install the `gcloud` command (CLI for interacting with the Google Cloud):
-
    ```
    curl https://sdk.cloud.google.com | bash
    ```
-
 1. Get authorization for your `gcloud` command:
-
    ```
    gcloud auth login
    ```
-
 1. Install the `kubectl` command (CLI for interacting with Kubernetes):
-
    ```
    gcloud components install kubectl
    ```
-
-1. Configure `kubectl` to point to the desired cluster using the appropriate `gcloud container clusters get-credentials` command listed at the top of this document.
-
+1. Configure `kubectl` to point to the desired cluster using the appropriate `gcloud container clusters get-credentials` command listed at the [top of this document](#deployments).
 1. Verify that you have access to kubernetes:
 
    ```
    kubectl get pods --all-namespaces
    ```
+
+#### Reauthenticate kubectl
+
+If you see the following when running `kubectl` commands:
+
+> Unable to connect to the server: x509: certificate signed by unknown authority
+
+Just run the appropriate `gcloud container clusters get-credentials` command listed at the [top of this document](#deployments) again to reauthenticate.
 
 ### kubectl cheatsheet
 

--- a/handbook/engineering/incidents/playbooks/index.md
+++ b/handbook/engineering/incidents/playbooks/index.md
@@ -1,6 +1,6 @@
 # Playbooks
 
-Many of these tips require kubectl usage - you can refer to the [deployment page's Kubernetes section](/handbook/engineering/deployments#kubernetes) to help you get set up and started with basic commands.
+Many of these tips require kubectl usage - you can refer to the [deployment page's Kubernetes section](../../deployments.md#kubernetes) to help you get set up and started with basic commands.
 
 ## Figure out why a pod is in CrashLoopBackoff
 
@@ -77,7 +77,7 @@ Dashboards for Prometheus metrics are available at `/-/debug/grafana` (for examp
 
 ### Tracing
 
-Check out the [kubectl cheatsheet](../../deployments.md#kubectl-cheatsheet) for how to get access to Jaeger locally.
+Jaeger is available at `/-/debug/jaeger` (for example, [sourcegraph.com/-/debug/jaeger](https://sourcegraph.com/-/debug/jaeger)).
 
 ### Prod logs
 
@@ -158,7 +158,7 @@ There's also a web interface for checking on common things, `https://pgsql-inspe
 
 ### Shell commands
 
-These commands assume you're on a local machine, and trying to access the live systems. Also refer to the [deployment page's Kubernetes section](/handbook/engineering/deployments#kubernetes) for kubectl tips.
+These commands assume you're on a local machine, and trying to access the live systems. Also refer to the [deployment page's Kubernetes section](../../deployments.md#kubernetes) for kubectl tips.
 
 #### Helpful aliases
 

--- a/handbook/engineering/incidents/playbooks/index.md
+++ b/handbook/engineering/incidents/playbooks/index.md
@@ -1,10 +1,6 @@
 # Playbooks
 
-Many of these tips require kubectl usage - you can refer to the [deployment page's Kubernetes section](https://about.sourcegraph.com/handbook/engineering/deployments#kubernetes) to help you get set up and started with basic commands.
-
-## [Sourcegraph.com is deleted entirely](dotcom_deleted_entirely.md)
-
-This playbook has a dedicated [page](dotcom_deleted_entirely.md)
+Many of these tips require kubectl usage - you can refer to the [deployment page's Kubernetes section](/handbook/engineering/deployments#kubernetes) to help you get set up and started with basic commands.
 
 ## Figure out why a pod is in CrashLoopBackoff
 
@@ -38,6 +34,56 @@ kubectl rollout restart deployment/$SERVICE
 Note the use of `deployment/` - you cannot restart services (`svc/`). Note that [stateful sets have a different process](#making-updates-to-stateful-sets).
 
 You can also bounce pods by manually finding them via `kubectl get pods` and `kubectl delete pod $POD_ID`. Once a pod is deleted, it will automatically be recreated.
+
+## Making updates to stateful sets
+
+Statefulsets are different to a deployment in that all pods must be in a healthy state before changes can be made.
+
+Currently sourcegraph uses statefulsets for the following services:
+
+- gitserver
+- grafana
+- indexed-search
+
+In order to push an update to a failing statefulset take the following action:
+
+### 1. Update the statefulset `yaml` with the appropriate change and apply using:
+
+```console
+`kubectl apply -f <service.StatefulSet.yaml>`
+```
+
+### 2. Delete the pods in the stateful set:
+
+```console
+REPLICAS=`kubectl get sts -n prod <statefulset> -o jsonpath={.spec.replicas}`; for i in `seq 0 $[REPLICAS-1]`; do POD=<statefulset>-$i;   echo "Deleting POD $POD";   kubectl delete pod -n prod $POD ; done
+```
+
+### 3. The statesfulset controller will now restart the pods. Verify the pods are starting successfully.
+
+```console
+watch -n1 kubectl get all -n prod -l app=gitserver -o wide
+```
+
+### 4. Verify service is restored
+
+Open the alert UI to click on the check URL that was failing and verify it's now working again.
+
+## Useful dashboards
+
+### Metrics
+
+Dashboards for Prometheus metrics are available at `/-/debug/grafana` (for example, [sourcegraph.com/-/debug/grafana](https://sourcegraph.com/-/debug/grafana)).
+
+### Tracing
+
+Check out the [kubectl cheatsheet](../../deployments.md#kubectl-cheatsheet) for how to get access to Jaeger locally.
+
+### Prod logs
+
+1. Go to **Kubernetes Engine > Workloads**, then search and click on the pod you're interested, e.g. `sourcegraph-frontend`.
+2. In the **Deployment details** page, there is a row called **Logs**, which has both **Container logs** and **Audit logs**.
+3. Click on the **Container logs**, then you should be redirected to the **Logs Viewer** page.
 
 ## Free gitserver disk space on sourcegraph.com
 
@@ -104,56 +150,6 @@ watch -n1 kubectl get all -n prod -l app=gitserver -o wide
 
 Open the alert UI to click on the check URL that was failing and verify it's now working again.
 
-## Making updates to stateful sets
-
-Statefulsets are different to a deployment in that all pods must be in a healthy state before changes can be made.
-
-Currently sourcegraph uses statefulsets for the following services:
-
-- gitserver
-- grafana
-- indexed-search
-
-In order to push an update to a failing statefulset take the following action:
-
-### 1. Update the statefulset `yaml` with the appropriate change and apply using:
-
-```console
-`kubectl apply -f <service.StatefulSet.yaml>`
-```
-
-### 2. Delete the pods in the stateful set:
-
-```console
-REPLICAS=`kubectl get sts -n prod <statefulset> -o jsonpath={.spec.replicas}`; for i in `seq 0 $[REPLICAS-1]`; do POD=<statefulset>-$i;   echo "Deleting POD $POD";   kubectl delete pod -n prod $POD ; done
-```
-
-### 3. The statesfulset controller will now restart the pods. Verify the pods are starting successfully.
-
-```console
-watch -n1 kubectl get all -n prod -l app=gitserver -o wide
-```
-
-### 4. Verify service is restored
-
-Open the alert UI to click on the check URL that was failing and verify it's now working again.
-
-## Useful dashboards
-
-### Metrics
-
-Dashboards for Prometheus metrics are available at `/-/debug/grafana` (for example, [sourcegraph.com/-/debug/grafana](https://sourcegraph.com/-/debug/grafana)).
-
-### Tracing
-
-Check out the [kubectl cheatsheet](../../deployments.md#kubectl-cheatsheet) for how to get access to Jaeger locally.
-
-### Prod logs
-
-1. Go to **Kubernetes Engine > Workloads**, then search and click on the pod you're interested, e.g. `sourcegraph-frontend`.
-2. In the **Deployment details** page, there is a row called **Logs**, which has both **Container logs** and **Audit logs**.
-3. Click on the **Container logs**, then you should be redirected to the **Logs Viewer** page.
-
 ## PostgreSQL database problems
 
 We provide two sets of instructions here, shell commands and PostgreSQL commands to be run inside a `psql` instance. PostgreSQL commands are denoted by the prompt `sg=#` in this documentation; the actual prompt corresponds to the postgres user name.
@@ -162,25 +158,13 @@ There's also a web interface for checking on common things, `https://pgsql-inspe
 
 ### Shell commands
 
-These commands assume you're on a local machine, and trying to access the live systems.
+These commands assume you're on a local machine, and trying to access the live systems. Also refer to the [deployment page's Kubernetes section](/handbook/engineering/deployments#kubernetes) for kubectl tips.
 
 #### Helpful aliases
 
 ```bash
 alias dbpod='kubectl get pods --namespace=prod | grep pgsql | cut -d " " -f 1'
 alias proddb='kubectl exec -it --namespace=prod $(dbpod) -- psql -U sg -P pager=off';
-```
-
-#### Reauthenticate kubectl
-
-If you see the following when running `kubectl` commands:
-
-> Unable to connect to the server: x509: certificate signed by unknown authority
-
-Run:
-
-```
-gcloud container clusters get-credentials dot-com --zone us-central1-f --project sourcegraph-dev
 ```
 
 #### Check load average
@@ -554,3 +538,7 @@ Import:
 ```
 gcloud --project=${TARGET_PROJECT} sql import sql ${TARGET_SERVER_NAME} 'gs://some-bucket/Cloud_SQL_Export_${SOURCE_SERVER_NAME}_${SOURCE_DB_NAME}' --database=${TARGET_DB_NAME}
 ```
+
+## [Sourcegraph.com is deleted entirely](dotcom_deleted_entirely.md)
+
+This playbook has a dedicated [page](dotcom_deleted_entirely.md)


### PR DESCRIPTION
Currently debugging a crashloopbackoff on k8s.sgdev.org where prometheus is failing to start using GCP, and I suddenly remembered that GCP is not very useful for this stuff because it doesnt seem to tell you why something might be restarting - CrashLoopBackoff seems to probably be the most common way issues present themselves, so I added a bit at the top of the playbook.

Also reorganized the sections a bit with the more general types of issues at the top, and consolidated some of the kubectl tips into the kubernetes section in deployments.

Also updated note on Jaeger - it is now available directly at https://sourcegraph.com/-/debug/jaeger