### PR TITLE
Replace dumb quotes with typographic quotes in case studies

### DIFF
--- a/website/src/css/pages/__case_studies.scss
+++ b/website/src/css/pages/__case_studies.scss
@@ -37,13 +37,13 @@
 
             &::before {
                 text-indent: -0.4em;
-                content: '"';
+                content: '“';
                 position: absolute;
                 margin-left: -2px;
             }
 
             &::after {
-                content: '"';
+                content: '”';
             }
 
             @include media-breakpoint-up(lg) {


### PR DESCRIPTION
This is a super simple fix that replaces [dumb quotes with typographic quotes](https://about.sourcegraph.com/handbook/communication/content_guidelines/style_and_mechanics#quotation-marks) for the blockquote elements used in case studies.

**Before:**

![Screenshot 2020-10-14 at 13 47 15](https://user-images.githubusercontent.com/6304497/95984640-c663b700-0e23-11eb-89a8-5af597fd815f.png)

**After:**

![Screenshot 2020-10-14 at 13 46 41](https://user-images.githubusercontent.com/6304497/95984580-b2b85080-0e23-11eb-93f2-923f090f8fc4.png)
