### PR TITLE
releases: proceed to final tag as fast as possible

### DIFF
--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -40,7 +40,7 @@ Upon branch cut, cut and test the first release candidate:
   yarn run release release:create-candidate $MAJOR.$MINOR.0-rc.1
   ```
 - [ ] Run regression tests:
-  - [ ] Follow [README.md](https://github.com/sourcegraph/sourcegraph/blob/main/web/src/regression/README.md) to set up your e2e environment. 
+  - [ ] Follow the [Regression tests guide](https://github.com/sourcegraph/sourcegraph/blob/main/client/web/src/regression/README.md) to set up your e2e environment. 
         Run the tests from the `web` directory. A more complete set of env vars can be found in this
         [1password](https://team-sourcegraph.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/gm5dfflq6sfclmotneuayfdj5q) entry.
   - [ ] New Sourcegraph Docker container:

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -31,9 +31,8 @@ Arguments:
   ```
 - [ ] Create the `$MAJOR.$MINOR` branch off the CHANGELOG commit in the previous step: `git branch $MAJOR.$MINOR && git push origin $MAJOR.$MINOR`.
 
-## Release candidates
 
-Upon branch cut, cut and test the first release candidate:
+Upon branch cut, create and test the first release candidate:
 
 - [ ] Tag the first release candidate:
   ```
@@ -52,9 +51,9 @@ Upon branch cut, cut and test the first release candidate:
   - [ ] New Sourcegraph Kubernetes cluster:
     - Run the initializer on a new Sourcegraph Kubernetes cluster.
     - Run the regression test suite.
-- [ ] File any regressions as `release-blocker` issues.
+- [ ] File any regressions as `release-blocker` issues and assign the appropriate teams.
 
-Revert or disable features that may cause delays. As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch. Continue to cut new release candidates daily as necessary, until no more `release-blocker` issues remain:
+Revert or disable features that may cause delays. As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch. Continue to create new release candidates daily or as necessary, until no more `release-blocker` issues remain:
 
 - [ ] Cut the Nth release candidate:
   ```
@@ -63,7 +62,7 @@ Revert or disable features that may cause delays. As necessary, `git cherry-pick
 - [ ] Re-run the automated test suite against the new release candidate, file any regressions as
   `release-blocker` issues.
   - [ ] If necessary, manually test features or workflows affected by the cherry-pick.
-- [ ] Post a release status update to Slack - review all release-blocking issues, and ensure someone is resolving each. If there are no more release-blocking issues, proceed to the next section.
+- [ ] Post a release status update by running the command below. Ensure someone is resolving each release-blocking issue. If there are no more release-blocking issues, proceed to tag the final release in the next section.
   ```
   yarn run release release:status $MAJOR.$MINOR.0
   ``` 

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -54,7 +54,7 @@ Upon branch cut, cut and test the first release candidate:
     - Run the regression test suite.
 - [ ] File any regressions as `release-blocker` issues.
 
-Aggressively revert or disable features that may cause delays. As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch. Continue to cut new release candidates daily as necessary, until no more `release-blocker` issues remain:
+Revert or disable features that may cause delays. As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch. Continue to cut new release candidates daily as necessary, until no more `release-blocker` issues remain:
 
 - [ ] Cut the Nth release candidate:
   ```

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -18,11 +18,10 @@ Arguments:
 
 ## $FIVE_WORKING_DAYS_BEFORE_RELEASE (5 work days before release): Prep for branch cut
 
-- [ ] Post a release status update to Slack:
+- [ ] Post a release status update to Slack - review all release-blocking issues, and ensure someone is resolving each.
   ```
   yarn run release release:status $MAJOR.$MINOR.0
   ``` 
-  - [ ] Review [all release-blocking issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Asourcegraph+label%3Arelease-blocker). Add them as checklist items here. Ensure someone is resolving each.
 
 ## $FOUR_WORKING_DAYS_BEFORE_RELEASE (4 work days before release): Branch cut
 
