### PR TITLE
managed: make it harder to make mistakes in upgrade process

### DIFF
--- a/handbook/engineering/distribution/managed/operations.md
+++ b/handbook/engineering/distribution/managed/operations.md
@@ -20,7 +20,7 @@ NAME                  ZONE           MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EX
 default-red-instance  us-central1-f  n1-standard-8               10.2.0.2                  RUNNING
 ```
 
-The `NAME` value indicates the currently active instance (`red` or `black`). During an upgrade, both `default-red-instance` and `default-black-instance` would be present. One being production, the other being the "new" upgraded production instance. When the upgrade is complete, the old one is turned off (red/black swap). Learn more about [managed instances upgrades here](upgrade_process.md).
+The `NAME` value indicates the currently active instance (`red` or `black`). During an upgrade, both `default-red-instance` and `default-black-instance` will be present. One being production, the other being the "new" upgraded production instance. When the upgrade is complete, the old one is turned off (red/black swap). Learn more about [managed instances upgrades here](upgrade_process.md).
 
 ## SSH access
 

--- a/handbook/engineering/distribution/managed/operations.md
+++ b/handbook/engineering/distribution/managed/operations.md
@@ -1,6 +1,6 @@
 # Managed instances operations
 
-- [Red/black deployment model](#red-black-deployment-model)
+- [Red/black deployment model](#redblack-deployment-model)
 - [SSH access](#ssh-access)
 - [Port-forwarding (direct access to Caddy, Jaeger, and Grafana)](#port-forwarding-direct-access-to-caddy-jaeger-and-grafana)
 - [Access through the GCP load balancer as a user would](#access-through-the-gcp-load-balancer-as-a-user-would)
@@ -15,19 +15,19 @@
 At any point in time only one deployment is the active production instance, this is noted in `deploy-sourcegraph-managed/$CUSTOMER/terraform.tfvars`, and except during upgrades only one is running. You can see this via:
 
 ```sh
-$ gcloud compute instances list --project=sourcegraph-managed-$COMPANY
+$ gcloud compute instances list --project=sourcegraph-managed-$CUSTOMER
 NAME                  ZONE           MACHINE_TYPE   PREEMPTIBLE  INTERNAL_IP  EXTERNAL_IP  STATUS
 default-red-instance  us-central1-f  n1-standard-8               10.2.0.2                  RUNNING
 ```
 
-During an upgrade, both `default-red-instance` and `default-black-instance` would be present. One being production, the other being the "new" upgraded production instance. When the upgrade is complete, the old one is turned off (red/black swap). Learn more about [managed instances upgrades here](upgrade_process.md).
+The `NAME` value indicates the currently active instance (`red` or `black`). During an upgrade, both `default-red-instance` and `default-black-instance` would be present. One being production, the other being the "new" upgraded production instance. When the upgrade is complete, the old one is turned off (red/black swap). Learn more about [managed instances upgrades here](upgrade_process.md).
 
 ## SSH access
 
 Locate the GCP instance you'd like to access (usually either `default-red-instance` or `default-black-instance`), and then:
 
 ```sh
-$ gcloud beta compute ssh --zone "us-central1-f" --tunnel-through-iap --project "sourcegraph-managed-$COMPANY" default-red-instance
+$ gcloud beta compute ssh --zone "us-central1-f" --tunnel-through-iap --project "sourcegraph-managed-$CUSTOMER" default-$DEPLOYMENT-instance
 ```
 
 If you get an error:
@@ -41,7 +41,7 @@ ERROR: (gcloud.beta.compute.ssh) [/usr/bin/ssh] exited with return code [255].
 This may be indicating that the VM is currently not running - check:
 
 ```sh
-$ gcloud beta compute instances list --project=sourcegraph-managed-$COMPANY
+$ gcloud beta compute instances list --project=sourcegraph-managed-$CUSTOMER
 ```
 
 And start the instance if needed (e.g. through the web UI.)
@@ -51,7 +51,7 @@ And start the instance if needed (e.g. through the web UI.)
 Locate the GCP instance you'd like to access (usually either `default-red-instance` or `default-black-instance`), and then:
 
 ```sh
