### PR TITLE
Draft PR to move the web team roadmap

### DIFF
--- a/company/goals/index.md
+++ b/company/goals/index.md
@@ -35,7 +35,7 @@ See "[Guidelines for goals](guidelines.md)" for more information about how we ch
 ### [Distribution](../../handbook/engineering/distribution/goals.md)
 ### [Search](../../handbook/engineering/search/goals.md)
 ### [Security](../../handbook/engineering/security/index.md#goals)
-### [Web](../../handbook/engineering/web/index.md#goals)
+### [Web](../../handbook/engineering/web/goals.md#goals)
 
 ## [Product](../../handbook/product/goals.md)
 

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -1,0 +1,47 @@
+# Web Team Goals and Priorities 
+
+## Goals
+
+### Long term
+
+**_Deliver the full, unique value of [extensions](https://docs.sourcegraph.com/extensions) to our users._**
+
+**Outcome**: Our webapp, browser extensions and native integrations are great platforms to provide our users unique value through extensions. These platforms are well-maintained, consistent, easy to setup, well-documented, well-tested, performant, and show their power through convincing extensions built on top of them. The extensions platform and API provide powerful capabilities to extension developers and a great developer experience.
+
+### Medium term
+
+To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
+We will tackle these medium-term goals in order, though expect to have some work done in parallel as we progress.
+
+1. **Make the products that extensions are build on (web app, code host integrations) more consistent and improve discoverability.**
+   Our web app has accumulated a lot of design debt over time, which negatively impacts how we can use it as a vehicle to deliver extensions.
+   With areas like the repository page, user settings area (which extensions are configured through), navigation, command palette UI and the extension registry affected, it is hard to provide a good UX around extensions (the extension registry blends into goal (2)).
+   Our code host integrations, which are an implementation of our extension API, are a huge driver of adoption inside companies and multiply the value of extensions by bringing them into code review workflows, but are difficult to discover and setup.
+2. **Bring the extension platform into shape.**
+   Our extension platform includes the workflow around creating, installing and using extensions, the API exposed to developers and its documentation.
+   To grow adoption of extensions, these need to be solid, but they are currently lacking on multiple dimensions.
+   Some API areas like code insights are still in prototype phase and are still undocumented (this blends into goal (3)).
+   Our extension host is also currently implemented in a way that makes it difficult for us to maintain, evolve to enable more use cases and to onboard new teammates into this area of the codebase.
+   Combining this with writing a few smaller extensions (part of goal (3)) allows us to dogfood the experience and inform us where the platform is lacking.
+3. **Build out compelling use cases with the extensions platform.**
+   This includes writing more extensions ourselves, but also extending the extension API with more capabilities to enable more use cases.
+   We have a long list of ideas and use cases customers shared with us that we can solve and/or enable customers to solve with extensions.
+   Some of these integrate Sourcegraph with more external services to suit the setups of more customers, others provide completely new value no other product provides.
+
+### Short term
+
+Our goals for the current iteration can be found in our [iteration goals living Google Doc](https://docs.google.com/document/d/1n9WKjieKmd2YYkNrEsOfdmxRYUrbowLWjq05phLoQ6s/edit).
+
+The individual tasks and progress of the current iteration can be found as GitHub issues in our [GitHub project board](https://github.com/orgs/sourcegraph/projects/45?fullscreen=true).
+
+## Roadmap
+
+1. ✅ Existing sourcegraph extensions are more discoverable ([RFC 209](https://docs.google.com/document/d/1I5BMEGp3QuB81AjSzLCQwq_XJV1sXevlU0lpB4O1pj8/edit#))
+1. ✅ The Sourcegraph browser extension is more discoverable and easy to congifure ([RFC 221](https://docs.google.com/document/d/19f4xleYBU1zZZdqMmXlLmFxeR-fwEpOwTOgViOFOnyo/edit))
+1. ✅ Build new and improved Sourcegraph extensions to showcase the value and opportunity of extensions ([RFC 246](https://docs.google.com/document/d/1HngEeLNAe7_QzVJr6UPi0Si4ZALqTzb7uonOxUiJP6g/edit))
+1. 🔄 Improve the Sourcegraph extensions (internal) development experience ([RFC 155](https://docs.google.com/document/d/1ikrUNVe3YVbR-JpegxhjrFdmRkTGzTLcOMkKHnOyjuE/edit)) and (external) documentation
+1. Code insights TBD
+1. Sourcegraph web app navigation is clearer and intentionally designed ([RFC 248](https://docs.google.com/document/d/1AEeCuXuYGlu2kU9HfTuh5rMuoL2ASxy-G4LFje_ySFE/edit?usp=drive_web&ouid=110069214620879702746))
+1. Page title breadcrumbs are unified and useful 
+1. Later-stage code insights work 
+

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -13,37 +13,9 @@ This is a large ownership area, so the team creates a focused plan each iteratio
 - #web channel or @web-team in Slack.
 - [team/web](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/web) label and [@sourcegraph/web](https://github.com/orgs/sourcegraph/teams/web) team on GitHub.
 
-## Goals
+## [Goals](goals.md)
 
-### Long term
-
-**_Deliver the full, unique value of [extensions](https://docs.sourcegraph.com/extensions) to our users._**
-
-**Outcome**: Our webapp, browser extensions and native integrations are great platforms to provide our users unique value through extensions. These platforms are well-maintained, consistent, easy to setup, well-documented, well-tested, performant, and show their power through convincing extensions built on top of them. The extensions platform and API provide powerful capabilities to extension developers and a great developer experience.
-
-### Medium term
-
-To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
-We will tackle these medium-term goals in order, though expect to have some work done in parallel as we progress.
-
-1. **Make the products that extensions are build on (web app, code host integrations) more consistent and improve discoverability.**
-   Our web app has accumulated a lot of design debt over time, which negatively impacts how we can use it as a vehicle to deliver extensions.
-   With areas like the repository page, user settings area (which extensions are configured through), navigation, command palette UI and the extension registry affected, it is hard to provide a good UX around extensions (the extension registry blends into goal (2)).
-   Our code host integrations, which are an implementation of our extension API, are a huge driver of adoption inside companies and multiply the value of extensions by bringing them into code review workflows, but are difficult to discover and setup.
-2. **Bring the extension platform into shape.**
-   Our extension platform includes the workflow around creating, installing and using extensions, the API exposed to developers and its documentation.
-   To grow adoption of extensions, these need to be solid, but they are currently lacking on multiple dimensions.
-   Some API areas like code insights are still in prototype phase and are still undocumented (this blends into goal (3)).
-   Our extension host is also currently implemented in a way that makes it difficult for us to maintain, evolve to enable more use cases and to onboard new teammates into this area of the codebase.
-   Combining this with writing a few smaller extensions (part of goal (3)) allows us to dogfood the experience and inform us where the platform is lacking.
-3. **Build out compelling use cases with the extensions platform.**
-   This includes writing more extensions ourselves, but also extending the extension API with more capabilities to enable more use cases.
-   We have a long list of ideas and use cases customers shared with us that we can solve and/or enable customers to solve with extensions.
-   Some of these integrate Sourcegraph with more external services to suit the setups of more customers, others provide completely new value no other product provides.
-
-### Short term
-
-See [iterations](#iterations).
+See [goals](goals.md)
 
 ## Tech stack
 

--- a/handbook/product/roadmap.md
+++ b/handbook/product/roadmap.md
@@ -96,12 +96,4 @@ See [WIP roadmap](https://sourcegraph.productboard.com/feature-board/2119755-clo
 
 ## Web
 
-1. ✅ Existing sourcegraph extensions are more discoverable ([RFC 209](https://docs.google.com/document/d/1I5BMEGp3QuB81AjSzLCQwq_XJV1sXevlU0lpB4O1pj8/edit#))
-1. ✅ The Sourcegraph browser extension is more discoverable and easy to congifure ([RFC 221](https://docs.google.com/document/d/19f4xleYBU1zZZdqMmXlLmFxeR-fwEpOwTOgViOFOnyo/edit))
-1. 🔄 Build new and improved Sourcegraph extensions to showcase the value and opportunity of extensions ([RFC 246](https://docs.google.com/document/d/1HngEeLNAe7_QzVJr6UPi0Si4ZALqTzb7uonOxUiJP6g/edit))
-1. Improve the Sourcegraph extensions (internal) development experience ([RFC 155](https://docs.google.com/document/d/1ikrUNVe3YVbR-JpegxhjrFdmRkTGzTLcOMkKHnOyjuE/edit)) and (external) documentation
-1. Code insights TBD
-1. Sourcegraph web app navigation is clearer and intentionally designed ([RFC 248](https://docs.google.com/document/d/1AEeCuXuYGlu2kU9HfTuh5rMuoL2ASxy-G4LFje_ySFE/edit?usp=drive_web&ouid=110069214620879702746))
-1. Page title breadcrumbs are unified and useful 
-1. Later-stage code insights work 
-
+See [web roadmap](../engineering/web/goals.md#roadmap)


### PR DESCRIPTION
I'm not sure what makes sense here in the long term, but copied the Cloud structure for now and kicked off because of [this thread](https://sourcegraph.slack.com/archives/C0C324C91/p1603917865276000). 

The thing I don't love is that we're linking to the iteration google doc and board in two places now. But I didn't want the goals page to not have direct links to all goals, and I also think it made sense to have the iterations linked to in the "iteration process" section of the web team index page. I'm happy to leave this PR in draft for a bit if there's another change coming that Christina may have alluded to in her slack message in that thread. 