### PR TITLE
Update the Cloud team goals, milestones, roadmap

### DIFF
--- a/company/goals/index.md
+++ b/company/goals/index.md
@@ -30,7 +30,7 @@ See "[Guidelines for goals](guidelines.md)" for more information about how we ch
 <!-- When updating the engineering team list below, please also update handbook/index.md. -->
 ### [Engineering leadership](../../handbook/engineering/leadership/index.md#goals)
 ### [Campaigns](../../handbook/engineering/campaigns/index.md#goals)
-### [Cloud](../../handbook/engineering/cloud/index.md#goals)
+### [Cloud](../../handbook/engineering/cloud/goals.md#goals)
 ### [Code intelligence](../../handbook/engineering/code-intelligence/index.md#goals)
 ### [Distribution](../../handbook/engineering/distribution/goals.md)
 ### [Search](../../handbook/engineering/search/index.md#goals)

--- a/handbook/engineering/cloud/goals.md
+++ b/handbook/engineering/cloud/goals.md
@@ -4,7 +4,7 @@
 
 1. **Make it work**: Build the backend blocking work, and expose it (even in a roughly usable way) to the Sourcegraph team. We will be able to quickly surface any glaring issues and will have more thoughts around usability. Take shortcuts where possible (this is currently due to the team having fewer frontend resources).
    - Where possible, making it work and usable should be combined (avoid duplicate efforts), but if it's possible to separate the two in order to move things forward, we should!
