### PR TITLE
Revert "Fixed so web team title shows up searching for the Web Team page again in search"

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -1,6 +1,6 @@
-# Web team
+<img src="./logo.svg" alt="Sourcegraph Web Team Logo" style="width: 35%; float: right; margin-left: 1rem">
 
-<img src="./logo.svg" alt="Sourcegraph Web Team Logo" style="width: 15%; float: left; margin-right: 1rem; margin-bottom: 1rem">
+# Web team
 
 The web team owns the maintenance and expansion of our web application and code host integrations as vehicles to deliver the value of [extensions](https://docs.sourcegraph.com/extensions) to our users.
 


### PR DESCRIPTION
Reverts sourcegraph/about#1892

Fixed this in https://github.com/sourcegraph/docsite/pull/63