### PR TITLE
Document growth plan for the search team

### DIFF
--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -71,9 +71,19 @@ Iterations start **every other Monday**.
 
 ## Growth plan
 
-_Updated 2020-10-07_
+_Updated 2020-11-05_
 
 We are looking to hire:
 
 - A [full-stack software engineer](../hiring/software-engineer-full-stack.md)
 - A [backend software engineer](../hiring/software-engineer-backend.md)
+
+### Splitting the team
+
+Loïc will be at management capacity when we reach 7-8 engineers on the team, but we will still need to grow further to deliver on our goals for search. Our next step will be to split the team in half:
+- The **Search:core** team will focus on the capabilities, scalability and polish of our core feature set: search language and supporting UI, search backends.
+- The **Search:growth** team will focus on initiatives aiming at growing usage or adoption of our search features, such as onboarding efforts or features unlocking new use cases (eg. code monitoring).
+
+Both of these teams will be cross-functional, with frontend + backend skills, and will have design needs.
+
+Before we split these teams, we will need to hire an EM and a PM.


### PR DESCRIPTION
The search team will eventually need to split to support future headcount growth, this PR documents a proposed split.