-gcloud compute start-iap-tunnel default-red-instance 80 --local-host-port=localhost:4444 --zone "us-central1-f" --project "sourcegraph-managed-$COMPANY"
+gcloud compute start-iap-tunnel default-$DEPLOYMENT-instance 80 --local-host-port=localhost:4444 --zone "us-central1-f" --project "sourcegraph-managed-$CUSTOMER"
 ```
 
 This will port-forward `localhost:4444` to port `80` on the VM instance:
@@ -60,18 +60,18 @@ Replace `80` with `3370` for Grafana, or `16686` for Jaeger. Note that other por
 
 ## Access through the GCP load balancer as a user would
 
-Users access Sourcegraph through GCP Load Balancer/HTTPS -> the Caddy load balancer/HTTP -> the actual sourcegraph-frontend/HTTP. If you suspect that an issue is being introduced by the GCP load balancer itself, e.g. perhaps a request is timing out there due to some misconfiguration, then you will need to access through the GCP load balancer itself. If the managed instance is protected by the load balancer firewall / not publicly accessible on the internet, then it is not possible for you to access `$COMPANY.sourcegraph.com` as a normal user would.
+Users access Sourcegraph through GCP Load Balancer/HTTPS -> the Caddy load balancer/HTTP -> the actual sourcegraph-frontend/HTTP. If you suspect that an issue is being introduced by the GCP load balancer itself, e.g. perhaps a request is timing out there due to some misconfiguration, then you will need to access through the GCP load balancer itself. If the managed instance is protected by the load balancer firewall / not publicly accessible on the internet, then it is not possible for you to access `$CUSTOMER.sourcegraph.com` as a normal user would.
 
 You can workaround this by proxying your internet traffic through the instance itself - which is allowed to reach and go through the public internet -> the GCP load balancer -> back to the instance itself. To do this, create a SOCKS5 proxy tunnel over SSH (replace `default-red-instance`, if needed):
 
-```ssh
-bash -c '(gcloud beta compute ssh --zone "us-central1-f" --tunnel-through-iap --project "sourcegraph-managed-$COMPANY" default-red-instance -- -N -p 22 -D localhost:5000) & sleep 600; kill $!'
+```sh
+bash -c '(gcloud beta compute ssh --zone "us-central1-f" --tunnel-through-iap --project "sourcegraph-managed-$CUSTOMER" default-$DEPLOYMENT-instance -- -N -p 22 -D localhost:5000) & sleep 600; kill $!'
 ```
 
 Then test you can access it using `curl`:
 
 ```
-$ curl --proxy socks5://localhost:5000 https://$COMPANY.sourcegraph.com
+$ curl --proxy socks5://localhost:5000 https://$CUSTOMER.sourcegraph.com
 <a href="/sign-in?returnTo=%2F">Found</a>.
 ```
 
@@ -98,14 +98,14 @@ You can then use regular Docker commands (e.g. `docker exec -it $CONTAINER sh`) 
 ## Finding the external IPs
 
 ```sh
-$ gcloud compute addresses list --project=sourcegraph-managed-$COMPANY
+$ gcloud compute addresses list --project=sourcegraph-managed-$CUSTOMER
 NAME                     ADDRESS/RANGE   TYPE      PURPOSE  NETWORK  REGION       SUBNET  STATUS
 default-global-address   $GLOBAL_IP      EXTERNAL                                         IN_USE
 default-nat-manual-ip-0  $NAT_IP_ONE     EXTERNAL                    us-central1          IN_USE
 default-nat-manual-ip-1  $NAT_IP_TWO     EXTERNAL                    us-central1          IN_USE
 ```
 
-- `$GLOBAL_IP` is the IP address that `$COMPANY.sourcegraph.com` should point to, it is the address of the GCP Load Balancer.
+- `$GLOBAL_IP` is the IP address that `$CUSTOMER.sourcegraph.com` should point to, it is the address of the GCP Load Balancer.
 - `$NAT_IP_ONE` and `$NAT_IP_TWO` are the external IPs from which egress traffic from the deployment will originate from. These are the addresses from which Sourcegraph will access the customer's code host, and as such the customer will need to allow them access to e.g. their internal code host.
 
 ## Impact of recreating the instance via Terraform

