### PR TITLE
Changing the web team goals to encompass design, extensions, and code insights 

### DIFF
--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -29,7 +29,7 @@ _To reach our long-term goal, we set the following medium-term goals to guide ou
 
 1. **Make Sourcegraph extensions a core part of Sourcegraph users' experiences.**
    1. Track anonymized, general usage of extensions to determine which extensions are most successful at adding value for our users to inform our future work.
-   1. Build new API endpoints that are robust and obviously useful (used immediately in an extension), to grow adoption of extensions. 
+   1. Build, maintain, and update API endpoints that are robust and immediately useful, to grow adoption of extensions. 
    1. Make the extensions action bar clear and scalable, and help users discover and use our extensions. 
    1. Improve discoverability and design of the extension registry to enable users to find the most useful extensions and make users excited to build their own extension. 
 

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -38,7 +38,7 @@ _To reach our long-term goal, we set the following medium-term goals to guide ou
    1. Expose more generalizable metrics that let our users measure and track their own goals, whether those are migrations, code smells, security needs, cross-collaboration, or other information about code. 
    1. Expose features that let our users build their own insights. 
 
-1. **Make code host integrations reach more users more often.**
+1. **Increase the weekly active users of all our code host integrations.**
    1. Maintain the existing native integrations and browser extensions. 
    1. Build support for new code hosts and new browsers, like Safari and Gerrit. 
    1. Build support for the browser extension to reference both a private Sourcegraph instance and public code on Sourcegraph.com. 

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -8,7 +8,7 @@
 
   1. **_Creating and maintaining a highly usable and intentionally designed webapp interface_**
   1. **_Delivering the full, unique value of Sourcegraph [extensions](https://docs.sourcegraph.com/extensions)_**
-  1. **_Maintaining and expanding code host [integrations](https://docs.sourcegraph.com/integration)_**
+  1. **_Maintaining and expanding [code host integrations](https://docs.sourcegraph.com/dev/background-information/web/code_host_integrations)_**
   1. **_Developing code insights into an entirely new featureset_**
 
 **Outcome**: 

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -21,7 +21,7 @@
 
 ### Medium term
 
-_To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans. These medium-term goals are listed in order of rough priority. This means we prefer a sooner-listed goal when making progress on one would conflict with another goal, but it doesn't mean we only work on the first goal until it's done – we balance our iterations in sum so we can make some progress on all of these goals over a quarter. Within each goal, the sub-goals are also listed in (stricter) priority order._ 
+_To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans. These medium-term goals are listed in order of rough priority. This means we preference a sooner-listed goal when making progress on one would conflict with another goal, but it doesn't mean we only work on the first goal until it's done – we balance our iterations in sum so we can make some progress on all of these goals over a quarter. Within each goal, the sub-goals are also listed in (stricter) priority order._ 
 
 1. **Make the Sourcegraph web interfaces more consistent and improve discoverability of Sourcegraph features.**
    1. Make progress on design debt throughout the web app where the web team owns the design: repo page areas and panels, navigation and headers, general theming, and the blob page (file viewer). 

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -21,7 +21,7 @@
 
 ### Medium term
 
-_To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans. These medium-term goals are listed in order of rought priority. This means we preference the sooner-listed goal when making progress on one would conflict with another goal, but it doesn't mean we only work on the first goal until it's done – we balance our iterations in sum so we can make some progress on all of these goals over a quarter. Within each goal, the sub-goals are also listed in (stricter) priority order._ 
+_To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans. These medium-term goals are listed in order of rough priority. This means we preference a sooner-listed goal when making progress on one would conflict with another goal, but it doesn't mean we only work on the first goal until it's done – we balance our iterations in sum so we can make some progress on all of these goals over a quarter. Within each goal, the sub-goals are also listed in (stricter) priority order._ 
 
 1. **Make the Sourcegraph web interfaces more consistent and improve discoverability of Sourcegraph features.**
    1. Make progress on design debt throughout the web app where the web team owns the design: repo page areas and panels, navigation and headers, general theming, and the blob page (file viewer). 

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -24,7 +24,7 @@
 _To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans. These medium-term goals are listed in order of rought priority. This means we preference the sooner-listed goal when making progress on one would conflict with another goal, but it doesn't mean we only work on the first goal until it's done – we balance our iterations in sum so we can make some progress on all of these goals over a quarter. Within each goal, the sub-goals are also listed in (stricter) priority order._ 
 
 1. **Make the Sourcegraph web interfaces more consistent and improve discoverability of Sourcegraph features.**
-   1. Make progress on design debt throughought the web app where the web team owns the design: repo page areas and panels, navigation and headers, general theming, and the blog page (file viewer). 
+   1. Make progress on design debt throughout the web app where the web team owns the design: repo page areas and panels, navigation and headers, general theming, and the blob page (file viewer). 
    1. Build and update designs to help users discover or understand everything Sourcegraph offers, like new navigation menus and header concepts. 
 
 1. **Make Sourcegraph extensions a core part of Sourcegraph users' experiences.**

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -21,7 +21,7 @@
 
 ### Medium term
 
-_To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans. These medium-term goals are listed in order of rough priority. This means we preference a sooner-listed goal when making progress on one would conflict with another goal, but it doesn't mean we only work on the first goal until it's done – we balance our iterations in sum so we can make some progress on all of these goals over a quarter. Within each goal, the sub-goals are also listed in (stricter) priority order._ 
+_To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans. These medium-term goals are listed in order of rough priority. This means we prefer a sooner-listed goal when making progress on one would conflict with another goal, but it doesn't mean we only work on the first goal until it's done – we balance our iterations in sum so we can make some progress on all of these goals over a quarter. Within each goal, the sub-goals are also listed in (stricter) priority order._ 
 
 1. **Make the Sourcegraph web interfaces more consistent and improve discoverability of Sourcegraph features.**
    1. Make progress on design debt throughout the web app where the web team owns the design: repo page areas and panels, navigation and headers, general theming, and the blob page (file viewer). 

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -4,35 +4,44 @@
 
 ### Long term
 
-**_The web team has three areas of focus: creating and maintaining a highly usable and intentionally designed webapp interface; delivering the full, unique value of [extensions](https://docs.sourcegraph.com/extensions); maintaining and expanding code host integrations; and developing code insights into an entirely new featureset._**
+**_The web team has four areas of focus:_**
+
+  1. **_Creating and maintaining a highly usable and intentionally designed webapp interface_**
+  1. **_Delivering the full, unique value of Sourcegraph [extensions](https://docs.sourcegraph.com/extensions)_**
+  1. **_Maintaining and expanding code host [integrations](https://docs.sourcegraph.com/integration)_**
+  1. **_Developing code insights into an entirely new featureset_**
 
 **Outcome**: 
-1. Our webapp, browser extensions and native integrations, and code insights all provide our users unique value. 
-1. These platforms are well-maintained, well-designed, consistent, easy to setup, well-documented, well-tested, performant, and leave users impressed. 
-1. The webapp helps users discover and employ the full power of Sourcegraph effectively, with a high quality and highly usable interface. 
-1. Soucegraph extensions and extensions API provide powerful capabilities to users and a great experience for extension developers. 
-1. Code insights expose the value of code metadata to users at all levels of an organization. 
+
+* All of these areas of focus are well-maintained, well-designed, well-documented, well-tested, performant, easy to set up, and leave users impressed. 
+* The webapp helps users discover and employ the full power of Sourcegraph effectively, with a high quality and highly usable interface. 
+* Soucegraph extensions and the extensions API provide powerful capabilities to users and a great experience for extension developers. 
+* Sourcegraph code host native integrations and browser extensions support the most common code hosts and browsers. 
+* Code insights expose the value of Sourcegraph's knowledge of your codebase to users at all levels of an organization. 
 
 ### Medium term
 
-TODO SPLIT TO 4 CATEGORIES
-
-To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
+_To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans. These medium-term goals are listed in order of rought priority. This means we preference the sooner-listed goal when making progress on one would conflict with another goal, but it doesn't mean we only work on the first goal until it's done – we balance our iterations in sum so we can make some progress on all of these goals over a quarter. Within each goal, the sub-goals are also listed in (stricter) priority order._ 
 
 1. **Make the Sourcegraph web interfaces more consistent and improve discoverability of Sourcegraph features.**
-   
-   1.  Make progress on design debt throughought the web app, such as on the repository page, user settings area, navigation, settings, and command palette UI. 
-   1. TODO ADD/SPLIT
+   1. Make progress on design debt throughought the web app where the web team owns the design: repo page areas and panels, navigation and headers, general theming, and the blog page (file viewer). 
+   1. Build and update designs to help users discover or understand everything Sourcegraph offers, like new navigation menus and header concepts. 
 
-2. **Make the browser extension and Sourcegraph extensions a core part of Sourcegraph users' experiences.**
-   1. To grow adoption of extensions, build new API endpoints that are robust and obviously useful. 
-   1. The extensions action bar needs to be clear and scalable, and help users discover our extensions. 
-   1. We want to track anonymized, general usage of extensions to determine which extensions are most successful at adding value for our users. 
+1. **Make Sourcegraph extensions a core part of Sourcegraph users' experiences.**
+   1. Track anonymized, general usage of extensions to determine which extensions are most successful at adding value for our users to inform our future work.
+   1. Build new API endpoints that are robust and obviously useful (used immediately in an extension), to grow adoption of extensions. 
+   1. Make the extensions action bar clear and scalable, and help users discover and use our extensions. 
    1. Improve discoverability and design of the extension registry to enable users to find the most useful extensions and make users excited to build their own extension. 
 
-3. **Make insights an entirely new reason to use Sourcegraph.**
-   1. We want to expose metrics that let our users measure and track their own goals, whether those are migrations, code smells, security needs, cross-collaboration, or other information about code. 
-   1. We want to focus this project on the most pressing needs of our customers, before expanding it to cover continually more use cases. 
+1. **Make code insights an entirely new reason to use Sourcegraph.**
+   1. Focus on building prototypes to solve the most pressing needs of our customers, to clearly demonstrate the value of code insights. 
+   1. Expose more generalizable metrics that let our users measure and track their own goals, whether those are migrations, code smells, security needs, cross-collaboration, or other information about code. 
+   1. Expose features that let our users build their own insights. 
+
+1. **Make code host integrations reach more users more often.**
+   1. Maintain the existing native integrations and browser extensions. 
+   1. Build support for new code hosts and new browsers, like Safari and Gerrit. 
+   1. Build support for the browser extension to reference both a private Sourcegraph instance and public code on Sourcegraph.com. 
 
 ### Short term
 
@@ -46,8 +55,8 @@ The individual tasks and progress of the current iteration can be found as GitHu
 1. ✅ The Sourcegraph browser extension is more discoverable and easy to congifure ([RFC 221](https://docs.google.com/document/d/19f4xleYBU1zZZdqMmXlLmFxeR-fwEpOwTOgViOFOnyo/edit))
 1. ✅ Build new and improved Sourcegraph extensions to showcase the value and opportunity of extensions ([RFC 246](https://docs.google.com/document/d/1HngEeLNAe7_QzVJr6UPi0Si4ZALqTzb7uonOxUiJP6g/edit))
 1. ✅ Improve the Sourcegraph extensions (internal) development experience ([RFC 155](https://docs.google.com/document/d/1ikrUNVe3YVbR-JpegxhjrFdmRkTGzTLcOMkKHnOyjuE/edit)) and (external) documentation
-1. 🔄 Code insights TBD
+1. 🔄 Code insights migration prototype and directory decoration
+1. 🔄 Safari browser extension
 1. Sourcegraph web app navigation is clearer and intentionally designed ([RFC 248](https://docs.google.com/document/d/1AEeCuXuYGlu2kU9HfTuh5rMuoL2ASxy-G4LFje_ySFE/edit?usp=drive_web&ouid=110069214620879702746))
 1. Page title breadcrumbs are unified and useful 
 1. Later-stage code insights work 
-

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -4,9 +4,9 @@
 
 ### Long term
 
-**_Deliver the full, unique value of [extensions](https://docs.sourcegraph.com/extensions) to our users._**
+**_The web team has three areas of focus: creating and maintaining a highly usable and intentionally designed webapp interface; delivering the full, unique value of [extensions](https://docs.sourcegraph.com/extensions) to our users; and developing code insights into an entirely new featureset._**
 
-**Outcome**: Our webapp, browser extensions and native integrations, and code insights are great platforms to provide our users unique value. These platforms are well-maintained, well-designed, consistent, easy to setup, well-documented, well-tested, performant, and leave users impressed. The extensions platform and API provide powerful capabilities to extension developers and a great developer experience. The webapp helps users discover and employ the full power of Sourcegraph effectively. Code insights expose the value of code metadata to users at all levels of an organization. 
+**Outcome**: Our webapp, browser extensions and native integrations, and code insights all provide our users unique value. These platforms are well-maintained, well-designed, consistent, easy to setup, well-documented, well-tested, performant, and leave users impressed. The webapp helps users discover and employ the full power of Sourcegraph effectively, with a high quality and highly usable interface. The extensions and extensions API provide powerful capabilities to users and a great experience for extension developers. Code insights expose the value of code metadata to users at all levels of an organization. 
 
 ### Medium term
 
@@ -14,11 +14,10 @@ To reach our long-term goal, we set the following medium-term goals to guide our
 
 1. **Make the Sourcegraph web interfaces more consistent and improve discoverability of Sourcegraph features.**
    Our web app has accumulated a lot of design debt over time, which negatively impacts how we can use it as a vehicle to deliver extensions.
-   With areas like the repository page, user settings area (which extensions are configured through), navigation, settings, command palette UI and overall design affected, we want to provide the best possible UX for using Sourcegraph. 
-   Our code host integrations, which are an implementation of our extension API, are a huge driver of adoption inside companies and multiply the value of extensions by bringing them into code review workflows, and we want to ensure every user can discover and set them up. 
-2. **Make extensions a core part of Sourcegraph users' experiences.**
+   With areas like the repository page, user settings area, navigation, settings, command palette UI and overall design affected, we want to provide the best possible UX for using Sourcegraph. 
+2. **Make the browser extension and Sourcegraph extensions a core part of Sourcegraph users' experiences.**
    Our extension platform includes the workflow around creating, installing and using extensions, the API exposed to developers and its documentation.
-   To grow adoption of extensions, these need to be solid, but they are currently lacking on multiple dimensions.
+   To grow adoption of extensions, these need to be solid and obviously useful. The extensions action bar needs to be clear and scalable, and help users discover our extensions. We want to track anonymized, general usage of extensions to determine which extensions are most successful at adding value for our users. 
    We have a powerful extension API, but we know of use cases and customer requests that could put adddional endpoints to use. 
    Extensions are much-loved by users, but the extensions registry can be difficult to discover and has room for design improvements around finding the most useful extensions and making someone excited to build their own extension. 
 3. **Make insights an entirely new reason to use Sourcegraph.**

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -4,24 +4,35 @@
 
 ### Long term
 
-**_The web team has three areas of focus: creating and maintaining a highly usable and intentionally designed webapp interface; delivering the full, unique value of [extensions](https://docs.sourcegraph.com/extensions) to our users; and developing code insights into an entirely new featureset._**
+**_The web team has three areas of focus: creating and maintaining a highly usable and intentionally designed webapp interface; delivering the full, unique value of [extensions](https://docs.sourcegraph.com/extensions); maintaining and expanding code host integrations; and developing code insights into an entirely new featureset._**
 
-**Outcome**: Our webapp, browser extensions and native integrations, and code insights all provide our users unique value. These platforms are well-maintained, well-designed, consistent, easy to setup, well-documented, well-tested, performant, and leave users impressed. The webapp helps users discover and employ the full power of Sourcegraph effectively, with a high quality and highly usable interface. The extensions and extensions API provide powerful capabilities to users and a great experience for extension developers. Code insights expose the value of code metadata to users at all levels of an organization. 
+**Outcome**: 
+1. Our webapp, browser extensions and native integrations, and code insights all provide our users unique value. 
+1. These platforms are well-maintained, well-designed, consistent, easy to setup, well-documented, well-tested, performant, and leave users impressed. 
+1. The webapp helps users discover and employ the full power of Sourcegraph effectively, with a high quality and highly usable interface. 
+1. Soucegraph extensions and extensions API provide powerful capabilities to users and a great experience for extension developers. 
+1. Code insights expose the value of code metadata to users at all levels of an organization. 
 
 ### Medium term
+
+TODO SPLIT TO 4 CATEGORIES
 
 To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
 
 1. **Make the Sourcegraph web interfaces more consistent and improve discoverability of Sourcegraph features.**
-   Our web app has accumulated a lot of design debt over time, which negatively impacts how we can use it as a vehicle to deliver extensions.
-   With areas like the repository page, user settings area, navigation, settings, command palette UI and overall design affected, we want to provide the best possible UX for using Sourcegraph. 
+   
+   1.  Make progress on design debt throughought the web app, such as on the repository page, user settings area, navigation, settings, and command palette UI. 
+   1. TODO ADD/SPLIT
+
 2. **Make the browser extension and Sourcegraph extensions a core part of Sourcegraph users' experiences.**
-   Our extension platform includes the workflow around creating, installing and using extensions, the API exposed to developers and its documentation.
-   To grow adoption of extensions, these need to be solid and obviously useful. The extensions action bar needs to be clear and scalable, and help users discover our extensions. We want to track anonymized, general usage of extensions to determine which extensions are most successful at adding value for our users. 
-   We have a powerful extension API, but we know of use cases and customer requests that could put adddional endpoints to use. 
-   Extensions are much-loved by users, but the extensions registry can be difficult to discover and has room for design improvements around finding the most useful extensions and making someone excited to build their own extension. 
+   1. To grow adoption of extensions, build new API endpoints that are robust and obviously useful. 
+   1. The extensions action bar needs to be clear and scalable, and help users discover our extensions. 
+   1. We want to track anonymized, general usage of extensions to determine which extensions are most successful at adding value for our users. 
+   1. Improve discoverability and design of the extension registry to enable users to find the most useful extensions and make users excited to build their own extension. 
+
 3. **Make insights an entirely new reason to use Sourcegraph.**
-   We have a powerful amount of information about a codebase, and we want to expose metrics that let our users measure and track their own goals, whether those are migrations, code smells, security needs, cross-collaboration, or other information about code. We want to focus this project on the most pressing needs of our customers, before expanding it to cover continually more use cases. 
+   1. We want to expose metrics that let our users measure and track their own goals, whether those are migrations, code smells, security needs, cross-collaboration, or other information about code. 
+   1. We want to focus this project on the most pressing needs of our customers, before expanding it to cover continually more use cases. 
 
 ### Short term
 
@@ -34,8 +45,8 @@ The individual tasks and progress of the current iteration can be found as GitHu
 1. ✅ Existing sourcegraph extensions are more discoverable ([RFC 209](https://docs.google.com/document/d/1I5BMEGp3QuB81AjSzLCQwq_XJV1sXevlU0lpB4O1pj8/edit#))
 1. ✅ The Sourcegraph browser extension is more discoverable and easy to congifure ([RFC 221](https://docs.google.com/document/d/19f4xleYBU1zZZdqMmXlLmFxeR-fwEpOwTOgViOFOnyo/edit))
 1. ✅ Build new and improved Sourcegraph extensions to showcase the value and opportunity of extensions ([RFC 246](https://docs.google.com/document/d/1HngEeLNAe7_QzVJr6UPi0Si4ZALqTzb7uonOxUiJP6g/edit))
-1. 🔄 Improve the Sourcegraph extensions (internal) development experience ([RFC 155](https://docs.google.com/document/d/1ikrUNVe3YVbR-JpegxhjrFdmRkTGzTLcOMkKHnOyjuE/edit)) and (external) documentation
-1. Code insights TBD
+1. ✅ Improve the Sourcegraph extensions (internal) development experience ([RFC 155](https://docs.google.com/document/d/1ikrUNVe3YVbR-JpegxhjrFdmRkTGzTLcOMkKHnOyjuE/edit)) and (external) documentation
+1. 🔄 Code insights TBD
 1. Sourcegraph web app navigation is clearer and intentionally designed ([RFC 248](https://docs.google.com/document/d/1AEeCuXuYGlu2kU9HfTuh5rMuoL2ASxy-G4LFje_ySFE/edit?usp=drive_web&ouid=110069214620879702746))
 1. Page title breadcrumbs are unified and useful 
 1. Later-stage code insights work 

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -6,27 +6,23 @@
 
 **_Deliver the full, unique value of [extensions](https://docs.sourcegraph.com/extensions) to our users._**
 
-**Outcome**: Our webapp, browser extensions and native integrations are great platforms to provide our users unique value through extensions. These platforms are well-maintained, consistent, easy to setup, well-documented, well-tested, performant, and show their power through convincing extensions built on top of them. The extensions platform and API provide powerful capabilities to extension developers and a great developer experience.
+**Outcome**: Our webapp, browser extensions and native integrations, and code insights are great platforms to provide our users unique value. These platforms are well-maintained, well-designed, consistent, easy to setup, well-documented, well-tested, performant, and leave users impressed. The extensions platform and API provide powerful capabilities to extension developers and a great developer experience. The webapp helps users discover and employ the full power of Sourcegraph effectively. Code insights expose the value of code metadata to users at all levels of an organization. 
 
 ### Medium term
 
 To reach our long-term goal, we set the following medium-term goals to guide our short-term iteration plans.
-We will tackle these medium-term goals in order, though expect to have some work done in parallel as we progress.
 
-1. **Make the products that extensions are build on (web app, code host integrations) more consistent and improve discoverability.**
+1. **Make the Sourcegraph web interfaces more consistent and improve discoverability of Sourcegraph features.**
    Our web app has accumulated a lot of design debt over time, which negatively impacts how we can use it as a vehicle to deliver extensions.
-   With areas like the repository page, user settings area (which extensions are configured through), navigation, command palette UI and the extension registry affected, it is hard to provide a good UX around extensions (the extension registry blends into goal (2)).
-   Our code host integrations, which are an implementation of our extension API, are a huge driver of adoption inside companies and multiply the value of extensions by bringing them into code review workflows, but are difficult to discover and setup.
-2. **Bring the extension platform into shape.**
+   With areas like the repository page, user settings area (which extensions are configured through), navigation, settings, command palette UI and overall design affected, we want to provide the best possible UX for using Sourcegraph. 
+   Our code host integrations, which are an implementation of our extension API, are a huge driver of adoption inside companies and multiply the value of extensions by bringing them into code review workflows, and we want to ensure every user can discover and set them up. 
+2. **Make extensions a core part of Sourcegraph users' experiences.**
    Our extension platform includes the workflow around creating, installing and using extensions, the API exposed to developers and its documentation.
    To grow adoption of extensions, these need to be solid, but they are currently lacking on multiple dimensions.
-   Some API areas like code insights are still in prototype phase and are still undocumented (this blends into goal (3)).
-   Our extension host is also currently implemented in a way that makes it difficult for us to maintain, evolve to enable more use cases and to onboard new teammates into this area of the codebase.
-   Combining this with writing a few smaller extensions (part of goal (3)) allows us to dogfood the experience and inform us where the platform is lacking.
-3. **Build out compelling use cases with the extensions platform.**
-   This includes writing more extensions ourselves, but also extending the extension API with more capabilities to enable more use cases.
-   We have a long list of ideas and use cases customers shared with us that we can solve and/or enable customers to solve with extensions.
-   Some of these integrate Sourcegraph with more external services to suit the setups of more customers, others provide completely new value no other product provides.
+   We have a powerful extension API, but we know of use cases and customer requests that could put adddional endpoints to use. 
+   Extensions are much-loved by users, but the extensions registry can be difficult to discover and has room for design improvements around finding the most useful extensions and making someone excited to build their own extension. 
+3. **Make insights an entirely new reason to use Sourcegraph.**
+   We have a powerful amount of information about a codebase, and we want to expose metrics that let our users measure and track their own goals, whether those are migrations, code smells, security needs, cross-collaboration, or other information about code. We want to focus this project on the most pressing needs of our customers, before expanding it to cover continually more use cases. 
 
 ### Short term
 


### PR DESCRIPTION
This came out of a web/product meeting around trying to resolve our tensions with “web goals” vs “design goals” and we decided that the web team has a couple “categories” of goals at the moment, all of which are important.

I'm not sure if "browser extension" should fall more in "extensions" or "general web feature" but that's not super important. 

I removed the "linearity" of our medium term goals since these need to be tackled in parallel. I removed some work we've already done. I also removed the attempt to "theme" everything about extensions and am digging into the fact that there are three distinct categories here. 

Short term goals updates are on their way!