### PR TITLE
Adding events calendar

### DIFF
--- a/handbook/people-ops/onboarding/index.md
+++ b/handbook/people-ops/onboarding/index.md
@@ -41,6 +41,7 @@ Never assume that a problem is somebody else's to fix!
   - Add any local [holidays](../holidays.md) you observe to your calendar so people know you're not working.
   - Make it so any attendees can edit meetings you create: `Default guest permissions: Modify event` (this makes it easy for teammates to reschedule when necessary).
   - Set up a recurring weekly 25-minute [1-1 meeting](../../leadership/1-1.md) with your manager (e.g., `1-1 $YOURNAME-$MANAGERNAME`).
+  - Join the Sourcegraph events calendar by copying `sourcegraph.com_9cd67o8p3gs0rtpj73bt326psk@group.calendar.google.com` into your [add calendar field](https://calendar.google.com/calendar/u/0/r/settings/addcalendar?) and also join the [social calendar](../../../company/remote/social_calendar.md)
 - Make sure you know how to contribute to the handbook
   - [Create an account on GitHub.com](https://github.com/join) if you don't already have one.
      - Share your username with your manager so they can add you to the Sourcegraph GitHub account and appropriate teams.


### PR DESCRIPTION
Couldn't find this documented anywhere. Still not ideal but can't seem to find the equivalent "join link" for the events calendar that we use for the [social calendar](https://about.sourcegraph.com/company/remote/social_calendar#social-calendar) and this works functionally. 