@@ -31,6 +30,11 @@ Arguments:
   yarn run release changelog:cut $MAJOR.$MINOR.0
   ```
 - [ ] Create the `$MAJOR.$MINOR` branch off the CHANGELOG commit in the previous step: `git branch $MAJOR.$MINOR && git push origin $MAJOR.$MINOR`.
+
+## Release candidates
+
+Upon branch cut, cut and test the first release candidate:
+
 - [ ] Tag the first release candidate:
   ```
   yarn run release release:create-candidate $MAJOR.$MINOR.0-rc.1
@@ -48,30 +52,25 @@ Arguments:
   - [ ] New Sourcegraph Kubernetes cluster:
     - Run the initializer on a new Sourcegraph Kubernetes cluster.
     - Run the regression test suite.
+- [ ] File any regressions as `release-blocker` issues.
 
-## $FOUR_WORKING_DAYS_BEFORE_RELEASE to $ONE_WORKING_DAY_BEFORE_RELEASE: Cut new release candidates
+Aggressively revert or disable features that may cause delays. As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch. Continue to cut new release candidates daily as necessary, until no more `release-blocker` issues remain:
 
-As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch.
-Aggressively revert or disable features that may cause delays.
-
-- [ ] Post a release status update to Slack:
-  ```
-  yarn run release release:status $MAJOR.$MINOR.0
-  ``` 
-  - [ ] Review [all release-blocking issues](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+archived%3Afalse+org%3Asourcegraph+label%3Arelease-blocker). Add them as checklist items here. Ensure someone is resolving each.
-  - [ ] Review [all other open issues in the milestone](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Asourcegraph+-label%3Arelease-blocker+milestone%3A$MAJOR.$MINOR) and ask assignees to triage them to a different milestone (preferring Backlog).
-
-Cut a new release candidate daily if necessary:
-
-- [ ] Cut release candidate:
+- [ ] Cut the Nth release candidate:
   ```
   N=<release-candidate-number> yarn run release release:create-candidate $MAJOR.$MINOR.0-rc.$N
   ```
 - [ ] Re-run the automated test suite against the new release candidate, file any regressions as
   `release-blocker` issues.
-- [ ] If necessary, manually test features or workflows affected by the cherry-pick.
+  - [ ] If necessary, manually test features or workflows affected by the cherry-pick.
+- [ ] Post a release status update to Slack - review all release-blocking issues, and ensure someone is resolving each. If there are no more release-blocking issues, proceed to the next section.
+  ```
+  yarn run release release:status $MAJOR.$MINOR.0
+  ``` 
 
-## $ONE_WORKING_DAY_BEFORE_RELEASE (1 work day before release) Tag final release
+## Tag final release
+
+Once there are no more release-blocking issues (as reported by the `release:status` command) proceed with creating the final release:
 
 - [ ] Tag the final release:
   ```
@@ -88,7 +87,6 @@ Cut a new release candidate daily if necessary:
   yarn run release release:publish $MAJOR.$MINOR.0
   ```
 - [ ] Create (but do not merge) a PR to update https://docs.sourcegraph.com/admin/updates/kubernetes indicating the steps required to upgrade.
-- [ ] Review [all issues in the release milestone](https://github.com/issues?utf8=%E2%9C%93&q=is%3Aopen+is%3Aissue+archived%3Afalse+org%3Asourcegraph+milestone%3A$MAJOR.$MINOR). Backlog things that didn't make it into the release and ping issues that still need to be done for the release (e.g. Tweets, marketing).
 
 ## $RELEASE_DATE by 10am: Release
 

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -87,7 +87,7 @@ Once there are no more release-blocking issues (as reported by the `release:stat
   ```
 - [ ] Create (but do not merge) a PR to update https://docs.sourcegraph.com/admin/updates/kubernetes indicating the steps required to upgrade.
 
-## $RELEASE_DATE by 10am: Release
+## $RELEASE_DATE: Release
 
 - [ ] Merge the release-publishing PRs created previously.
   - For [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph), also:


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/14911 by updating the instructions to indicate releases should proceed to a final tag as fast as possible.

Also removes steps about reviewing milestone tasks since that doesn't really seem to happen, and add a step to post a release status update whenever a candidate is cut (which will include links to blocking issues and milestone issues)