-1. **Make it usable**: The experience has been designed and thought through. We feel good about putting this in front of users, and they will find it valuable!
+1. **Make it smooth**: The experience has been designed and thought through. We feel good about putting this in front of users, and they will find it valuable!
 1. **Make it fast**: Now that users can try it, make sure the experience is fast for them (but it's better to have a slow working feature than a fast not-working one).
 1. **Make it scale**: Make it work at large scale. Up until now we have been starting to grow awareness of the feature, so the number of users is starting to matter. It is better to have high demand and need to surge on scalability than to make an infinitely scalable unused feature.
 

--- a/handbook/engineering/cloud/goals.md
+++ b/handbook/engineering/cloud/goals.md
@@ -1,4 +1,4 @@
-# Goals
+# Cloud goals and priorities
 
 ## Guiding principles
 
@@ -10,26 +10,19 @@
 
 ## Goals
 
-### User configured public code on Sourcegraph Cloud
+### Private code on Sourcegraph Cloud
 
-**Problem:** Sourcegraph Cloud proactively indexes and refreshes only a fixed set of public repositories (e.g., top 100k public repositories on GitHub.com). Code outside of this set is lazily updated when a user visits that repository, and is not stored in our search index. This does not allow individual users to search over all the code that they might care about (e.g., as user might have one or more of their own repositories that are not in the top 100k on GitHub.com).
+**Problem:** Customers who want to use Sourcegraph with their private code must setup and run a Sourcegraph instance on their own compute infrastructure. There are customers who want to use Sourcegraph but don't want to have to deploy and operate their own Sourcegraph instance and associated compute infrastructure. These customers expect to be able to search over only the code they care about, and are not inundated with public or irrelevant code. To host private code on Sourcegraph Cloud, we need to not only ensure the security of our product (which is important for on-premise deployments too), but we also have to ensure the security of our Sourcegraph Cloud infrastructure.
 
 **Milestones:**
 
-1. The Sourcegraph organization and team members can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
+1. ✅ The Sourcegraph organization and team members can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
    - Code is indexed.
-1. Any user can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
+1. 🔄 Any user can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
    - Connecting their first code host and adding their own public repos is intuitive and easy for new and existing users.
    - System activity and progress is easy to understand and doesn’t take too long.
      - Repo syncing
      - Repo indexing
-
-### Private code on Sourcegraph Cloud
-
-**Problem:** Customers who want to use Sourcegraph with their private code must setup and run a Sourcegraph instance on their own compute infrastructure. There are customers who want to use Sourcegraph but don't want to have to deploy and operate their own Sourcegraph instance and associated compute infrastructure. To host private code on Sourcegraph Cloud, we need to not only ensure the security of our product (which is important for on-premise deployments too), but we also have to ensure the security of our Sourcegraph Cloud infrastructure.
-
-**Milestones:**
-
 1. The Sourcegraph organization and team members can add private code to Sourcegraph Cloud.
    - No plaintext tokens or secrets anywhere (including gitserver .git/config remotes).
    - All private repository content are only decryptable by Sourcegraph services.

--- a/handbook/engineering/cloud/goals.md
+++ b/handbook/engineering/cloud/goals.md
@@ -1,0 +1,55 @@
+# Goals
+
+## Guiding principles
+
+1. **Make it work**: Build the backend blocking work, and expose it (even in a roughly usable way) to the Sourcegraph team. We will be able to quickly surface any glaring issues and will have more thoughts around usability. Take shortcuts where possible (this is currently due to the team having fewer frontend resources).
+   - Where possible, making it work and usable should be combined (avoid duplicate efforts), but if it's possible to separate the two in order to move things forward, we should!
+1. **Make it usable**: The experience has been designed and thought through. We feel good about putting this in front of users, and they will find it valuable!
+1. **Make it fast**: Now that users can try it, make sure the experience is fast for them (but it's better to have a slow working feature than a fast not-working one).
+1. **Make it scale**: Make it work at large scale. Up until now we have been starting to grow awareness of the feature, so the number of users is starting to matter. It is better to have high demand and need to surge on scalability than to make an infinitely scalable unused feature.
+
+## Goals
+
+### User configured public code on Sourcegraph Cloud
+
+**Problem:** Sourcegraph Cloud proactively indexes and refreshes only a fixed set of public repositories (e.g., top 100k public repositories on GitHub.com). Code outside of this set is lazily updated when a user visits that repository, and is not stored in our search index. This does not allow individual users to search over all the code that they might care about (e.g., as user might have one or more of their own repositories that are not in the top 100k on GitHub.com).
+
+**Milestones:**
+
+1. The Sourcegraph organization and team members can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
+   - Code is indexed.
+1. Any user can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
+   - Connecting their first code host and adding their own public repos is intuitive and easy for new and existing users.
+   - System activity and progress is easy to understand and doesn’t take too long.
+     - Repo syncing
+     - Repo indexing
+
+### Private code on Sourcegraph Cloud
+
+**Problem:** Customers who want to use Sourcegraph with their private code must setup and run a Sourcegraph instance on their own compute infrastructure. There are customers who want to use Sourcegraph but don't want to have to deploy and operate their own Sourcegraph instance and associated compute infrastructure. To host private code on Sourcegraph Cloud, we need to not only ensure the security of our product (which is important for on-premise deployments too), but we also have to ensure the security of our Sourcegraph Cloud infrastructure.
+
+**Milestones:**
+
+1. The Sourcegraph organization and team members can add private code to Sourcegraph Cloud.
+   - No plaintext tokens or secrets anywhere (including gitserver .git/config remotes).
+   - All private repository content are only decryptable by Sourcegraph services.
+     - Gitserver.
+     - Searcher and code intel caches.
+     - Any other service that needs access to repository contents needs to be able to decrypt what it needs on the fly.
+   - Searching the user's or organization's private code versus searching all Cloud code is intuitive.
+   - **DEPENDENCY:** We first need to finish [user configured public code on Sourcegraph Cloud](#user-configured-public-code-on-sourcegraph-cloud).
+1. Any user or organization can add private code to Sourcegraph Cloud for free before it's GA.
+   - Authorization from code hosts is enforced (e.g., organizations, teams).
+   - Repository visibility and permissions on Sourcegraph is intuitive.
+   - Adding private repositories is part of the same flows as adding public repositories.
+   - **DEPENDENCY**: We need to have [visibility into our attack surface](../security/index.md#visibility-into-sourcegraph-clouds-attack-surface).
+1. Sourcegraph Cloud is Generally Available (GA).
+   - Abuse protection: API rate limiting, DDoS mitigation, limiting user accounts.
+   - Scalable syncing of permissions, repos, changesets.
+   - High availability, SLOs, etc.
+   - Billing and subscriptions.
+   - [Confidence in our security model](../security/index.md#confidence-in-our-security-model).
+
+### Backend infrastructure
+
+Backend infrastructure goals are ad hoc as requests come up from customers or other teams. The Cloud team is responsible for scheduling and prioritizing these requests as they come up. See the [roadmap](../../product/roadmap.md#cloud) for planned items.

--- a/handbook/engineering/cloud/goals.md
+++ b/handbook/engineering/cloud/goals.md
@@ -21,7 +21,7 @@
 1. 🔄 Any user can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
 1. Organization admins can manage membership (wording WIP).
 1. Any user or organization can add private code to Sourcegraph Cloud for free before it's GA.
-1. Sourcegraph Cloud is Generally Available (GA).
+1. Sourcegraph Cloud is a paid product that is Generally Available (GA)
 
 ### Backend infrastructure
 

--- a/handbook/engineering/cloud/goals.md
+++ b/handbook/engineering/cloud/goals.md
@@ -29,26 +29,6 @@ Backend infrastructure goals are ad hoc as requests come up from customers or ot
 
 ## Roadmap
 
-<!-- Gantt chart syntax documentation: https://mermaid-js.github.io/mermaid/diagrams-and-syntax-and-examples/gantt.html -->
-
-<pre class="mermaid" data-rendered-width="150%" data-scroll-right="50%">
-gantt
-    title In progress work
-    dateFormat YYYY-MM-DD
-    axisFormat %b %d
-
-section Milestones
-    3.21 :active, release-3.21, 2020-09-21, 2020-10-20
-    3.22 :        release-3.22, 2020-10-21, 2020-11-20
-
-section Cloud
-    User added code is indexed and searchable                 :done,   2020-09-23, 2020-10-07
-    RFC 167 - Product license tiers                           :active, 2020-10-07, 14d
-    Syncing repos is more scalable                            :active, 2020-10-07, 14d
-    Metrics/monitoring in place                               :active, 2020-10-07, 14d
-    GitHub app to simplify access to repositories (spike)     :        2020-10-21, 2d
-    Webhooks to receive repo permissions and metadata (spike) :        2020-10-21, 2d
-
 1. ✅ User added code is indexed
 1. ✅ Users do not need to take any steps for a repository they add to be searchable
 1. 🔄 [RFC 167: Product license tiers](https://docs.google.com/document/d/1XozQ4JINJqirdaG-XqGtboT2-PlIXPyBn6EwV7Q3pWI/edit?ts=5f0811cf#heading=h.trqab8y0kufp)

--- a/handbook/engineering/cloud/goals.md
+++ b/handbook/engineering/cloud/goals.md
@@ -17,7 +17,7 @@
 **Milestones:**
 
 1. ✅ The Sourcegraph organization and team members can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
-1. The Sourcegraph organization and team members can add private code to Sourcegraph Cloud.
+1. 🔄 The Sourcegraph organization and team members can add private code to Sourcegraph Cloud.
 1. 🔄 Any user can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
 1. Organization admins can manage membership (wording WIP).
 1. Any user or organization can add private code to Sourcegraph Cloud for free before it's GA.

--- a/handbook/engineering/cloud/goals.md
+++ b/handbook/engineering/cloud/goals.md
@@ -19,7 +19,7 @@
 1. ✅ The Sourcegraph organization and team members can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
 1. The Sourcegraph organization and team members can add private code to Sourcegraph Cloud.
 1. 🔄 Any user can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
-1. Organization admins can manage membership.
+1. Organization admins can manage membership (wording WIP).
 1. Any user or organization can add private code to Sourcegraph Cloud for free before it's GA.
 1. Sourcegraph Cloud is Generally Available (GA).
 
@@ -45,7 +45,7 @@ Unplanned:
 
 - [Non-Git VCS](https://docs.google.com/document/d/1Y2xYbckAz5jlBePER_BarypeDfP3mjjX9bBOZm3ALqY/edit#heading=h.m60esa7uysvx)
 
-### Old notes:
+### Old notes
 
 - Connecting their first code host and adding their own public repos is intuitive and easy for new and existing users.
    - System activity and progress is easy to understand and doesn’t take too long.

--- a/handbook/engineering/cloud/goals.md
+++ b/handbook/engineering/cloud/goals.md
@@ -17,32 +17,73 @@
 **Milestones:**
 
 1. ✅ The Sourcegraph organization and team members can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
-   - Code is indexed.
+1. The Sourcegraph organization and team members can add private code to Sourcegraph Cloud.
 1. 🔄 Any user can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
-   - Connecting their first code host and adding their own public repos is intuitive and easy for new and existing users.
+1. Organization admins can manage membership.
+1. Any user or organization can add private code to Sourcegraph Cloud for free before it's GA.
+1. Sourcegraph Cloud is Generally Available (GA).
+
+### Backend infrastructure
+
+Backend infrastructure goals are ad hoc as requests come up from customers or other teams. The Cloud team is responsible for scheduling and prioritizing these requests as they come up. See the [roadmap](../../product/roadmap.md#cloud) for planned items.
+
+## Roadmap
+
+<!-- Gantt chart syntax documentation: https://mermaid-js.github.io/mermaid/diagrams-and-syntax-and-examples/gantt.html -->
+
+<pre class="mermaid" data-rendered-width="150%" data-scroll-right="50%">
+gantt
+    title In progress work
+    dateFormat YYYY-MM-DD
+    axisFormat %b %d
+
+section Milestones
+    3.21 :active, release-3.21, 2020-09-21, 2020-10-20
+    3.22 :        release-3.22, 2020-10-21, 2020-11-20
+
+section Cloud
+    User added code is indexed and searchable                 :done,   2020-09-23, 2020-10-07
+    RFC 167 - Product license tiers                           :active, 2020-10-07, 14d
+    Syncing repos is more scalable                            :active, 2020-10-07, 14d
+    Metrics/monitoring in place                               :active, 2020-10-07, 14d
+    GitHub app to simplify access to repositories (spike)     :        2020-10-21, 2d
+    Webhooks to receive repo permissions and metadata (spike) :        2020-10-21, 2d
+
+1. ✅ User added code is indexed
+1. ✅ Users do not need to take any steps for a repository they add to be searchable
+1. 🔄 [RFC 167: Product license tiers](https://docs.google.com/document/d/1XozQ4JINJqirdaG-XqGtboT2-PlIXPyBn6EwV7Q3pWI/edit?ts=5f0811cf#heading=h.trqab8y0kufp)
+1. 🔄 Syncing repos is more scalable
+1. 🔄 Metrics/monitoring in place to ensure a good experience
+1. GitHub app to have users sign in with GitHub and select the repos/organizations that have access.
+1. Use webhooks to receive updates on anything that is relevant to this user’s connection to GitHub
+1. Equivalent things to GitLab and Bitbucket Cloud
+1. User understands state and progress of their configured repositories and associated metadata
+1. [UX TBD: New sign up/auth flow]
+1. [UX TBD: Communicate state]
+
+Unplanned:
+
+- [Non-Git VCS](https://docs.google.com/document/d/1Y2xYbckAz5jlBePER_BarypeDfP3mjjX9bBOZm3ALqY/edit#heading=h.m60esa7uysvx)
+
+### Old notes:
+
+- Connecting their first code host and adding their own public repos is intuitive and easy for new and existing users.
    - System activity and progress is easy to understand and doesn’t take too long.
      - Repo syncing
      - Repo indexing
-1. The Sourcegraph organization and team members can add private code to Sourcegraph Cloud.
-   - No plaintext tokens or secrets anywhere (including gitserver .git/config remotes).
+- No plaintext tokens or secrets anywhere (including gitserver .git/config remotes).
    - All private repository content are only decryptable by Sourcegraph services.
      - Gitserver.
      - Searcher and code intel caches.
      - Any other service that needs access to repository contents needs to be able to decrypt what it needs on the fly.
    - Searching the user's or organization's private code versus searching all Cloud code is intuitive.
    - **DEPENDENCY:** We first need to finish [user configured public code on Sourcegraph Cloud](#user-configured-public-code-on-sourcegraph-cloud).
-1. Any user or organization can add private code to Sourcegraph Cloud for free before it's GA.
-   - Authorization from code hosts is enforced (e.g., organizations, teams).
+- Authorization from code hosts is enforced (e.g., organizations, teams).
    - Repository visibility and permissions on Sourcegraph is intuitive.
    - Adding private repositories is part of the same flows as adding public repositories.
    - **DEPENDENCY**: We need to have [visibility into our attack surface](../security/index.md#visibility-into-sourcegraph-clouds-attack-surface).
-1. Sourcegraph Cloud is Generally Available (GA).
-   - Abuse protection: API rate limiting, DDoS mitigation, limiting user accounts.
+- Abuse protection: API rate limiting, DDoS mitigation, limiting user accounts.
    - Scalable syncing of permissions, repos, changesets.
    - High availability, SLOs, etc.
    - Billing and subscriptions.
    - [Confidence in our security model](../security/index.md#confidence-in-our-security-model).
-
-### Backend infrastructure
-
-Backend infrastructure goals are ad hoc as requests come up from customers or other teams. The Cloud team is responsible for scheduling and prioritizing these requests as they come up. See the [roadmap](../../product/roadmap.md#cloud) for planned items.

--- a/handbook/engineering/cloud/index.md
+++ b/handbook/engineering/cloud/index.md
@@ -18,59 +18,9 @@ The cloud team is also responsible for all [backend-infrastructure areas of owne
 - Admin and user settings
 - Analytics
 
-## Guiding principles
+## [Goals](goals.md)
 
-1. **Make it work**: Build the backend blocking work, and expose it (even in a roughly usable way) to the Sourcegraph team. We will be able to quickly surface any glaring issues and will have more thoughts around usability. Take shortcuts where possible (this is currently due to the team having fewer frontend resources).
-   - Where possible, making it work and usable should be combined (avoid duplicate efforts), but if it's possible to separate the two in order to move things forward, we should!
-1. **Make it usable**: The experience has been designed and thought through. We feel good about putting this in front of users, and they will find it valuable!
-1. **Make it fast**: Now that users can try it, make sure the experience is fast for them (but it's better to have a slow working feature than a fast not-working one).
-1. **Make it scale**: Make it work at large scale. Up until now we have been starting to grow awareness of the feature, so the number of users is starting to matter. It is better to have high demand and need to surge on scalability than to make an infinitely scalable unused feature.
-
-## Goals
-
-### User configured public code on Sourcegraph Cloud
-
-**Problem:** Sourcegraph Cloud proactively indexes and refreshes only a fixed set of public repositories (e.g., top 100k public repositories on GitHub.com). Code outside of this set is lazily updated when a user visits that repository, and is not stored in our search index. This does not allow individual users to search over all the code that they might care about (e.g., as user might have one or more of their own repositories that are not in the top 100k on GitHub.com).
-
-**Milestones:**
-
-1. The Sourcegraph organization and team members can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
-   - Code is indexed.
-1. Any user can add public code from GitHub.com, GitLab.com, and Bitbucket Cloud.
-   - Connecting their first code host and adding their own public repos is intuitive and easy for new and existing users.
-   - System activity and progress is easy to understand and doesn’t take too long.
-     - Repo syncing
-     - Repo indexing
-
-### Private code on Sourcegraph Cloud
-
-**Problem:** Customers who want to use Sourcegraph with their private code must setup and run a Sourcegraph instance on their own compute infrastructure. There are customers who want to use Sourcegraph but don't want to have to deploy and operate their own Sourcegraph instance and associated compute infrastructure. To host private code on Sourcegraph Cloud, we need to not only ensure the security of our product (which is important for on-premise deployments too), but we also have to ensure the security of our Sourcegraph Cloud infrastructure.
-
-**Milestones:**
-
-1. The Sourcegraph organization and team members can add private code to Sourcegraph Cloud.
-   - No plaintext tokens or secrets anywhere (including gitserver .git/config remotes).
-   - All private repository content are only decryptable by Sourcegraph services.
-     - Gitserver.
-     - Searcher and code intel caches.
-     - Any other service that needs access to repository contents needs to be able to decrypt what it needs on the fly.
-   - Searching the user's or organization's private code versus searching all Cloud code is intuitive.
-   - **DEPENDENCY:** We first need to finish [user configured public code on Sourcegraph Cloud](#user-configured-public-code-on-sourcegraph-cloud).
-1. Any user or organization can add private code to Sourcegraph Cloud for free before it's GA.
-   - Authorization from code hosts is enforced (e.g., organizations, teams).
-   - Repository visibility and permissions on Sourcegraph is intuitive.
-   - Adding private repositories is part of the same flows as adding public repositories.
-   - **DEPENDENCY**: We need to have [visibility into our attack surface](../security/index.md#visibility-into-sourcegraph-clouds-attack-surface).
-1. Sourcegraph Cloud is Generally Available (GA).
-   - Abuse protection: API rate limiting, DDoS mitigation, limiting user accounts.
-   - Scalable syncing of permissions, repos, changesets.
-   - High availability, SLOs, etc.
-   - Billing and subscriptions.
-   - [Confidence in our security model](../security/index.md#confidence-in-our-security-model).
-
-### Backend infrastructure
-
-Backend infrastructure goals are ad hoc as requests come up from customers or other teams. The Cloud team is responsible for scheduling and prioritizing these requests as they come up. See the [roadmap](../../product/roadmap.md#cloud) for planned items.
+See [goals](goals.md)
 
 ## Contact
 

--- a/handbook/product/roadmap.md
+++ b/handbook/product/roadmap.md
@@ -63,21 +63,7 @@ See [roadmap at a glance](https://docs.google.com/document/d/1zRTfK6mENKicfLwDaW
 
 ## Cloud
 
-1. ✅ User added code is indexed
-1. ✅ Users do not need to take any steps for a repository they add to be searchable
-1. 🔄 [RFC 167: Product license tiers](https://docs.google.com/document/d/1XozQ4JINJqirdaG-XqGtboT2-PlIXPyBn6EwV7Q3pWI/edit?ts=5f0811cf#heading=h.trqab8y0kufp)
-1. 🔄 Syncing repos is more scalable
-1. 🔄 Metrics/monitoring in place to ensure a good experience
-1. GitHub app to have users sign in with GitHub and select the repos/organizations that have access.
-1. Use webhooks to receive updates on anything that is relevant to this user’s connection to GitHub
-1. Equivalent things to GitLab and Bitbucket Cloud
-1. User understands state and progress of their configured repositories and associated metadata
-1. [UX TBD: New sign up/auth flow]
-1. [UX TBD: Communicate state]
-
-Unplanned:
-
-- [Non-Git VCS](https://docs.google.com/document/d/1Y2xYbckAz5jlBePER_BarypeDfP3mjjX9bBOZm3ALqY/edit#heading=h.m60esa7uysvx)
+See [cloud roadmap](../engineering/cloud/goals.md#roadmap)
 
 ## Code intel
 

--- a/handbook/product/roadmap.md
+++ b/handbook/product/roadmap.md
@@ -82,7 +82,6 @@ See [cloud roadmap](../engineering/cloud/goals.md#roadmap)
 
 See [Code Intel roadmap](https://docs.google.com/document/d/1JPNelxg_8xwZKz8TT2BnpCccShOgxJrLubf2RNGye50/edit#) for more.
 
-
 ## Distribution
 
 See [Distribution roadmap](https://github.com/sourcegraph/about/pull/1104).


### PR DESCRIPTION
Review by commit:

1. Move goals onto separate page
1. Update goals to focus on private code
1. Move roadmap to goals page and update milestones

@tsenart @ryanslade @quinnkeast - I propose merging this PR as is to get these high-level changes in. Then Ryan and Quinn can create a new/cleaner PR for updating the roadmap. Let me know if you have any concerns!

@nicksnyder - FYI, we are actively working on improving this, and this will only be a short term state.