### PR TITLE
release: allow pull requests to be release blockers

### DIFF
--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -57,7 +57,7 @@ Arguments:
 As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch.
 Aggressively revert or disable features that may cause delays:
 
-- [ ] Review [all release-blocking issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Asourcegraph+label%3Arelease-blocker). Add them as checklist items here. Ensure someone is resolving each.
+- [ ] Review [all release-blocking issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+archived%3Afalse+org%3Asourcegraph+label%3Arelease-blocker). Add them as checklist items here. Ensure someone is resolving each.
 - [ ] Review [all other open issues in the milestone](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Asourcegraph+-label%3Arelease-blocker+milestone%3A$MAJOR.$MINOR) and ask assignees to triage them to a different milestone (preferring Backlog).
 
 Cut a new release candidate daily if necessary:


### PR DESCRIPTION
Allows pull requests like https://github.com/sourcegraph/deploy-sourcegraph/pull/1067 to be release blockers