### PR TITLE
deployments: add sourcegraph managed instances

### DIFF
--- a/handbook/engineering/deployments/index.md
+++ b/handbook/engineering/deployments/index.md
@@ -7,6 +7,8 @@ We maintain multiple [instances](instances.md) of Sourcegraph:
   - [sourcegraph.sgdev.org](instances.md#sourcegraph-sgdev-org) is our private deployment of Sourcegraph that contains some of our private code.
   - [k8s.sgdev.org](instances.md#k8s-sgdev-org) is a dogfood deployment that replicates the scale of our largest customers. Note that this also contains all of our private code.
 - [Managed instances](../distribution/managed/index.md) are deployments of Sourcegraph we manage for customers.
+  - [demo.sourcegraph.com](instances.md#demo-sourcegraph-copm) is a managed instance used for CE demos.
+  - [devmanaged.sourcegraph.com](instances.md#devmanaged-sourcegraph-com) is a managed instance used for managed instances development.
 
 Learn more about how these work in:
 

--- a/handbook/engineering/deployments/instances.md
+++ b/handbook/engineering/deployments/instances.md
@@ -1,4 +1,8 @@
-# sourcegraph.com
+# Instances
+
+Information about Sourcegraph's different instances. For deployments of Sourcegraph we manage for customers, see [managed instances](../distribution/managed/index.md).
+
+## sourcegraph.com
 
 [![Build status](https://badge.buildkite.com/ef1289610fdd05b606bf1e57a034af2365c7b09c95ac6121f9.svg)](https://buildkite.com/sourcegraph/deploy-sourcegraph-dot-com)
 
@@ -13,11 +17,11 @@ This deployment is also colloquially referred to as "Sourcegraph Cloud", "Cloud"
 - Alerts: `#alerts-cloud` and [OpsGenie](../incidents/on_call.md)
 - [Playbooks](./playbooks.md#sourcegraph-com)
 
-# k8s.sgdev.org
+## k8s.sgdev.org
 
 [![Build status](https://badge.buildkite.com/65c9b6f836db6d041ea29b05e7310ebb81fa36741c78f207ce.svg?branch=release)](https://buildkite.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2)
 
-🚨 This deployment contains private code - do not use it for demos!
+🚨 This deployment contains private code - for demos, use [demo.sourcegraph.com](https://demo.sourcegraph.com) instead.
 
 This deployment is also colloquially referred to as "dogfood", "dogfood-k8s", or just "k8s". It deploys the latest changes in [`deploy-sourcegraph`](https://github.com/sourcegraph/deploy-sourcegraph), and by extension, `sourcegraph/sourcegraph`, via automated updates - learn more in [deployment basics](#deployment-basics).
 
@@ -32,13 +36,13 @@ This deployment is also colloquially referred to as "dogfood", "dogfood-k8s", or
 
 Updates from `deploy-sourcegraph` are performed upon [notification from upstream](#deploy-sourcegraph) by the ["Update from deploy-sourcegraph"](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/actions?query=workflow%3A%22Update+from+deploy-sourcegraph%22) workflow.
 
-# sourcegraph.sgdev.org
+## sourcegraph.sgdev.org
 
 [![Build status](https://badge.buildkite.com/135a00d4fba76ec97944bfb2fc28015d1565e0525853b4de06.svg)](https://buildkite.com/sourcegraph/deploy-sourcegraph-dogfood-server)
 
-This deployment runs the single-image version of Sourcegraph. It is deployed by the [infrastructure repository](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-server) and uses the shared `dogfood` cluster (also used by [k8s.sgdev.org](#k8s-sgdev-org)).
+🚨 This deployment contains private code - for demos, use [demo.sourcegraph.com](https://demo.sourcegraph.com) instead.
 
-🚨 This deployment contains private code - do not use it for demos!
+This deployment runs the single-image version of Sourcegraph. It is deployed by the [infrastructure repository](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-server) and uses the shared `dogfood` cluster (also used by [k8s.sgdev.org](#k8s-sgdev-org)).
 
 - [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-f/dogfood?project=sourcegraph-dogfood)
   ```
@@ -46,3 +50,19 @@ This deployment runs the single-image version of Sourcegraph. It is deployed by 
   ```
 - [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-server)
 - [Infrastructure configuration](https://github.com/sourcegraph/infrastructure/tree/main/dogfood)
+
+## demo.sourcegraph.com
+
+This deployment is a [managed instance](../distribution/managed/index.md) used by Sourcegraph CE for demos.
+
+- [GCP project](https://console.cloud.google.com/home/dashboard?project=sourcegraph-managed-demo)
+- [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/master/demo)
+- [Operations](../distribution/managed/operations.md)
+
+## devmanaged.sourcegraph.com
+
+This deployment is a [managed instance](../distribution/managed/index.md) used by Distribution for experimenting with managed instances in general.
+
+- [GCP project](https://console.cloud.google.com/home/dashboard?project=sourcegraph-managed-dev)
+- [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/master/dev)
+- [Operations](../distribution/managed/operations.md)


### PR DESCRIPTION
Add managed instances that we manage for ourselves. It's a bit scant for now, but can come back to add more details if needed