### PR TITLE
Standardize goals and roadmaps for engineering teams

### DIFF
--- a/company/goals/index.md
+++ b/company/goals/index.md
@@ -29,12 +29,12 @@ See "[Guidelines for goals](guidelines.md)" for more information about how we ch
 ## Engineering
 <!-- When updating the engineering team list below, please also update handbook/index.md. -->
 ### [Engineering leadership](../../handbook/engineering/leadership/index.md#goals)
-### [Campaigns](../../handbook/engineering/campaigns/index.md#goals)
+### [Campaigns](../../handbook/engineering/campaigns/goals.md#goals)
 ### [Cloud](../../handbook/engineering/cloud/goals.md#goals)
-### [Code intelligence](../../handbook/engineering/code-intelligence/index.md#goals)
-### [Distribution](../../handbook/engineering/distribution/goals.md)
-### [Search](../../handbook/engineering/search/goals.md)
-### [Security](../../handbook/engineering/security/index.md#goals)
+### [Code intelligence](../../handbook/engineering/code-intelligence/goals.md#goals)
+### [Distribution](../../handbook/engineering/distribution/goals.md#goals)
+### [Search](../../handbook/engineering/search/goals.md#goals)
+### [Security](../../handbook/engineering/security/goals.md#goals)
 ### [Web](../../handbook/engineering/web/goals.md#goals)
 
 ## [Product](../../handbook/product/goals.md)