--- a/handbook/engineering/distribution/managed/upgrade_process.md
+++ b/handbook/engineering/distribution/managed/upgrade_process.md
@@ -62,7 +62,7 @@ You can replace the `DEPLOYMENT` variable used in [operations](./operations.md),
 
 ```sh
 export DEPLOYMENT=$OLD_DEPLOYMENT
-# ... commands
+# ... commands that target specific instances like `default-$DEPLOYMENT-instance`
 ```
 
 ## 1) Add a banner indicating scheduled maintenance is in progress

--- a/handbook/engineering/distribution/managed/upgrade_process.md
+++ b/handbook/engineering/distribution/managed/upgrade_process.md
@@ -1,5 +1,7 @@
 # Upgrading a managed instance
 
+Managed instances configuration is tracked in [`deploy-sourcegraph-managed-instances`](https://github.com/sourcegraph/deploy-sourcegraph-managed). For basic operations like accessing an instance for these steps, see [managed instances operations](operations.md).
+
 - [Walkthrough video](#walkthrough-video)
 - [0) Setup](#0-setup)
 - [1) Add a banner indicating scheduled maintenance is in progress](#1-add-a-banner-indicating-scheduled-maintenance-is-in-progress)
@@ -30,7 +32,7 @@ These videos reference some customer names, and as such can only be shared with 
 
 Managed instances configuration is tracked in [`deploy-sourcegraph-managed`](https://github.com/sourcegraph/deploy-sourcegraph-managed) - make sure you have the latest revision of this repository checked out. For basic operations like accessing an instance for these steps, see [managed instances operations](operations.md).
 
-Many of the following commands in this guide, as well as the commands [operations](./operations.md), use variables. You can replace variables with the correct values by hand, or export the appropriate values for the upgrade:
+Many of the following commands in this guide, as well as the commands [operations](./operations.md), use environment variables. Export the appropriate values for the upgrade so you don't lose track:
 
 ```sh
 export CUSTOMER=<customer_or_instance_name>
@@ -49,7 +51,7 @@ Figure out [what instance is currently live](./operations.md#redblack-deployment
 gcloud compute instances list --project=sourcegraph-managed-$CUSTOMER
 ```
 
-Set up the following values (or replace them as you go):
+Export the following values in your shell:
 
 ```sh
 export OLD_DEPLOYMENT=red # the current deployment
@@ -116,7 +118,7 @@ Make sure the version (`3-17-2`) describes the current version of the instance, 
 
 ## 4) Initialize the new production deployment
 
-Copy the previous deployment's Docker Compose configuration:
+Copy the old deployment's Docker Compose configuration:
 
 ```sh
 cd $CUSTOMER
@@ -125,7 +127,7 @@ git add $NEW_DEPLOYMENT/
 git commit -m "$CUSTOMER: cp -R $OLD_DEPLOYMENT/ $NEW_DEPLOYMENT/"
 ```
 
-Initialize the `NEW_DEPLOYMENT` production deployment using the snapshot created in the previous step, by editing `$CUSTOMER/terraform.tfvars` with something like:
+Initialize the new production deployment (`NEW_DEPLOYMENT`) using the snapshot created in the previous step, by editing `$CUSTOMER/terraform.tfvars` with something like:
 
 ```diff
  load_balancer_target = "red"
@@ -188,7 +190,7 @@ Take down the new `$NEW_DEPLOYMENT` deployment, for example:
 
 ## 8) Confirm instance health
 
-[Access Grafana](operations.md#port-forwarding-direct-access-to-caddy-jaeger-and-grafana) and confirm the instance is healthy by verifying no critical alerts are firing.
+[Access Grafana](operations.md#port-forwarding-direct-access-to-caddy-jaeger-and-grafana) and confirm the instance is healthy by verifying no critical alerts are firing, and there has been no large increase in warning alerts.
 
 ## 9) Switch the load balancer target
 
@@ -238,3 +240,5 @@ git push origin HEAD
 ```
 
 And click the provided link to open a pull request in [`deploy-sourcegraph-managed`](https://github.com/sourcegraph/deploy-sourcegraph-managed).
+
+**IMPORTANT: DO NOT FORGET TO GET YOUR PR APPROVED AND MERGED**, if you forget then the next person upgrading the instance will have a very bad time.

--- a/handbook/engineering/distribution/managed/upgrade_process.md
+++ b/handbook/engineering/distribution/managed/upgrade_process.md
@@ -58,7 +58,7 @@ export OLD_DEPLOYMENT=red # the current deployment
 export NEW_DEPLOYMENT=$([ "$OLD_DEPLOYMENT" = "red" ] && echo "black" || echo "red")
 ```
 
-You can replace the `DEPLOYMENT` variable used in [operations](./operations.md), following the steps in this guide to determine which value `DEPLOYMENT` should be, like so:
+You can replace the `DEPLOYMENT` variable used in the examples in [operations](./operations.md) (using this guide to determine the appropriate value) like so:
 
 ```sh
 export DEPLOYMENT=$OLD_DEPLOYMENT

--- a/handbook/engineering/distribution/managed/upgrade_process.md
+++ b/handbook/engineering/distribution/managed/upgrade_process.md
@@ -13,6 +13,7 @@
 - [9) Switch the load balancer target](#9-switch-the-load-balancer-target)
 - [10) Remove the banner indicating scheduled maintenance is in progress](#10-remove-the-banner-indicating-scheduled-maintenance-is-in-progress)
 - [11) Take down the old deployment](#11-take-down-the-old-deployment)
+- [12) Open a pull request to commit your changes](#12-open-a-pull-request-to-commit-your-changes)
 
 ## Walkthrough video
 
@@ -34,6 +35,12 @@ Many of the following commands in this guide, as well as the commands [operation
 ```sh
 export CUSTOMER=<customer_or_instance_name>
 export VERSION=v<sourcegraph_version>
+```
+
+Start a branch for your upgrade in [`deploy-sourcegraph-managed`](https://github.com/sourcegraph/deploy-sourcegraph-managed):
+
+```sh
+git checkout -b $CUSTOMER/upgrade-to-$VERSION
 ```
 
 Figure out [what instance is currently live](./operations.md#redblack-deployment-model) for the managed instance you are upgrading - it should be either `red` or `black`:
@@ -223,3 +230,11 @@ rm -rf $OLD_DEPLOYMENT/
 git add .
 git commit -m "$CUSTOMER: remove $OLD_DEPLOYMENT deployment"
 ```
+
+## 12) Open a pull request to commit your changes
+
+```sh
+git push origin HEAD
+```
+
+And click the provided link to open a pull request in [`deploy-sourcegraph-managed`](https://github.com/sourcegraph/deploy-sourcegraph-managed).

--- a/handbook/engineering/distribution/managed/upgrade_process.md
+++ b/handbook/engineering/distribution/managed/upgrade_process.md
@@ -220,5 +220,6 @@ Also remove the deploy config for that deployment as it is no longer used:
 ```sh
 cd $CUSTOMER
 rm -rf $OLD_DEPLOYMENT/
+git add .
 git commit -m "$CUSTOMER: remove $OLD_DEPLOYMENT deployment"
 ```

--- a/handbook/engineering/distribution/managed/upgrade_process.md
+++ b/handbook/engineering/distribution/managed/upgrade_process.md
@@ -49,7 +49,12 @@ export OLD_DEPLOYMENT=red # the current deployment
 export NEW_DEPLOYMENT=$([ "$OLD_DEPLOYMENT" = "red" ] && echo "black" || echo "red")
 ```
 
-For the most 
+You can replace the `DEPLOYMENT` variable used in [operations](./operations.md), following the steps in this guide to determine which value `DEPLOYMENT` should be, like so:
+
+```sh
+export DEPLOYMENT=$OLD_DEPLOYMENT
+# ... commands
+```
 
 ## 1) Add a banner indicating scheduled maintenance is in progress
 
@@ -151,7 +156,7 @@ cd $CUSTOMER
 VERSION=$VERSION ../update-docker-compose.sh $NEW_DEPLOYMENT/
 # Address any merge conflicts in $NEW_DEPLOYMENT/ if needed.
 git add $NEW_DEPLOYMENT/
-git commit -m "$CUSTOMER: upgrade to to $VERSION"
+git commit -m "$CUSTOMER: upgrade to $VERSION"
 ```
 
 Then `terraform apply`.

--- a/handbook/engineering/distribution/managed/upgrade_process.md
+++ b/handbook/engineering/distribution/managed/upgrade_process.md
@@ -1,8 +1,7 @@
 # Upgrading a managed instance
 
-Managed instances configuration is tracked in [`deploy-sourcegraph-managed-instances`](https://github.com/sourcegraph/deploy-sourcegraph-managed). For basic operations like accessing an instance for these steps, see [managed instances operations](operations.md).
-
 - [Walkthrough video](#walkthrough-video)
+- [0) Setup](#0-setup)
 - [1) Add a banner indicating scheduled maintenance is in progress](#1-add-a-banner-indicating-scheduled-maintenance-is-in-progress)
 - [2) Mark the database as ready-only](#2-mark-the-database-as-ready-only)
 - [3) Create a snapshot of the current deployment](#3-create-a-snapshot-of-the-current-deployment)
@@ -26,9 +25,35 @@ These videos reference some customer names, and as such can only be shared with 
 
 **Note:** You do not need to watch the above videos to perform this process, these are for educational purposes only. The steps below may be more up-to-date and accurate than the videos above.
 
+## 0) Setup
+
+Managed instances configuration is tracked in [`deploy-sourcegraph-managed`](https://github.com/sourcegraph/deploy-sourcegraph-managed) - make sure you have the latest revision of this repository checked out. For basic operations like accessing an instance for these steps, see [managed instances operations](operations.md).
+
+Many of the following commands in this guide, as well as the commands [operations](./operations.md), use variables. You can replace variables with the correct values by hand, or export the appropriate values for the upgrade:
+
+```sh
+export CUSTOMER=<customer_or_instance_name>
+export VERSION=v<sourcegraph_version>
+```
+
+Figure out [what instance is currently live](./operations.md#redblack-deployment-model) for the managed instance you are upgrading - it should be either `red` or `black`:
+
+```sh
+gcloud compute instances list --project=sourcegraph-managed-$CUSTOMER
+```
+
+Set up the following values (or replace them as you go):
+
+```sh
+export OLD_DEPLOYMENT=red # the current deployment
+export NEW_DEPLOYMENT=$([ "$OLD_DEPLOYMENT" = "red" ] && echo "black" || echo "red")
+```
+
+For the most 
+
 ## 1) Add a banner indicating scheduled maintenance is in progress
 
-Add to the global user settings:
+Add to the global user settings (`/site-admin/global-settings`):
 
 ```jsonc
   "notices": [
@@ -42,7 +67,7 @@ Add to the global user settings:
 
 ## 2) Mark the database as ready-only
 
-Mark the database as read-only:
+[SSH into `DEPLOYMENT=$OLD_DEPLOYMENT`](./operations.md#ssh-access) and mark the database as read-only:
 
 ```sh
 docker exec -it pgsql psql -U sg -c 'ALTER DATABASE sg SET default_transaction_read_only = true;'
@@ -62,7 +87,7 @@ During this time:
 
 ## 3) Create a snapshot of the current deployment
 
-Edit `deploy-sourcegraph-managed/$CUSTOMER/terraform.tfvars` to create a snapshot of the current deployment:
+Edit `$CUSTOMER/terraform.tfvars` to create a snapshot of the current deployment, for example:
 
 ```diff
  load_balancer_target = "red"
@@ -70,24 +95,25 @@ Edit `deploy-sourcegraph-managed/$CUSTOMER/terraform.tfvars` to create a snapsho
  disks = {
      red = { from_snapshot = null }
  }
-+snapshots = {
+ snapshots = {
 +    upgrade-from-3-17-2 = { from_disk = "default-red-data-disk" }
-+}
+ }
 ```
 
 Make sure the version (`3-17-2`) describes the current version of the instance, and `from_disk` is correct, then `terraform apply` it to create the snapshot. This can take anywhere from a minute to several minutes, depending on how large the disk is.
 
 ## 4) Initialize the new production deployment
 
-Then in `deploy-sourcegraph-docker/$CUSTOMER` copy the `red` deployment's Docker Compose configuration:
+Copy the previous deployment's Docker Compose configuration:
 
 ```sh
-cp -R red/ black/
-git add black/
-git commit -m 'cp -R red/ black/'
+cd $CUSTOMER
+cp -R $OLD_DEPLOYMENT/ $NEW_DEPLOYMENT/
+git add $NEW_DEPLOYMENT/
+git commit -m "$CUSTOMER: cp -R $OLD_DEPLOYMENT/ $NEW_DEPLOYMENT/"
 ```
 
-Initialize the new `black` production deployment using the snapshot created in the previous step, by editing `deploy-sourcegraph-docker/$CUSTOMER/terraform.tfvars` with something like:
+Initialize the `NEW_DEPLOYMENT` production deployment using the snapshot created in the previous step, by editing `$CUSTOMER/terraform.tfvars` with something like:
 
 ```diff
  load_balancer_target = "red"
@@ -108,7 +134,7 @@ Then `terraform apply` to update the metadata. This should only modify the deplo
 
 ## 5) Make the database on the new deployment writable
 
-On the _new_ deployment to be upgraded, make the database writable:
+[SSH into `DEPLOYMENT=$NEW_DEPLOYMENT`](./operations.md#ssh-access) (the _new_ deployment) to be upgraded, and make the database writable:
 
 ```sh
 docker exec -it pgsql psql -U sg -c 'set transaction read write; ALTER DATABASE sg SET default_transaction_read_only = false;'
@@ -116,23 +142,23 @@ docker exec -it pgsql psql -U sg -c 'set transaction read write; ALTER DATABASE 
 
 ## 6) Upgrade the new deployment
 
-First check the new version at https://docs.sourcegraph.com/admin/updates/docker_compose requires no manual migration steps.
+First check that thew new version requires no manual migration steps in [docker-compose upgrade guide](https://docs.sourcegraph.com/admin/updates/docker_compose)
 
-Then, to upgrade the new `black` deployment to 3.18.0:
+Then, to upgrade the new `$NEW_DEPLOYMENT` deployment to `$VERSION`:
 
 ```sh
-cd deploy-sourcegraph-docker/$CUSTOMER
-VERSION=v3.18.0 ../update-docker-compose.sh black/
-# Address any merge conflicts in black/ if needed.
-git add black/
-git commit -m 'update to v3.18.0'
+cd $CUSTOMER
+VERSION=$VERSION ../update-docker-compose.sh $NEW_DEPLOYMENT/
+# Address any merge conflicts in $NEW_DEPLOYMENT/ if needed.
+git add $NEW_DEPLOYMENT/
+git commit -m "$CUSTOMER: upgrade to to $VERSION"
 ```
 
 Then `terraform apply`.
 
 ## 7) Recreate the deployment
 
-Take down the new `black` deployment:
+Take down the new `$NEW_DEPLOYMENT` deployment, for example:
 
 ```diff
  load_balancer_target = "red"
@@ -140,7 +166,7 @@ Take down the new `black` deployment:
 +deployments = ["red"]
 ```
 
-`terraform apply` and recreate it (so the startup script runs on a clean OS disk):
+`terraform apply` and recreate it (so the startup script runs on a clean OS disk), for example:
 
 ```diff
  load_balancer_target = "red"
@@ -150,7 +176,7 @@ Take down the new `black` deployment:
 
 ## 8) Confirm instance health
 
-[Access Grafana](operations.md#port-forwarding-direct-access-to-caddy-jaeger-and-grafana) and confirm the instance is healthy.
+[Access Grafana](operations.md#port-forwarding-direct-access-to-caddy-jaeger-and-grafana) and confirm the instance is healthy by verifying no critical alerts are firing.
 
 ## 9) Switch the load balancer target
 
@@ -170,7 +196,7 @@ Remove the notice previously added to the global user settings.
 
 ## 11) Take down the old deployment
 
-Remove the old `red` deployment and its data disk:
+Remove the old `$OLD_DEPLOYMENT` deployment and its data disk, for example:
 
 ```diff
  load_balancer_target = "red"
@@ -187,7 +213,7 @@ And `terraform apply` it.
 Also remove the deploy config for that deployment as it is no longer used:
 
 ```sh
-cd deploy-sourcegraph-docker/$CUSTOMER
-rm -rf red/
-git commit -m 'remove red deployment'
+cd $CUSTOMER
+rm -rf $OLD_DEPLOYMENT/
+git commit -m "$CUSTOMER: remove $OLD_DEPLOYMENT deployment"
 ```


### PR DESCRIPTION
I just did a customer upgrade (https://github.com/sourcegraph/deploy-sourcegraph-managed/pull/10) and the scariest part was probably making sure I was running commands on the right thing. This change makes it easier to set up variables to correctly substitute in the correct values - `CUSTOMER`, `DEPLOYMENT`, etc.

Also makes misc. improvements based on doing this