### PR TITLE
Fixed so web team title shows up searching for the Web Team page again in search

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -1,6 +1,6 @@
-<img src="./logo.svg" alt="Sourcegraph Web Team Logo" style="width: 35%; float: right; margin-left: 1rem">
-
 # Web team
+
+<img src="./logo.svg" alt="Sourcegraph Web Team Logo" style="width: 15%; float: left; margin-right: 1rem; margin-bottom: 1rem">
 
 The web team owns the maintenance and expansion of our web application and code host integrations as vehicles to deliver the value of [extensions](https://docs.sourcegraph.com/extensions) to our users.
 


### PR DESCRIPTION
We added a logo, but it seems that when you add anything above the first h1 tag the docsite search leaves it an "untitled" page: 
![image](https://user-images.githubusercontent.com/11967660/97767537-e8bf2b00-1ad9-11eb-80bf-08dfdc267104.png)

So I moved the image back below the title. Feel free to restyle. 