--- a/handbook/engineering/campaigns/goals.md
+++ b/handbook/engineering/campaigns/goals.md
@@ -1,0 +1,61 @@
+# Campaigns goals and priorities
+
+## Goals
+
+### Build a base of three customers who regularly use campaigns
+
+We want to get a solid set of customers who regularly use and rely on campaigns. “Regularly” means at least one campaign per month.
+
+What will get us there?
+
+- **Smoother on-ramp:** Internal testing has revealed that using campaigns for the first time is not as easy as it could be. A frictionless initial experience is critical to adoption and a delightful user experience.
+- **Better debugging experience:** It can be challenging to debug a more complex campaign. Figuring out what went wrong and how to fix it is a slow iterative loop.
+- **User validation:** The above issues were revealed by user testing. Once we believe we have fixed them, we need to validate this with further user testing.
+
+### Grow adoption of campaigns
+
+Once we’re out of beta, we want everyone to start using campaigns!
+
+We need to follow-up with customers who are already using campaigns to make sure that we’re taking their input into consideration when prioritizing new features.
+
+We need to make it as easy as possible for new customers to try out campaigns:
+
+- **Even smoother on-ramp:** Minimize the number of steps it takes a user to go from “found Campaigns in the Sourcegraph menu” to “has created a pull request, making a meaningful change”.
+- **Easy to try:** Allow users to run campaigns on sourcegraph.com to try them out (requires user-specific tokens).
+- **Examples:** Document as many meaningful example campaigns as possible.
+- **More examples:** Provide ready-to-go campaign specs that users can easily run.
+
+[Looker dashboard with usage metrics (internal only)](https://sourcegraph.looker.com/dashboards/136)
+
+### Make it easier for customers to change the code they want to change in their preferred way
+
+As we learn how people use Campaigns, we also need to focus on _how they wish they could use_ Campaigns.
+
+For example, Campaigns run on _repositories_ vs. on specific search results. When running a campaign, the code that’s being run to change code doesn’t have access to the specific search results (i.e. file + line number), only to the repository. That makes it hard to make really granular changes based on search results. (A possible solution would be a more refined interface between search results and user-supplied code. For example: we could pass lines of _<filename>:<lineno>_ on stdin to each command that’s executed in a repository.)
+
+Another example: in some cases, it’s cumbersome to first search code in the browser and then have to copy the query to a campaign-spec file and run the campaign. (A possible solution would be an implementation of the prototype that generates patches in the browser.)
+
+### Perform actions beyond creating/merging changesets
+
+Our users use more than just their code host and Sourcegraph. They use ticket trackers, review systems, and time trackers.
+
+We want to discover what external systems our users want to use campaigns with, and ensure that we can integrate with them. For example, an organization that uses JIRA will likely want to be able to link tickets to campaigns and have the state updated as the campaign is executed.
+
+## Roadmap
+
+1. **Customer outreach to improve adoption of campaigns**
+1. User credentials ([RFC 242](https://docs.google.com/document/d/1SqoWWm1xs82QibrWwYsXmpmgweN6EpcKt1qXrRBjjlU/edit)), which will allow non-site-admins to create campaigns
+1. Better burndown charts
+1. Versioning/releasing of src-cli with respect to sg/sg
+1. Improved documentation of src-cli login process
+1. Add filtering/searching to campaign and changeset lists
+1. Ability to auto-merge changesets, depending on various conditions
+1. Ability to add default reviewers to changesets
+
+### Roadmap Process
+
+Our roadmapping process is a team effort. As we receive customer feedback, and as we come up with cool new features, we record these in one of three places. Customer feedback goes into our [team Productboard page](https://sourcegraph.productboard.com/feature-board/2104383-campaigns). Well-defined tasks live in our [team backlog](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Ateam%2Fcampaigns+milestone%3ABacklog). And larger, less defined ideas live in the bottom section of our [private roadmap doc](https://docs.google.com/document/d/1zRTfK6mENKicfLwDaWgLk1dBvQVKDg-J7pwjGg8tpps/edit#), below the _fog of war_ line.
+
+It is the job of the EM and PM to pull/formulate/define tasks from the above sources and prioritize them. That prioritized list is under the [Future heading](https://docs.google.com/document/d/1zRTfK6mENKicfLwDaWgLk1dBvQVKDg-J7pwjGg8tpps/edit#heading=h.jk3gp8lyopke) of our roadmap doc.
+
+For our sprint planning, the team looks over the prioritized list, revises estimates on work needed, and agrees on these priorities. Once we are aligned, we pull as much as will comfortably fit into the next sprint, creating GitHub issues as needed, and track those in that sprint's tracking issue.

--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -29,58 +29,9 @@ Users provide the code to make the change, we provide the plumbing to turn it in
 * We don't try to come up with fancy and seemingly magic ways of changing code (i.e. high-level tools to refactor code) before we get the fundamentals right (running users' code in thousands of repositories and turning that into thousands of pull requests).
 * We don't interfere with the code that produces a change. We provide the infrastructure to run it across all of your repositories and turn it into a large-scale code change.
 
-## Goals
+## Goals and priorities
 
-### Build a base of three customers who regularly use campaigns
-
-We want to get a solid set of customers who regularly use and rely on campaigns. “Regularly” means at least one campaign per month.
-
-What will get us there?
-
-- **Smoother on-ramp:** Internal testing has revealed that using campaigns for the first time is not as easy as it could be. A frictionless initial experience is critical to adoption and a delightful user experience.
-- **Better debugging experience:** It can be challenging to debug a more complex campaign. Figuring out what went wrong and how to fix it is a slow iterative loop.
-- **User validation:** The above issues were revealed by user testing. Once we believe we have fixed them, we need to validate this with further user testing.
-
-### Grow adoption of campaigns
-
-Once we’re out of beta, we want everyone to start using campaigns!
-
-We need to follow-up with customers who are already using campaigns to make sure that we’re taking their input into consideration when prioritizing new features.
-
-We need to make it as easy as possible for new customers to try out campaigns:
-
-- **Even smoother on-ramp:** Minimize the number of steps it takes a user to go from “found Campaigns in the Sourcegraph menu” to “has created a pull request, making a meaningful change”.
-- **Easy to try:** Allow users to run campaigns on sourcegraph.com to try them out (requires user-specific tokens).
-- **Examples:** Document as many meaningful example campaigns as possible.
-- **More examples:** Provide ready-to-go campaign specs that users can easily run.
-
-[Looker dashboard with usage metrics (internal only)](https://sourcegraph.looker.com/dashboards/136)
-
-### Make it easier for customers to change the code they want to change in their preferred way
-
-As we learn how people use Campaigns, we also need to focus on _how they wish they could use_ Campaigns.
-
-For example, Campaigns run on _repositories_ vs. on specific search results. When running a campaign, the code that’s being run to change code doesn’t have access to the specific search results (i.e. file + line number), only to the repository. That makes it hard to make really granular changes based on search results. (A possible solution would be a more refined interface between search results and user-supplied code. For example: we could pass lines of _<filename>:<lineno>_ on stdin to each command that’s executed in a repository.)
-
-Another example: in some cases, it’s cumbersome to first search code in the browser and then have to copy the query to a campaign-spec file and run the campaign. (A possible solution would be an implementation of the prototype that generates patches in the browser.)
-
-### Perform actions beyond creating/merging changesets
-
-Our users use more than just their code host and Sourcegraph. They use ticket trackers, review systems, and time trackers.
-
-We want to discover what external systems our users want to use campaigns with, and ensure that we can integrate with them. For example, an organization that uses JIRA will likely want to be able to link tickets to campaigns and have the state updated as the campaign is executed.
-
-## Roadmap
-
-Our team's public roadmap is part of our larger [Product roadmap](https://about.sourcegraph.com/handbook/product/roadmap#campaigns).
-
-### Roadmap Process
-
-Our roadmapping process is a team effort. As we receive customer feedback, and as we come up with cool new features, we record these in one of three places. Customer feedback goes into our [team Productboard page](https://sourcegraph.productboard.com/feature-board/2104383-campaigns). Well-defined tasks live in our [team backlog](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Ateam%2Fcampaigns+milestone%3ABacklog). And larger, less defined ideas live in the bottom section of our [private roadmap doc](https://docs.google.com/document/d/1zRTfK6mENKicfLwDaWgLk1dBvQVKDg-J7pwjGg8tpps/edit#), below the _fog of war_ line.
-
-It is the job of the EM and PM to pull/formulate/define tasks from the above sources and prioritize them. That prioritized list is under the [Future heading](https://docs.google.com/document/d/1zRTfK6mENKicfLwDaWgLk1dBvQVKDg-J7pwjGg8tpps/edit#heading=h.jk3gp8lyopke) of our roadmap doc.
-
-For our sprint planning, the team looks over the prioritized list, revises estimates on work needed, and agrees on these priorities. Once we are aligned, we pull as much as will comfortably fit into the next sprint, creating GitHub issues as needed, and track those in that sprint's tracking issue.
+See [Campaigns goals and priorities](goals.md)
 
 ## Analogies
 

--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -2,9 +2,11 @@
 
 Goals are continuously updated and reviewed. If you find these goals do not reflect our current priorities or are out of date, please update them as soon as possible or add it as a topic to our [weekly sync](recurring_processes.md#weekly-distribution-team-sync).
 
-## Medium-term goals (~3-6 Months)
+## Goals
 
-### [Improve internal deployment pipeline UX](https://github.com/orgs/sourcegraph/projects/96)
+### Medium-term goals (~3-6 Months)
+
+#### [Improve internal deployment pipeline UX](https://github.com/orgs/sourcegraph/projects/96)
 
 Our existing deployment pipelines to our Sourcegraph instances (such as Sourcegraph Cloud) has several usability problems - for example, it is hard for engineers to identify when a commit was deployed to an environment or which deployment is currently running in a particular environment. We want to improve the deployment experience, making sure we can deploy with confidence and can easily understand in which stage of the pipeline a change currently is.
 
@@ -20,7 +22,7 @@ Our existing deployment pipelines to our Sourcegraph instances (such as Sourcegr
   - TBD: We can trigger rollbacks and deployments via a `/` command in Slack.
 - **Milestones**: TBD
 
-### Any engineer at Sourcegraph can create a release for all of our supported deployment types by running a single action
+#### Any engineer at Sourcegraph can create a release for all of our supported deployment types by running a single action
 
 Creating a new release for our deployments is currently a semi-automated process, which requires several manual steps and synchronizing our versioned artifacts (Sourcegraph, Kubernetes manifests, docker-compose manifests, etc). We want to enable any engineer to perform a release as often as needed, to enable this we want to make releasing Sourcegraph a simple, automated process.
 
@@ -39,7 +41,7 @@ Creating a new release for our deployments is currently a semi-automated process
   - [Ensure relevant engineers are notified of broken builds](https://github.com/orgs/sourcegraph/projects/90). **In progress**
   - Releases can be done automatically with a single action (e.g. CLI command, `/` command in Slack, etc.). _Estimated: 2020_
 
-### [Upgrades between releases are easy to perform](https://github.com/orgs/sourcegraph/projects/71)
+#### [Upgrades between releases are easy to perform](https://github.com/orgs/sourcegraph/projects/71)
 
 Performing upgrades to deployments is currently a complicated process that requires keeping a fork of our configuration and resolving diff conflicts when performing upgrades which are often complicated as the configuration might contain environment-specific customization. This process creates a bad experience for our customers because of the unknown amount of effort of the upgrade process.
 We will start by looking at our Kubernetes deployment and working on an easier update process.
@@ -64,7 +66,7 @@ We will start by looking at our Kubernetes deployment and working on an easier u
   - Design customization workflow.
     - Potentially Kustomize would still be used for last-mile changes and non-standard derivations.
 
-### Improve the debugging and troubleshooting process
+#### Improve the debugging and troubleshooting process
 
 As we deploy Sourcegraph to multiple different environments, we need to provide a consistent and straightforward process to debug issues. We are currently lacking tools to collect debugging information (configuration, type, size, diff from upstream, etc) consistently and a process to capture the output of debugging sessions to feed back into our priorities and documentation.
 We will initially focus on reducing the time it takes to collect troubleshooting information.
@@ -94,7 +96,7 @@ We will initially focus on reducing the time it takes to collect troubleshooting
   - Document project and folder usage guidelines.
   - Set spending limits for dynamic environments.
 
-### Site admins use reliable methods like Docker Compose or Kubernetes for production deployments
+#### Site admins use reliable methods like Docker Compose or Kubernetes for production deployments
 
 Many customers of Sourcegraph today are still running a single-container `sourcegraph/server` deployment in production. In 2019 we began advising all new deployments that this deployment option is _not_ for production use because it has no proper resource isolation and as such when it falls over it is impossible to debug, leading to painstakingly urgent migrations to better deployment types and frustrated/angry customers. We would like to get to a world where all production instances of Sourcegraph use reliable deployment methods like Docker Compose or Kubernetes.
 
@@ -109,7 +111,7 @@ Many customers of Sourcegraph today are still running a single-container `source
   - RFC approval.
   - ...TBD...
 
-### Support upgrading across multiple Sourcegraph versions
+#### Support upgrading across multiple Sourcegraph versions
 
 Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today (3.14 -> 3.15 -> 3.16 -> 3.17) which is extremely painful and time consuming for site admins, especially so given how time consuming our upgrade process is in general. We would like to make upgrades across multiple Sourcegraph versions easier.
 
@@ -119,10 +121,14 @@ Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today (3.
   - Customers can upgrade across multiple versions of Sourcegraph, allowing them to get up-to-date more quickly and easily.
 - **Milestones**:
 
-## Short-term goals
+### Short-term goals
 
 Short-term goals are described in our [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Atracking+label%3Ateam%2Fdistribution).
 
 ## Past goals
 
 We record past goals that we have completed [here](goals_completed.md).
+
+## Roadmap
+
+[Distribution roadmap PR](https://github.com/sourcegraph/about/pull/1104)

--- a/handbook/engineering/security/goals.md
+++ b/handbook/engineering/security/goals.md
@@ -1,0 +1,40 @@
+# Security goals and priorities
+
+## Goals
+
+These goals represent our targeted work for 70% of our time. The remaining 30% is reserved for items that arise such as security reports. Our current work is documented in our [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Atracking+label%3Ateam%2Fsecurity+is%3Aopen).
+
+### Visibility into Sourcegraph Cloud's attack surface
+
+**Problem:** The Cloud team is working toward [private code on Sourcegraph Cloud](../cloud/index.md#private-code-on-sourcegraph-cloud). Before we can have [confidence in our security model](#confidence-in-our-security-model), we first need to have visibility into current risks, issues, and threats, so we can proactively plan what work needs to be done (i.e., we don't want to be relying on or waiting for security researchers or customer to report vulnerabilities to us).
+
+**Milestones:**
+
+1. All Docker images are continuously scanned for known security vulnerabilities and the security team is alerted as vulnerabilities are found. (3.21 release)
+    1. Three or more vulnerabilities with a high severity, or a CVSS score of at least 4.0 are resolved. (3.21 release)
+1. We have resolved container vulnerabilities with a high severity, or a CVSS score of at least 4.0, or that resolution is planned. (3.22 release)
+1. All compute nodes are continuously scanned for known security vulnerabilities and the security team is alerted as vulnerabilities are found. (3.22 release)
+    1. We have resolved compute vulnerabilities with a high severity, or a CVSS score of at least 4.0, or that resolution is planned. (3.23 release)
+1. Implement centralized storage of all of our existing logs (e.g., application logs, compute infrastructure logs). (3.23 release)
+1. Start collecting audit and access logs (e.g., visibility into both intentional and unintentional logins). This is useful from both a security visibility point of view, as also a requirement for various auditing frameworks (though not currently a target). (3.23 release)
+1. Normalize log format in our centralized log storage so that it is easier to correlate and search. This is a prerequisite for creating automated alerts from the logs. (3.24 release)
+1. Create alerts and dashboards to automate the process of investigating events of interest (e.g., detect and alert on a spike of failed login attempts to a single account, or across Sourcegraph Cloud as a whole). (3.24 release)
+
+### Confidence in our security model
+
+**Problem:** We need to have a high degree of confidence in our overall security before we ask paying customers to trust us with their private code.
+
+**Milestones:**
+
+1. We need a better way to store and access [our own secrets](https://docs.google.com/document/d/1HzO7szEm-h4fqlQOnVbcJdpDmfQiM7Rb-Tz4CMEYl-Q).
+1. We connect our [test security repository](https://github.com/sourcegraph/security-test/blob/main/README.md) to Sourcegraph Cloud and only [members who can access that repository on GitHub](https://github.com/sourcegraph/security-test/settings/access) can access that repository on Sourcegraph Cloud (i.e., [Sourcegraph organization owners](https://github.com/orgs/sourcegraph/people?query=role%3Aowner) and [@sourcegraph/security](https://github.com/orgs/sourcegraph/teams/security) members). (3.22 release)
+   - **DEPENDENCY:** We can't do this until we can have [private code on Sourcegraph Cloud](../cloud/index.md#private-code-on-sourcegraph-cloud)
+1. We advertise a bounty for each unique vulnerability that allows an unauthorized person to gain access to our [test security repository](https://github.com/sourcegraph/security-test/blob/main/README.md) on Sourcegraph Cloud. (3.23 release)
+   - **DEPENDENCY:** This milestone depends on milestone 3 of [Visibility into Sourcegraph Cloud's attack surface](#visibility-into-sourcegraph-clouds-attack-surface). We should detect and fix the obvious issues ourselves before we start to invite others to attack us with large bounties.
+1. We run a time-bound capture the flag event where there are larger bounties for being able to gain access to our [test security repository](https://github.com/sourcegraph/security-test/blob/main/README.md) on Sourcegraph Cloud. (3.24 release)
+1. We host our private [infrastructure repository](http://github.com/sourcegraph/infrastructure) on Sourcegraph Cloud. (TBD, somewhat dependent on outputs of CtF)
+1. We allow paying customers to host their private code on Sourcegraph Cloud. (TBD, somewhat dependent on outputs of CtF)
+
+## Roadmap
+
+See [WIP roadmap in productboard](https://sourcegraph.productboard.com/feature-board/2119755-cloud)

--- a/handbook/engineering/security/index.md
+++ b/handbook/engineering/security/index.md
@@ -13,40 +13,9 @@ We think that security is an enabler for the business. Sourcegraph is committed 
 - [@sourcegraph/security](https://github.com/orgs/sourcegraph/teams/security) on GitHub.
 - [report a vulnerability](reporting-vulnerabilities.md)
 
-## Goals
+## Goals and priorities
 
-These goals represent our targeted work for 70% of our time. The remaining 30% is reserved for items that arise such as security reports. Our current work is documented in our [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+label%3Atracking+label%3Ateam%2Fsecurity+is%3Aopen).
-
-### Visibility into Sourcegraph Cloud's attack surface
-
-**Problem:** The Cloud team is working toward [private code on Sourcegraph Cloud](../cloud/index.md#private-code-on-sourcegraph-cloud). Before we can have [confidence in our security model](#confidence-in-our-security-model), we first need to have visibility into current risks, issues, and threats, so we can proactively plan what work needs to be done (i.e., we don't want to be relying on or waiting for security researchers or customer to report vulnerabilities to us).
-
-**Milestones:**
-
-1. All Docker images are continuously scanned for known security vulnerabilities and the security team is alerted as vulnerabilities are found. (3.21 release)
-    1. Three or more vulnerabilities with a high severity, or a CVSS score of at least 4.0 are resolved. (3.21 release)
-1. We have resolved container vulnerabilities with a high severity, or a CVSS score of at least 4.0, or that resolution is planned. (3.22 release)
-1. All compute nodes are continuously scanned for known security vulnerabilities and the security team is alerted as vulnerabilities are found. (3.22 release)
-    1. We have resolved compute vulnerabilities with a high severity, or a CVSS score of at least 4.0, or that resolution is planned. (3.23 release)
-1. Implement centralized storage of all of our existing logs (e.g., application logs, compute infrastructure logs). (3.23 release)
-1. Start collecting audit and access logs (e.g., visibility into both intentional and unintentional logins). This is useful from both a security visibility point of view, as also a requirement for various auditing frameworks (though not currently a target). (3.23 release)
-1. Normalize log format in our centralized log storage so that it is easier to correlate and search. This is a prerequisite for creating automated alerts from the logs. (3.24 release)
-1. Create alerts and dashboards to automate the process of investigating events of interest (e.g., detect and alert on a spike of failed login attempts to a single account, or across Sourcegraph Cloud as a whole). (3.24 release)
-
-### Confidence in our security model
-
-**Problem:** We need to have a high degree of confidence in our overall security before we ask paying customers to trust us with their private code.
-
-**Milestones:**
-
-1. We need a better way to store and access [our own secrets](https://docs.google.com/document/d/1HzO7szEm-h4fqlQOnVbcJdpDmfQiM7Rb-Tz4CMEYl-Q).
-1. We connect our [test security repository](https://github.com/sourcegraph/security-test/blob/main/README.md) to Sourcegraph Cloud and only [members who can access that repository on GitHub](https://github.com/sourcegraph/security-test/settings/access) can access that repository on Sourcegraph Cloud (i.e., [Sourcegraph organization owners](https://github.com/orgs/sourcegraph/people?query=role%3Aowner) and [@sourcegraph/security](https://github.com/orgs/sourcegraph/teams/security) members). (3.22 release)
-   - **DEPENDENCY:** We can't do this until we can have [private code on Sourcegraph Cloud](../cloud/index.md#private-code-on-sourcegraph-cloud)
-1. We advertise a bounty for each unique vulnerability that allows an unauthorized person to gain access to our [test security repository](https://github.com/sourcegraph/security-test/blob/main/README.md) on Sourcegraph Cloud. (3.23 release)
-   - **DEPENDENCY:** This milestone depends on milestone 3 of [Visibility into Sourcegraph Cloud's attack surface](#visibility-into-sourcegraph-clouds-attack-surface). We should detect and fix the obvious issues ourselves before we start to invite others to attack us with large bounties.
-1. We run a time-bound capture the flag event where there are larger bounties for being able to gain access to our [test security repository](https://github.com/sourcegraph/security-test/blob/main/README.md) on Sourcegraph Cloud. (3.24 release)
-1. We host our private [infrastructure repository](http://github.com/sourcegraph/infrastructure) on Sourcegraph Cloud. (TBD, somewhat dependent on outputs of CtF)
-1. We allow paying customers to host their private code on Sourcegraph Cloud. (TBD, somewhat dependent on outputs of CtF)
+See [security goals and priorities](goals.md)
 
 ----
 

--- a/handbook/product/roadmap.md
+++ b/handbook/product/roadmap.md
@@ -2,6 +2,8 @@
 
 We strive for an outcome-based roadmap: each roadamp item should describe the problem we want to solve or outcome we want to achieve.
 
+## Roadmap visualization
+
 <!-- Gantt chart syntax documentation: https://mermaid-js.github.io/mermaid/diagrams-and-syntax-and-examples/gantt.html -->
 
 <pre class="mermaid" data-rendered-width="150%" data-scroll-right="50%">
@@ -14,9 +16,6 @@ section Milestones
     3.21 :active, release-3.21, 2020-09-21, 2020-10-20
     3.22 :        release-3.22, 2020-10-21, 2020-11-20
 
-%% section Campaigns
-%%     TO DO :active, after release-3.21, 30d
-
 section Cloud
     User added code is indexed and searchable                 :done,   2020-09-23, 2020-10-07
     RFC 167 - Product license tiers                           :active, 2020-10-07, 14d
@@ -25,9 +24,6 @@ section Cloud
     GitHub app to simplify access to repositories (spike)     :        2020-10-21, 2d
     Webhooks to receive repo permissions and metadata (spike) :        2020-10-21, 2d
 
-%%section Code intel
- %% TO DO   
-
 section Web
     Browser extension discoverability                         :done,    2020-09-28, 14d
     Build new and improved extensions                         :active,   2020-10-12, 14d
@@ -35,44 +31,105 @@ section Web
     Code insights TBD                                         :         2020-11-09, 14d
     Web nav updates                                           :         2020-11-09, 7d
     Breadcrumbs                                               :         2020-11-16, 7d
-
-%% section Search
-%%     TO DO :active, after release-3.21, 30d
 </pre>
 
-## Campaigns
+<div id="roadmap-loading">
+	Compiling roadmap...
+	<br/>
+	<small>If the roadmaps do not appear, please <a href="https://github.com/sourcegraph/about/issues">report this issue</a> and include the output from your browser's devtools JavaScript console.</small>
+</div>
 
-1. **Customer outreach to improve adoption of campaigns**
-1. User credentials ([RFC 242](https://docs.google.com/document/d/1SqoWWm1xs82QibrWwYsXmpmgweN6EpcKt1qXrRBjjlU/edit)), which will allow non-site-admins to create campaigns
-1. Better burndown charts
-1. Versioning/releasing of src-cli with respect to sg/sg
-1. Improved documentation of src-cli login process
-1. Add filtering/searching to campaign and changeset lists
-1. Ability to auto-merge changesets, depending on various conditions
-1. Ability to add default reviewers to changesets
+## [Campaigns roadmap](../engineering/campaigns/goals.md#roadmap)
+## [Cloud roadmap](../engineering/cloud/goals.md#roadmap)
+## [Code Intel roadmap](../engineering/code-intelligence/goals.md#roadmap)
+## [Distribution roadmap](../engineering/distribution/goals.md#roadmap)
+## [Search roadmap](../engineering/search/goals.md#roadmap)
+## [Security roadmap](../engineering/security/goals.md#roadmap)
+## [Web roadmap](../engineering/web/goals.md#roadmap)
 
-See [our team page](https://about.sourcegraph.com/handbook/engineering/campaigns#roadmap) for more detail about our longer-term roadmap and our roadmap process.
+---
 
-## Cloud
+## How to edit
 
-See [cloud roadmap](../engineering/cloud/goals.md#roadmap)
+This page is generated automatically based on the contents of other handbook pages.
 
-## Code intel
+1. To add a team's roadmap, [edit this page](https://github.com/sourcegraph/about/edit/main/handbook/product/roadmap.md) and add a link to the section of the team's page that lists the roadmap (such as `### [My team](../../handbook/myteam/goals.md#roadmap)`). If the entire page is about the rooadmap, omit the section from the URL (for example, omit `#roadmap`).
+1. To edit a team's roadmap, edit the linked section on the team's page. In the example above, you'd edit the `Roadmap` section of `../../handbook/myteam/goals.md`. Everything in that section until the next same-level heading is displayed on this page.
+1. To add any other text or structure to this page, just insert it as you would normally. Only 3rd-level heading links (lines that start with `###` and that have a link) are treated specially; all other content is preserved.
 
-See [Code Intel roadmap](../engineering/code-intelligence/goals.md#roadmap)
+<script>
+// This script injects the roadmap content into each section of this page that links to a team page.
+// It is similar to the script used to generate the org chart in ../../company/team/org_chart.md and ../../company/goals/index.md
 
-## Distribution
+const getHeadingLevel = heading => heading instanceof HTMLHeadingElement ? parseInt(heading.tagName.slice(1), 10) : undefined
 
-See [Distribution roadmap](https://github.com/sourcegraph/about/pull/1104).
+const cloneHeading = (origHeading, level) => {
+	const newHeading = document.createElement(`h${level}`)
+	newHeading.innerHTML = origHeading.innerHTML
+	return newHeading
+}
 
-## Search
+async function getPageSectionContent(pageUrl, level) {
+	const sectionId = pageUrl.includes('#') ? pageUrl.replace(/^.*#/, '') : null
 
-See [search roadmap](../engineering/search/goals.md).
+	const resp = await fetch(pageUrl)
+	const doc = new DOMParser().parseFromString(await resp.text(), "text/html")
+	const section = sectionId ? doc.getElementById(sectionId) : doc.querySelector('.markdown-body > h1')
+	if (!section) {
+		const error = document.createElement('p')
+		error.innerText = `Error compiling roadmap: page at ${pageUrl} has no ${sectionId ? `section with ID ${sectionId}` : 'content'}.`
+		return error
+	}
 
-## Security
+	const wrapper = document.createElement('section')
+	const iterator = doc.createNodeIterator(doc, NodeFilter.SHOW_ELEMENT, () => NodeFilter.FILTER_ACCEPT)
+	let curNode
+	let started = false
+	let startLevel = undefined
+	let demoteByLevels = undefined
+	while (curNode = iterator.nextNode()) {
+		if (curNode instanceof HTMLHeadingElement && sectionId ? curNode.id === sectionId : curNode === section) {
+			started = true
+			startLevel = getHeadingLevel(curNode)
+			demoteByLevels = level - startLevel
+			continue
+		}
+		if (started) {
+			if (curNode instanceof HTMLHeadingElement) {
+				const curNodeLevel = getHeadingLevel(curNode)
 
-See [WIP roadmap](https://sourcegraph.productboard.com/feature-board/2119755-cloud).
+				if (curNodeLevel <= startLevel) {
+					// End at next same-level heading.
+					break
+				}
 
-## Web
+				// Demote headings so that the injected content's headings are smaller.
+				const demotedLevel = Math.min(curNodeLevel + demoteByLevels, 6)
+				curNode = cloneHeading(curNode, demotedLevel)
+			}
 
-See [web roadmap](../engineering/web/goals.md#roadmap)
+			wrapper.appendChild(curNode)
+		}
+	}
+
+	return wrapper
+}
+
+const sectionHeaders = Array.from(document.querySelectorAll('h2,h3')).filter(section => Boolean(section.querySelector('a[href]:not([aria-hidden])')))
+Promise.all(
+	sectionHeaders.map(async sectionHeader => ({
+		header: sectionHeader,
+		content: await getPageSectionContent(
+			sectionHeader.querySelector('a[href]:not([aria-hidden])').href,
+			getHeadingLevel(sectionHeader)
+		),
+	}))
+).then(sections => {
+	const loading = document.getElementById('roadmap-loading')
+	loading.innerHTML = '' // clear
+
+	for (const {header, content} of sections) {
+		header.parentNode.insertBefore(content, header.nextSibling)
+	}
+})
+</script>


### PR DESCRIPTION
Only tagged Eng managers for teams that had changes. No copy/goals/roadmap was changed other than moving the location.

This is expecting code intel PR to be merged: https://github.com/sourcegraph/about/pull/1952 