### PR TITLE
add backlog section for discussion

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -51,9 +51,9 @@ TypeScript, React, RxJS, GraphQL, Go.
 
 The web team keeps a [backlog Github project board](https://github.com/orgs/sourcegraph/projects/98). 
 
-We own and control what gets added to the board. We use the backlog for tracking bugs and small fixes. We don't use the backlog for tracking work that is expressly planned in our [roadmap](../../product/roadmap.md#web). (Note: the backlog is fairly new and this process is still developing.) 
+We use the backlog for tracking bugs, small features, and unplanned work. We don't use the backlog for tracking work that is expressly planned in our [roadmap](../../product/roadmap.md#web).
 
-Unless you're directly asked, only web team members should add issues to this backlog board. To ensure your issue is seen, tag the issue with `team/web`. A web team member will see this, confirm the issue is web team-related, and then add it to the appropriate column in the backlog. 
+To add an issue, tag it `team/web` to notify the web team PM and put it in the "to triage" column of the board. Unless you're directly asked, only web team members should move issues out of the "to triage" column on the board. A web team member will confirm the issue is web team-related, and then move it to the appropriate column. 
 
 ### Iterations
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -47,6 +47,14 @@ TypeScript, React, RxJS, GraphQL, Go.
 
 ## Processes
 
+### Backlog
+
+The web team keeps a [backlog Github project board](https://github.com/orgs/sourcegraph/projects/98). 
+
+We own and control what gets added to the board. We use the backlog for tracking bugs and small fixes. We don't use the backlog for tracking work that is expressly planned in our [roadmap](../../product/roadmap.md#web). (Note: the backlog is fairly new and this process is still developing.) 
+
+Unless you're directly asked, only web team members should add issues to this backlog board. To ensure your issue is seen, tag the issue with `team/web`. A web team member will see this, confirm the issue is web team-related, and then add it to the appropriate column in the backlog. 
+
 ### Iterations
 
 We plan our work in **2-week iterations**.


### PR DESCRIPTION
@sourcegraph/web realized this wasn't documented after @AlicjaSuska asked me about adding a code insights issue to our backlog. Obviously, the whole backlog process is new for us and we can iterate regardless of what we decide here. 

(This is non-urgent and perhaps something to discuss in our sync tomorrow.)

One question I have on ownership: 
- Should we own the backlog (so, others create issues and label `team/web` and only we then add to backlog whenever we see, to verify they're actually web team issues)? 
- Should just *I* own adding to the backlog? One reason for this – if you add something to 'to triage' I might not know it was added, unless I also track all new team/web issues (which I am currently) so I don't see too much purpose in asking you to take time to add it to 'to triage' if I still have to look at the issue anyway. It would still be helpful for me if you see a team/web issue that's not actually team/web in the codebase that you tag/comment as much, like Felix did [here](https://github.com/sourcegraph/sourcegraph/issues/11461#issuecomment-710467575).  
- Do we want people adding things to 'to triage' even if those people aren't on the web team (and I'll still use the 'team/web' notification I get in order to not miss triaging anything)? 

And one more on overall purpose: 

I created this for "slack time" (bugs, small issues, things we could work on that aren't RFC-level or big projects that ought to have multiple issues). I still think that makes sense. **Does that mean we want or need a separate board to track our roadmap?** (Do we feel a need to have code insights, extensions improvements, etc on a board even when we're not actively working on them? Do we feel this would help other teams beyond having them in our roadmap?) 

My preference on that question is "no;" basically "backlog = small bugs/issues we can work on as need be," "iteration board = detail view of what we're currently working on," "roadmap = things we plan to work on but aren't broken up into details because we're not working on them yet." I'd rather not maintain a board to just map against the roadmap – if anything gets added to one it should be added to the other anyway. Nor do I feel like we need a combined single board – I think you all know well when to work off our iteration board vs when to grab something from the backlog. 

(In the case of "should we have a code insights issue on a board somewhere" I've told Alicja at the moment that I think when it's a "single issue" it belongs more on a product+design board rather than our boards.) 