### PR TITLE
Move search plan from goals to roadmap, add more information for roadmap items

### DIFF
--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -75,7 +75,7 @@ _Updated 2020-09-11_
 - **Extend Search Query Language**
   - **Problem:** It is imperative that users can find and filter the code, files, repositories, and commits they care about in extremely large codebases.
   - **Outcomes:** Users can express relations on code, files, repositories, and commits in search queries to more effectively filter the data they need. Sourcegraph is the exclusive industrial-strength search solution that provides these capabilities.
-  - **Planned work** Search language rules engine
+  - **Planned work:** Search language rules engine
 
 ### Easy to use
 
@@ -95,6 +95,7 @@ _Updated 2020-09-11_
 - **Code monitoring** ([RFC 227](https://docs.google.com/document/d/1_R5DgpUkxyZilsJ9vBQm5cvRPT2udc3tZIPg2q3cnZU/edit))
   - **Problem:** Users want to be notified about important things going on in their code.
   - **Outcome:** Notifications create a shared understanding and raise awareness of what’s going on in the code.
+  - **Planned work:** Code monitoring version 1
 
 
 ## Contact

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -12,6 +12,10 @@ Sourcegraph search is:
 - **Easy to use:** Users can quickly understand how to find what they are looking for and what options are available for searching. The search syntax is clear and intuitive.
 - **Shareable:** Sourcegraph searches are easy to share, and provide team and organization wide value. This in turn creates network effects that compound the value Sourcegraph provides with scale.
 
+## Search Roadmap
+
+The search team's current roadmap can be found in [roadmap](./index.md#roadmap).
+
 ## Iterations
 
 The search team plans its work in **2-week iterations**.
@@ -44,7 +48,6 @@ Iterations start **every other Monday**.
     - The mid-iteration update should contain a forecast for the next week, and whether the remaining planned work is on track to be completed on time.
     - The end-of-iteration update should mention whether the planned outcomes were reached or not, and if not, why.
 
-
 ## Goals
 
 _Updated 2020-09-11_
@@ -54,10 +57,7 @@ _Updated 2020-09-11_
 - **Scale indexed search to 500k repositories**
    - **Problem:** We have customers who need Sourcegraph to scale to 500k repositories. Some parts of Sourcegraph don't work well at that scale.
    - **Outcome:** Sourcegraph can search 500k repositories in less than 300ms. This is on par with [grep.app](https://grep.app).
-   - **Plan:** Incrementally add repositories to Sourcegraph.com until searches get slow or start breaking. Fix those things. Then continue adding repositories.
-   - **Owners:** Keegan/Stefan
-   - **Status:** [In progress](perf.md)
-   - **Estimated completion**: 3.23 (End of December 2020)
+   - **Planned work:** Scaling indexed text search to 500k repositories
 
 ### Fast
 
@@ -66,45 +66,23 @@ _Updated 2020-09-11_
   - **Outcome:**
       - Unblock the ability to add responsive and fast-loading search results.
       - Return results faster for large result sets, e.g. indexed repositories in very large codebases.
-  - **Plan:** Streaming search
-  - **Owners:** Keegan, Juliana
-  - **Status:** In progress
-  - **Estimated completion:**
-    - ~~3.21~~ 2020-09-23 update: We revised this estimate after discussing needed work on the design & frontend side.
-    - 3.22
+  - **In progress work:** Streaming search
 
 ### Expressive
 
 - **Extend Search Query Language**
   - **Problem:** It is imperative that users can find and filter the code, files, repositories, and commits they care about in extremely large codebases.
   - **Outcomes:** Users can express relations on code, files, repositories, and commits in search queries to more effectively filter the data they need. Sourcegraph is the exclusive industrial-strength search solution that provides these capabilities.
-  - **Owner:** Rijnard
-  - **Status:** In progress
-  - **Plan**
-      - Implement a query language extension to express relations (i.e., rules) on code, files, repositories, and commits. This replaces awkward one-off filters like `repohasfile`, `repohascommitafter` that do not generalize.
-      - Prototype semantic search functionality that combines text search and LSIF data
-      - Implement quality-of-life features for search: syntax highlighting, multiline queries, improve structural search performance
-  - **Owner:** Rijnard/Stefan
-  - **Status:** Not started
-  - **Estimated start:** 3.21
-  - **Estimated effort:** 4 months
+  - **Planned work** Search language rules engine
 
 ### Easy to use
 
 - **Improve search experience**
   - **Problem:**
       - New users who are trying Sourcegraph for the first time have trouble learning the syntax and breadth of Sourcegraph features.
-          - **Plan:** Search onboarding tour
-          - **Owner:** Farhan
-          - **Status:** In progress
-          - **Estimated completion**:
-              - ~~3.20~~ 2020-09-22 update: not all bugs found during the initial round of user testing were fixed in 3.20
-              - 3.21
+          - **In progress work:** Search onboarding tour
       - It is hard for users to quickly get to code they care about.
-          - **Plan:** Enterprise homepage
-          - **Owner:** Farhan, Juliana
-          - **Status:** In progress
-         - **Estimated completion**: 3.21
+          - **In progress work:** Enterprise homepage
   - **Outcomes:**
      - New users introduced to Sourcegraph are able to quickly run searches that show them the value of Sourcegraph.
      - Users can run searches over code they care about more quickly.
@@ -115,16 +93,7 @@ _Updated 2020-09-11_
 - **Code monitoring** ([RFC 227](https://docs.google.com/document/d/1_R5DgpUkxyZilsJ9vBQm5cvRPT2udc3tZIPg2q3cnZU/edit))
   - **Problem:** Users want to be notified about important things going on in their code.
   - **Outcome:** Notifications create a shared understanding and raise awareness of what’s going on in the code.
-  - **Plan**
-      - Improved diff search performance
-      - Webhooks on search results
-          - Slack integration
-          - Zapier integration
-          - Email
-  - **Owner:** TBD
-  - **Status:** Not started
-  - **Estimated start:** 2020-11-02
-  - **Estimated effort:** 4 weeks
+
 
 ## Contact
 

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -12,9 +12,11 @@ Sourcegraph search is:
 - **Easy to use:** Users can quickly understand how to find what they are looking for and what options are available for searching. The search syntax is clear and intuitive.
 - **Shareable:** Sourcegraph searches are easy to share, and provide team and organization wide value. This in turn creates network effects that compound the value Sourcegraph provides with scale.
 
-## Search Roadmap
+## Roadmap
 
-The search team's current roadmap can be found in [roadmap](./index.md#roadmap).
+The search roadmap is driven by the team's [goals](#goals) and upcoming work is planned in [iterations](#iterations).
+
+The items on search roadmap can be found in [roadmap](./roadmap.md). 
 
 ## Iterations
 

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -14,9 +14,9 @@ Sourcegraph search is:
 
 ## Roadmap
 
-The search roadmap is driven by the team's [goals](#goals) and upcoming work is planned in [iterations](#iterations).
+The search roadmap is driven by the team's [goals](#goals) and the upcoming work is planned in [iterations](#iterations).
 
-The items on search roadmap can be found in [roadmap](./roadmap.md). 
+The roadmap items can be found in the [search roadmap](./roadmap.md). 
 
 ## Iterations
 

--- a/handbook/engineering/search/iteration_log.md
+++ b/handbook/engineering/search/iteration_log.md
@@ -1,4 +1,4 @@
-# Iteration log
+# Roadmap
 
 This document contains the goals and work log for the search team's [2-week iterations](./index.md#iterations).
 

--- a/handbook/engineering/search/iteration_log.md
+++ b/handbook/engineering/search/iteration_log.md
@@ -1,4 +1,4 @@
-# Roadmap
+# Iteration log
 
 This document contains the goals and work log for the search team's [2-week iterations](./index.md#iterations).
 

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -49,7 +49,7 @@ This document contains the search team's current roadmap. The items on the roadm
 #### 4. Scaling indexed text search to 500k repositories
    - **Plan:** Incrementally add repositories to Sourcegraph.com until searches get slow or start breaking. Fix those things. Then continue adding repositories.
    - **Owners:** Keegan/Stefan
-    - **Status:** [In progress](perf.md)
+   - **Status:** [In progress](perf.md)
    - **Estimated completion**: 3.23 (End of December 2020)
 
 #### 5. Streaming search 

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -1,6 +1,6 @@
 # Roadmap
 
-This document contains the search team's current roadmap. Items are described in more detail below. Work that's in progress has an owner(s), plan and timeline associated with it. 
+This document contains the search team's current roadmap. The items on the roadmap are described in detail below. Items have an owner(s), plan and timeline associated with it.
 
 1. 🔄 [Enterprise homepage](1-enterprise-homepage)
 1. 🔄 Search tour(2-search-tour)
@@ -30,32 +30,35 @@ This document contains the search team's current roadmap. Items are described in
 
 
 
-#### 1. 🔄 Enterprise homepage
+#### 1. Enterprise homepage
 - **Owner:** Farhan, Juliana
+- **Status:** Completed
 - **Estimated completion**: 3.21
          
-#### 2. 🔄 Search tour
+#### 2. Search tour
 - **Owner:** Farhan
+- **Status:** Completed
 - **Estimated completion**:
        - ~~3.20~~ 2020-09-22 update: not all bugs found during the initial round of user testing were fixed in 3.20
        - 3.21
        
-#### 3. 🔄 Search expressions
+#### 3. Search expressions
  - **Owner:** Rijnard
  - **Status:** In progress
 
-#### 4. 🔄 Scaling indexed text search to 500k repositories
+#### 4. Scaling indexed text search to 500k repositories
    - **Plan:** Incrementally add repositories to Sourcegraph.com until searches get slow or start breaking. Fix those things. Then continue adding repositories.
    - **Owners:** Keegan/Stefan
-   - **Status:** (perf.md)
+    - **Status:** [In progress](perf.md)
    - Planned work
     -- code monitoring -- description
     -- diff/commit search --- 
    - **Estimated completion**: 3.23 (End of December 2020)
 
-#### 5. 🔄 Streaming search 
+#### 5. Streaming search 
   - **Plan:** Streaming search
   - **Owners:** Keegan, Juliana
+  - **Status:** In progress
   - **Estimated completion:**
     - ~~3.21~~ 2020-09-23 update: We revised this estimate after discussing needed work on the design & frontend side.
     - 3.22

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -50,9 +50,6 @@ This document contains the search team's current roadmap. The items on the roadm
    - **Plan:** Incrementally add repositories to Sourcegraph.com until searches get slow or start breaking. Fix those things. Then continue adding repositories.
    - **Owners:** Keegan/Stefan
     - **Status:** [In progress](perf.md)
-   - Planned work
-    -- code monitoring -- description
-    -- diff/commit search --- 
    - **Estimated completion**: 3.23 (End of December 2020)
 
 #### 5. Streaming search 
@@ -78,7 +75,7 @@ This document contains the search team's current roadmap. The items on the roadm
 
 #### 8. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
   - Consolidate the overlapping features for this experience - repogroups and search scope pages.
-  - Scoping your search to multiple repositories is intuitive and easy [issue](https://github.com/sourcegraph/sourcegraph/issues/10621
+  - Scoping your search to multiple repositories is intuitive and easy [issue](https://github.com/sourcegraph/sourcegraph/issues/10621)
 
 #### 9. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
   - Creating version context scopes manually is time consuming. Improve this user experience. [issue](https://github.com/sourcegraph/sourcegraph/issues/11569)
@@ -98,7 +95,7 @@ This document contains the search team's current roadmap. The items on the roadm
   
 #### 11. Saved searches without monitoring
   - Save or bookmark a search query you want to run again.
-  - Save a "composable query" or a query that can added on to the existing search query entered (i.e., improve (search scopes)[https://docs.sourcegraph.com/code_search/how-to/scopes]).
+  - Save a "composable query" or a query that can added on to the existing search query entered (i.e., improve [search scopes](https://docs.sourcegraph.com/code_search/how-to/scopes)).
   
 #### 12. Search results redesign
   - Search Tabs. Streaming search allows us to improve the search experience for each of these tabs.
@@ -107,7 +104,7 @@ This document contains the search team's current roadmap. The items on the roadm
   - more. scope TBD
   
 #### 13. Diff/commit search performance
-  - Diff/commit search performance works beyond the 50 repository limit (issue)[https://github.com/sourcegraph/sourcegraph/issues/6826].
+  - Diff/commit search performance works beyond the 50 repository limit [issue](https://github.com/sourcegraph/sourcegraph/issues/6826).
   - Support security use cases which require searching over code history, specifically commits and diffs.
   
 #### 14. Search input redesign

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -2,9 +2,9 @@
 
 This document contains the search team's current roadmap. The items on the roadmap are described in detail below. Items have an owner(s), plan and timeline associated with it.
 
-1. 🔄 [Enterprise homepage](1-enterprise-homepage)
-1. 🔄 Search tour(2-search-tour)
-1. 🔄 Search expressions(3-search-expressions)
+1. 🔄 Enterprise homepage
+1. 🔄 Search tour
+1. 🔄 Search expressions
 1. 🔄 Scaling indexed text search to 500k repositories
 1. 🔄 Streaming search
 1. Code monitoring (private code monitors, no sharing, emails + webhooks)

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -5,23 +5,23 @@ This document contains the search team's current roadmap.
 1. 🔄 [Enterprise homepage](#1-enterprise-homepage)
 1. 🔄 [Search tour](#2-search-tour)
 1. 🔄 [Search expressions](#3-search-expressions)
-1. 🔄 Scaling indexed text search to 500k repositories
-1. 🔄 Streaming search
-1. Code monitoring (private code monitors, no sharing, emails + webhooks)
-1. Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
-1. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
-1. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
-1. Search language rules engine
-1. Saved searches without monitoring
-1. Search results redesign
-1. Diff/commit search performance
-1. Search input redesign
-1. Structural search performance
-1. As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)
-1. Code monitoring (shareable)
-1. Semantic search: prototype validation
-1. External search result providers
-1. Semantic search: implementation
+1. 🔄 [Scaling indexed text search to 500k repositories](#4-scaling-indexed-text-search-to-500k-repositories)
+1. 🔄 [Streaming search](#5-streaming-search)
+1. [Code monitoring (private code monitors, no sharing, emails + webhooks)](#6-code-monitoring-version-1)
+1. [Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD](#7-performance-at-scale)
+1. [As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)](#8-search-expressions)
+1. [As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)](#9-search-expressions)
+1. [Search language rules engine](#10-search-language-rules-engine)
+1. [Saved searches without monitoring](#11-saved-searches-without-monitoring)
+1. [Search results redesign](#12-search-results-redesign)
+1. [Diff/commit search performance](#13-diffcommit-search-performance)
+1. [Search input redesign](#14-search-input-redesign)
+1. [Structural search performance](#15-structural-search-performance)
+1. [As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)](#16-as-a-user-i-can-create-a-scope-of-code-i-want-to-search-across-as-a-list-of-repositories-branches-that-should-be-indexed-better-version-contexts-22)
+1. [Code monitoring (shareable)](#17-code-monitoring-version-2)
+1. [Semantic search: prototype validation](#18-semantic-search-prototype-validation)
+1. [External search result providers](#19-external-search-result-providers)
+1. [Semantic search: implementation](#20-semantic-search-implementation)
 
 
 

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -1,10 +1,10 @@
 # Roadmap
 
-This document contains the search team's current roadmap. The items on the roadmap are described in detail below. Items have an owner(s), plan and timeline associated with it.
+This document contains the search team's current roadmap. 
 
 1. 🔄 [Enterprise homepage](#1-enterprise-homepage)
 1. 🔄 [Search tour](#2-search-tour)
-1. 🔄 Search expressions
+1. 🔄 [Search expressions](#3-search-expressions)
 1. 🔄 Scaling indexed text search to 500k repositories
 1. 🔄 Streaming search
 1. Code monitoring (private code monitors, no sharing, emails + webhooks)
@@ -75,10 +75,10 @@ This document contains the search team's current roadmap. The items on the roadm
 
 #### 8. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
   - Consolidate the overlapping features for this experience - repogroups and search scope pages.
-  - Scoping your search to multiple repositories is intuitive and easy [issue](https://github.com/sourcegraph/sourcegraph/issues/10621)
+  - Scoping your search to multiple repositories is intuitive and easy ([issue](https://github.com/sourcegraph/sourcegraph/issues/10621))
 
 #### 9. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
-  - Creating version context scopes manually is time consuming. Improve this user experience. [issue](https://github.com/sourcegraph/sourcegraph/issues/11569)
+  - Creating version context scopes manually is time consuming. Improve this user experience ([issue](https://github.com/sourcegraph/sourcegraph/issues/11569))
   - ToDo: consolidate user requests for a better search experience with version contexts set
 
 #### 10. Search language rules engine
@@ -98,19 +98,19 @@ This document contains the search team's current roadmap. The items on the roadm
   - Save a "composable query" or a query that can added on to the existing search query entered (i.e., improve [search scopes](https://docs.sourcegraph.com/code_search/how-to/scopes)).
   
 #### 12. Search results redesign
-  - Search Tabs. Streaming search allows us to improve the search experience for each of these tabs.
+  - Search Tabs 
   - Search results with sidebar
-  - Design refresh includes ability to copy the search result content and more.
-  - more. scope TBD
+  - Design refresh
+  - and more. scope TBD
   
 #### 13. Diff/commit search performance
-  - Diff/commit search performance works beyond the 50 repository limit [issue](https://github.com/sourcegraph/sourcegraph/issues/6826).
+  - Diff/commit search performance works beyond the 50 repository limit ([issue](https://github.com/sourcegraph/sourcegraph/issues/6826)).
   - Support security use cases which require searching over code history, specifically commits and diffs.
   
 #### 14. Search input redesign
-  - Reduce business in the search bar.
-  - Search Expressions work as expected
-  - more. scope TBD
+  - Reduce business in the search bar
+  - Search Expressions are supported
+  - and more. scope TBD
 
 #### 15. Structural search performance
   - Structural search is a good experience for larger-scale code bases and cloud users.
@@ -124,7 +124,6 @@ This document contains the search team's current roadmap. The items on the roadm
   - Plan below should be updated based on learnings from user testing code monitoring version 1.
   - **Plan**
     - Organization level code monitors
-    - More information (e.g. search result content) is exposed in the notification message 
                 
 #### 18. Semantic search: prototype validation
   - Referencing precise code intelligence (e.g. usages, definition) in search

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -8,17 +8,21 @@ This document contains the search team's current roadmap.
 1. 🔄 [Scaling indexed text search to 500k repositories](#4-scaling-indexed-text-search-to-500k-repositories)
 1. 🔄 [Streaming search](#5-streaming-search)
 1. [Code monitoring (private code monitors, no sharing, emails + webhooks)](#6-code-monitoring-version-1)
-1. [Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD](#7-performance-at-scale)
-1. [As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)](#8-search-expressions)
-1. [As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)](#9-search-expressions)
+1. [Performance at scale](#7-performance-at-scale)
+follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
+1. [Consolidate repogroups + search scopes](#8-consolidate-repogroups-search-scopes)
+as a user, I can create a scope of code I want to search across as a list of repositories 
+1. [Better version contexts 1/2](#9-better-version-contexts-12)
+as a user, I can create a scope of code I want to search across as a list of repositories + branches
 1. [Search language rules engine](#10-search-language-rules-engine)
 1. [Saved searches without monitoring](#11-saved-searches-without-monitoring)
 1. [Search results redesign](#12-search-results-redesign)
 1. [Diff/commit search performance](#13-diffcommit-search-performance)
 1. [Search input redesign](#14-search-input-redesign)
 1. [Structural search performance](#15-structural-search-performance)
-1. [As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)](#16-as-a-user-i-can-create-a-scope-of-code-i-want-to-search-across-as-a-list-of-repositories-branches-that-should-be-indexed-better-version-contexts-22)
-1. [Code monitoring (shareable)](#17-code-monitoring-version-2)
+1. [Better version contexts 2/2](#16-better-version-contexts-22) 
+as a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed
+1. [Code monitoring version 2](#17-code-monitoring-version-2)
 1. [Semantic search: prototype validation](#18-semantic-search-prototype-validation)
 1. [External search result providers](#19-external-search-result-providers)
 1. [Semantic search: implementation](#20-semantic-search-implementation)
@@ -71,13 +75,16 @@ This document contains the search team's current roadmap.
   - **Estimated start:** 2020-11-02
   - **Estimated effort:** 4 weeks
   
-#### 7. Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
+#### 7. Performance at scale 
+Follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
 
-#### 8. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
+#### 8. Consolidate repogroups + search scopes
+As a user, I can create a scope of code I want to search across as a list of repositories
   - Consolidate the overlapping features for this experience - repogroups and search scope pages.
   - Scoping your search to multiple repositories is intuitive and easy ([issue](https://github.com/sourcegraph/sourcegraph/issues/10621))
 
-#### 9. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
+#### 9. Better version contexts 1/2
+As a user, I can create a scope of code I want to search across as a list of repositories + branches
   - Creating version context scopes manually is time consuming. Improve this user experience ([issue](https://github.com/sourcegraph/sourcegraph/issues/11569))
   - ToDo: consolidate user requests for a better search experience with version contexts set
 
@@ -116,7 +123,8 @@ This document contains the search team's current roadmap.
   - Structural search is a good experience for larger-scale code bases and cloud users.
   - Structural search supports security use cases that require returning exhaustive search results, i.e., every result from the entire set of code they care about.
 
-#### 16. As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)
+#### 16. Better version contexts 2/2
+As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed
   - Improve the speed for unindexed code (e.g. diffs, commits) in the version context scopes they want to search over.
 
 #### 17. Code monitoring version 2

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -1,6 +1,34 @@
 # Roadmap
 
-This document contains the search team's current roadmap. 
+This document contains the search team's current roadmap. Items are described in more detail below. Work that's in progress has an owner(s), plan and timeline associated with it. 
+
+1. 🔄 [Enterprise homepage](1-enterprise-homepage)
+1. 🔄 Search tour(2-search-tour)
+1. 🔄 Search expressions(3-search-expressions)
+1. 🔄 Scaling indexed text search to 500k repositories
+1. 🔄 Streaming search
+1. Code monitoring (private code monitors, no sharing, emails + webhooks)
+1. Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
+1. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
+1. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
+1. Search language rules engine
+1. Saved searches without monitoring
+1. Search results redesign
+1. Diff/commit search performance
+1. Search input redesign
+1. Structural search performance
+1. As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)
+1. Code monitoring (shareable)
+1. Semantic search: prototype validation
+1. External search result providers
+1. Semantic search: implementation
+
+
+
+
+
+
+
 
 #### 1. 🔄 Enterprise homepage
 - **Owner:** Farhan, Juliana
@@ -11,7 +39,11 @@ This document contains the search team's current roadmap.
 - **Estimated completion**:
        - ~~3.20~~ 2020-09-22 update: not all bugs found during the initial round of user testing were fixed in 3.20
        - 3.21
+       
 #### 3. 🔄 Search expressions
+ - **Owner:** Rijnard
+ - **Status:** In progress
+
 #### 4. 🔄 Scaling indexed text search to 500k repositories
    - **Plan:** Incrementally add repositories to Sourcegraph.com until searches get slow or start breaking. Fix those things. Then continue adding repositories.
    - **Owners:** Keegan/Stefan
@@ -20,23 +52,35 @@ This document contains the search team's current roadmap.
     -- code monitoring -- description
     -- diff/commit search --- 
    - **Estimated completion**: 3.23 (End of December 2020)
+
 #### 5. 🔄 Streaming search 
- - **Plan:** Streaming search
+  - **Plan:** Streaming search
   - **Owners:** Keegan, Juliana
   - **Estimated completion:**
     - ~~3.21~~ 2020-09-23 update: We revised this estimate after discussing needed work on the design & frontend side.
     - 3.22
-#### 6. Code monitoring v1
-      - **Plan**
-          - Private / Individual code monitors
-          - Email and Webhooks Support
-      - **Owner:** Juliana, Stefan
-      - **Status:** Not started
-      - **Estimated start:** 2020-11-02
-      - **Estimated effort:** 4 weeks
+
+#### 6. Code monitoring version 1
+  - Code monitoring sends users notifications for new search results in channels outside of Sourcegraph.
+  - Improve email notification support and expand the types of notification channels available.
+  - **Plan**
+    - Personal code monitors (no organization level monitors in v1)
+    - Email and Webhooks Support
+  - **Owner:** Juliana, Stefan
+  - **Status:** Not started
+  - **Estimated start:** 2020-11-02
+  - **Estimated effort:** 4 weeks
+  
 #### 7. Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
+
 #### 8. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
+  - Consolidate the overlapping features for this experience - repogroups and search scope pages.
+  - Scoping your search to multiple repositories is intuitive and easy [issue](https://github.com/sourcegraph/sourcegraph/issues/10621
+
 #### 9. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
+  - Creating version context scopes manually is time consuming. Improve this user experience. [issue](https://github.com/sourcegraph/sourcegraph/issues/11569)
+  - ToDo: consolidate user requests for a better search experience with version contexts set
+
 #### 10. Search language rules engine
   - **Owner:** Rijnard
   - **Status:** In progress
@@ -48,26 +92,49 @@ This document contains the search team's current roadmap.
   - **Status:** Not started
   - **Estimated start:** 3.21
   - **Estimated effort:** 4 months
+  
 #### 11. Saved searches without monitoring
+  - Save or bookmark a search query you want to run again.
+  - Save a "composable query" or a query that can added on to the existing search query entered (i.e., improve (search scopes)[https://docs.sourcegraph.com/code_search/how-to/scopes]).
+  
 #### 12. Search results redesign
-      - 
+  - Search Tabs. Streaming search allows us to improve the search experience for each of these tabs.
+  - Search results with sidebar
+  - Design refresh includes ability to copy the search result content and more.
+  - more. scope TBD
+  
 #### 13. Diff/commit search performance
-      - requested by customers -  issue
-      - important for code monitors
-      - security use case search over code history / commits
+  - Diff/commit search performance works beyond the 50 repository limit (issue)[https://github.com/sourcegraph/sourcegraph/issues/6826].
+  - Support security use cases which require searching over code history, specifically commits and diffs.
+  
 #### 14. Search input redesign
+  - Reduce business in the search bar.
+  - Search Expressions work as expected
+  - more. scope TBD
 
 #### 15. Structural search performance
+  - Structural search is a good experience for larger-scale code bases and cloud users.
+  - Structural search supports security use cases that require returning exhaustive search results, i.e., every result from the entire set of code they care about.
 
 #### 16. As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)
-#### 17. Code monitoring v2
-       - Update based on learnings gained from user testing v1
-       - Sharing monitors within an organization 
+  - Improve the speed for unindexed code (e.g. diffs, commits) in the version context scopes they want to search over.
+
+#### 17. Code monitoring version 2
+  - Code monitoring sends users notifications for new search results in channels outside of Sourcegraph.
+  - Plan below should be updated based on learnings from user testing code monitoring version 1.
+  - **Plan**
+    - Organization level code monitors
+    - More information (e.g. search result content) is exposed in the notification message 
+                
 #### 18. Semantic search: prototype validation
-       - Reference precise code intelligence data in search
+  - Referencing precise code intelligence (e.g. usages, definition) in search
+  - **Plan**
+    - Build a prototype to validate the idea
+  
 #### 19. External search result providers
-       - Ability to search over issue trackers, internal tools, etc.
-       - First set of providers is likely extensions 
+  - Ability to search over data from issue trackers, internal tools, etc.
+  - The first set of providers is likely Sourcegraph [extensions](https://sourcegraph.com/extensions)
+  
 #### 20. Semantic search: implementation
-       - Reference precise code intelligence data in search
+  - Referencing precise code intelligence (e.g. usages, definition) in search
 

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -2,8 +2,8 @@
 
 This document contains the search team's current roadmap. The items on the roadmap are described in detail below. Items have an owner(s), plan and timeline associated with it.
 
-1. 🔄 Enterprise homepage
-1. 🔄 Search tour
+1. 🔄 [Enterprise homepage](#1-enterprise-homepage)
+1. 🔄 [Search tour](#2-search-tour)
 1. 🔄 Search expressions
 1. 🔄 Scaling indexed text search to 500k repositories
 1. 🔄 Streaming search

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -2,33 +2,31 @@
 
 This document contains the search team's current roadmap. 
 
-1. 🔄 Enterprise homepage
-       - **Owner:** Farhan, Juliana
-          - **Status:** In progress
-         - **Estimated completion**: 3.21
-1. 🔄 Search tour
-    - **Owner:** Farhan
-          - **Status:** In progress
-          - **Estimated completion**:
-              - ~~3.20~~ 2020-09-22 update: not all bugs found during the initial round of user testing were fixed in 3.20
-              - 3.21
-1. 🔄 Search expressions
-1. 🔄 Scaling indexed text search to 500k repositories
+#### 1. 🔄 Enterprise homepage
+- **Owner:** Farhan, Juliana
+- **Estimated completion**: 3.21
+         
+#### 2. 🔄 Search tour
+- **Owner:** Farhan
+- **Estimated completion**:
+       - ~~3.20~~ 2020-09-22 update: not all bugs found during the initial round of user testing were fixed in 3.20
+       - 3.21
+#### 3. 🔄 Search expressions
+#### 4. 🔄 Scaling indexed text search to 500k repositories
    - **Plan:** Incrementally add repositories to Sourcegraph.com until searches get slow or start breaking. Fix those things. Then continue adding repositories.
    - **Owners:** Keegan/Stefan
-   - **Status:** [In progress](perf.md)
+   - **Status:** (perf.md)
    - Planned work
     -- code monitoring -- description
     -- diff/commit search --- 
    - **Estimated completion**: 3.23 (End of December 2020)
-1. 🔄 Streaming search 
+#### 5. 🔄 Streaming search 
  - **Plan:** Streaming search
   - **Owners:** Keegan, Juliana
-  - **Status:** In progress
   - **Estimated completion:**
     - ~~3.21~~ 2020-09-23 update: We revised this estimate after discussing needed work on the design & frontend side.
     - 3.22
-1. Code monitoring v1
+#### 6. Code monitoring v1
       - **Plan**
           - Private / Individual code monitors
           - Email and Webhooks Support
@@ -36,10 +34,10 @@ This document contains the search team's current roadmap.
       - **Status:** Not started
       - **Estimated start:** 2020-11-02
       - **Estimated effort:** 4 weeks
-1. Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
-1. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
-1. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
-1. Search language rules engine
+#### 7. Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
+#### 8. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
+#### 9. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
+#### 10. Search language rules engine
   - **Owner:** Rijnard
   - **Status:** In progress
   - **Plan**
@@ -50,18 +48,26 @@ This document contains the search team's current roadmap.
   - **Status:** Not started
   - **Estimated start:** 3.21
   - **Estimated effort:** 4 months
-1. Saved searches without monitoring
-1. Search results redesign
-1. Diff/commit search performance
-1. Search input redesign
-1. Structural search performance
-1. As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)
-1. Code monitoring v2
-       - Learn from user testing private monitors
-       - Diff/commit search performance, 
-       - Sharing monitors in organization, 
-       - Improve notification message 
-1. Semantic search: prototype validation
-1. External search result providers
-1. Semantic search: implementation
+#### 11. Saved searches without monitoring
+#### 12. Search results redesign
+      - 
+#### 13. Diff/commit search performance
+      - requested by customers -  issue
+      - important for code monitors
+      - security use case search over code history / commits
+#### 14. Search input redesign
+
+#### 15. Structural search performance
+
+#### 16. As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)
+#### 17. Code monitoring v2
+       - Update based on learnings gained from user testing v1
+       - Sharing monitors within an organization 
+#### 18. Semantic search: prototype validation
+       - Reference precise code intelligence data in search
+#### 19. External search result providers
+       - Ability to search over issue trackers, internal tools, etc.
+       - First set of providers is likely extensions 
+#### 20. Semantic search: implementation
+       - Reference precise code intelligence data in search
 

--- a/handbook/engineering/search/roadmap.md
+++ b/handbook/engineering/search/roadmap.md
@@ -1,0 +1,67 @@
+# Roadmap
+
+This document contains the search team's current roadmap. 
+
+1. 🔄 Enterprise homepage
+       - **Owner:** Farhan, Juliana
+          - **Status:** In progress
+         - **Estimated completion**: 3.21
+1. 🔄 Search tour
+    - **Owner:** Farhan
+          - **Status:** In progress
+          - **Estimated completion**:
+              - ~~3.20~~ 2020-09-22 update: not all bugs found during the initial round of user testing were fixed in 3.20
+              - 3.21
+1. 🔄 Search expressions
+1. 🔄 Scaling indexed text search to 500k repositories
+   - **Plan:** Incrementally add repositories to Sourcegraph.com until searches get slow or start breaking. Fix those things. Then continue adding repositories.
+   - **Owners:** Keegan/Stefan
+   - **Status:** [In progress](perf.md)
+   - Planned work
+    -- code monitoring -- description
+    -- diff/commit search --- 
+   - **Estimated completion**: 3.23 (End of December 2020)
+1. 🔄 Streaming search 
+ - **Plan:** Streaming search
+  - **Owners:** Keegan, Juliana
+  - **Status:** In progress
+  - **Estimated completion:**
+    - ~~3.21~~ 2020-09-23 update: We revised this estimate after discussing needed work on the design & frontend side.
+    - 3.22
+1. Code monitoring v1
+      - **Plan**
+          - Private / Individual code monitors
+          - Email and Webhooks Support
+      - **Owner:** Juliana, Stefan
+      - **Status:** Not started
+      - **Estimated start:** 2020-11-02
+      - **Estimated effort:** 4 weeks
+1. Performance at scale: follow-up to “scale indexed text search to 500k repositories”, focus and scope TBD
+1. As a user, I can create a scope of code I want to search across as a list of repositories (consolidate repogroups + search scopes)
+1. As a user, I can create a scope of code I want to search across as a list of repositories + branches (better version contexts 1/2)
+1. Search language rules engine
+  - **Owner:** Rijnard
+  - **Status:** In progress
+  - **Plan**
+      - Implement a query language extension to express relations (i.e., rules) on code, files, repositories, and commits. This replaces awkward one-off filters like `repohasfile`, `repohascommitafter` that do not generalize.
+      - Prototype semantic search functionality that combines text search and LSIF data
+      - Implement quality-of-life features for search: syntax highlighting, multiline queries, improve structural search performance
+  - **Owner:** Rijnard/Stefan
+  - **Status:** Not started
+  - **Estimated start:** 3.21
+  - **Estimated effort:** 4 months
+1. Saved searches without monitoring
+1. Search results redesign
+1. Diff/commit search performance
+1. Search input redesign
+1. Structural search performance
+1. As a user, I can create a scope of code I want to search across as a list of repositories + branches that should be indexed (better version contexts 2/2)
+1. Code monitoring v2
+       - Learn from user testing private monitors
+       - Diff/commit search performance, 
+       - Sharing monitors in organization, 
+       - Improve notification message 
+1. Semantic search: prototype validation
+1. External search result providers
+1. Semantic search: implementation
+


### PR DESCRIPTION
Currently our goals and roadmap items intersect. The goals should explain the why and the roadmap the how.

To make this clearer, as a first step, I’ve moved the plan details from the goals section to under each roadmap item. Additionally, I’ve split out the roadmap into it’s own page and started adding more information for each roadmap item.

To Do:
[WIP] Continue adding color for each roadmap item.
The goals themselves need to be refined.
Add sizing for roadmap items.

