### PR TITLE
Add evaluating values to hiring process

### DIFF
--- a/handbook/people-ops/hiring/evaluating_values.md
+++ b/handbook/people-ops/hiring/evaluating_values.md
@@ -2,27 +2,17 @@
 
 We expect every teammate, team, and our company to live up to the [Sourcegraph values](../../../company/values.md). It is therefore important that we evaluate every candidate on the values to determine how successful they will be within Sourcegraph.
 
-It is the responsibility of every interviewer to think about these values when interviewing a candidate. When submitting feedback for a candidate, copy the list of values into your notes and score the candidate out of 5 based on the rubric.
+We are actively working on creating a formal process for values interviewing ([Ops RFC 7](https://docs.google.com/document/d/1d1a53dEP-k5Qsjv7BOAGq9lg4RL4Br7wg-weglJjHwY/edit)) to create a structured set of questions that are used consistently across the organization to evaluate value alignment.
 
 ## Rubric
 
+In the short-term, the Product team is experimenting with having a values score card inside of feedback forms that uses the following rubric:
+
 | Score | Description |
 | --- | --- |
-| -1 | Exhibited behavior that is contrary to this value. |
-| 0 | No evidence towards or against this value (neutral). |
-| 1 | Demonstrated this value with evidence. |
-| 2 | Exceptionally demonstrated this value, with abundant evidence. |
+| 👎👎 | Exhibited behavior that is contrary to this value. |
+| 👎 | No evidence towards or against this value (neutral). |
+| 👍 | Demonstrated this value with evidence. |
+| 👍👍 | Exceptionally demonstrated this value, with abundant evidence. |
 
-## Values to copy into feedback
-
-Use this plaintext format for easy addition to the Lever feedback area.
-
-```markdown
-- Be customer driven:
-- Work as a team:
-- High agency:
-- High quality:
-- Open and transparent:
-- Continuously grow:
-- Be a good human:
-```
+There is a text box for filling in any notes about the above value ratings.

--- a/handbook/people-ops/hiring/evaluating_values.md
+++ b/handbook/people-ops/hiring/evaluating_values.md
@@ -1,0 +1,29 @@
+# Evaluating values in an interview
+
+We expect every teammate, team, and our company to live up to the [Sourcegraph values](../../../company/values.md). It is therefore important taht we evaluate every candidate on the values to determin how successful they will be within Sourcegraph.
+
+It is the responsibility of every interviewer to think about these values when interviewing a candidate. When submitting feedback for a candidate, copy the list of values into your notes and score the candidate out of 5 based on the rubric.
+
+## Rubric
+
+Scored out of 5:
+
+- 1 - Exhibited behavior that is contrary to this value
+- 2 - I did not have any evidence towards or against this value (neutral)
+- 3 - Gave the impression they have this value, but lacking evidence
+- 4 - Demonstrated this value with evidence
+- 5 - Exceptionally demonstrated this value, with abundent evidence
+
+## Values to copy into feedback
+
+Use this plaintext format for easy addition to the Lever feedback area.
+
+```markdown
+- Be customer driven:
+- Work as a team:
+- High agency:
+- High quality:
+- Open and transparent:
+- Continuously grow:
+- Be a good human:
+```

--- a/handbook/people-ops/hiring/evaluating_values.md
+++ b/handbook/people-ops/hiring/evaluating_values.md
@@ -1,6 +1,6 @@
 # Evaluating values in an interview
 
-We expect every teammate, team, and our company to live up to the [Sourcegraph values](../../../company/values.md). It is therefore important taht we evaluate every candidate on the values to determin how successful they will be within Sourcegraph.
+We expect every teammate, team, and our company to live up to the [Sourcegraph values](../../../company/values.md). It is therefore important that we evaluate every candidate on the values to determine how successful they will be within Sourcegraph.
 
 It is the responsibility of every interviewer to think about these values when interviewing a candidate. When submitting feedback for a candidate, copy the list of values into your notes and score the candidate out of 5 based on the rubric.
 

--- a/handbook/people-ops/hiring/evaluating_values.md
+++ b/handbook/people-ops/hiring/evaluating_values.md
@@ -6,13 +6,12 @@ It is the responsibility of every interviewer to think about these values when i
 
 ## Rubric
 
-Scored out of 5:
-
-- 1 - Exhibited behavior that is contrary to this value
-- 2 - I did not have any evidence towards or against this value (neutral)
-- 3 - Gave the impression they have this value, but lacking evidence
-- 4 - Demonstrated this value with evidence
-- 5 - Exceptionally demonstrated this value, with abundent evidence
+| Score | Description |
+| --- | --- |
+| -1 | Exhibited behavior that is contrary to this value. |
+| 0 | No evidence towards or against this value (neutral). |
+| 1 | Demonstrated this value with evidence. |
+| 2 | Exceptionally demonstrated this value, with abundant evidence. |
 
 ## Values to copy into feedback
 

--- a/handbook/people-ops/hiring/evaluating_values.md
+++ b/handbook/people-ops/hiring/evaluating_values.md
@@ -10,9 +10,11 @@ In the short-term, the Product team is experimenting with having a values score 
 
 | Score | Description |
 | --- | --- |
-| 👎👎 | Exhibited behavior that is contrary to this value. |
-| 👎 | No evidence towards or against this value (neutral). |
+| 👎👎 | Abundant evidence that this person 's behavior isn't aligned with this value. |
+| 👎 | Evidence that this person 's behavior isn't aligned with this value.  |
 | 👍 | Demonstrated this value with evidence. |
 | 👍👍 | Exceptionally demonstrated this value, with abundant evidence. |
 
 There is a text box for filling in any notes about the above value ratings.
+
+If your interview did not get signal on a value (or if you got conflicting signals), then you can choose to not rate the value and instead share your thoughts in the open text box.

--- a/handbook/people-ops/hiring/interview_process.md
+++ b/handbook/people-ops/hiring/interview_process.md
@@ -51,6 +51,10 @@ Your feedback should contain two parts:
 
 You can interleave these together, or leave the assessment for the end, whichever you prefer.
 
+### Evaluating values
+
+Every interviewer should be evaluating candidates on the Sourcegraph values in addition to their specific interview topic. See more at [evaluating values](evaluating_values.md).
+
 ### Rating
 
 - **Strong positive**. You are confident that this person would make our team better and you would be excited to have the chance to work with them.


### PR DESCRIPTION
I think we should immediately start having every interviewer follow this process. 

@withdavidli - is it possible to add this as a separate section/field? It would be better if we didn't have to copy and paste every time.