### PR TITLE
releases: remove milestone close, some tags, config compile

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -16,6 +16,10 @@ Arguments:
 
 ---
 
+**Note:** All `yarn run release ...` commands should be run from folder `dev/release`.
+
+**Note:** All `yarn run test ...` commands should be run from folder `web`.
+
 ## Setup
 
 - [ ] Ensure release configuration in `dev/release/config.json` on `main` is up to date with the parameters for the current release.

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -14,6 +14,8 @@ Arguments:
 
 - [ ] TODO: Add commit links and their associated patch request issues here
 
+---
+
 ## Setup
 
 - [ ] Ensure release configuration in `dev/release/config.json` on `main` is up to date with the parameters for the current release.
@@ -76,11 +78,6 @@ Arguments:
 <!-- Keep in sync with release_issue_template's "Release" section -->
 
 - [ ] From the [release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns), merge the release-publishing PRs created previously.
-  - For [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph), also:
-    - [ ] Tag the `v$MAJOR.$MINOR.0` release at the most recent commit on the `v$MAJOR.$MINOR` branch.
-        ```sh
-        VERSION='v$MAJOR.$MINOR.0' bash -c 'git tag -a "$VERSION" -m "$VERSION" && git push origin "$VERSION"'
-        ```
   - For [sourcegraph](https://github.com/sourcegraph/sourcegraph), also:
     - [ ] Cherry pick the release-publishing PR from `sourcegraph/sourcegraph@main` into the release branch.
 - [ ] Announce that the release is live:
@@ -91,7 +88,7 @@ Arguments:
 ## Post-release
 
 - [ ] Open a PR to update `dev/release/config.json` with the parameters for the current release.
-- [ ] Run `yarn build` to rebuild the release script (necessary, because `config.json` is compiled in).
+- [ ] Run `yarn build` to rebuild the release script.
 - [ ] Close this issue.
 
 *Note*: If another patch release is requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md) be filled out first.

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -95,4 +95,4 @@ Arguments:
 - [ ] Run `yarn build` to rebuild the release script.
 - [ ] Close this issue.
 
-*Note*: If another patch release is requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md) be filled out first.
+**Note:** If another patch release is requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md) be filled out and approved first.

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -18,6 +18,7 @@ This release is scheduled for $RELEASE_DATE.
 ---
 
 **Note:** All `yarn run release ...` commands should be run from folder `dev/release`.
+
 **Note:** All `yarn run test ...` commands should be run from folder `web`.
 
 ## Setup

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -127,4 +127,4 @@ Once there are no more release-blocking issues (as reported by the `release:stat
   ```
 - [ ] Close this issue.
 
-*Note*: If a patch release are requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1%3A+) be filled out first.
+**Note:** If a patch release are requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1%3A+) be filled out and approved first.

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -11,7 +11,11 @@ Arguments:
 - $ONE_WORKING_DAY_BEFORE_RELEASE
 -->
 
-# $MAJOR.$MINOR Release ($RELEASE_DATE)
+# $MAJOR.$MINOR Release
+
+This release is scheduled for $RELEASE_DATE.
+
+---
 
 **Note:** All `yarn run release ...` commands should be run from folder `dev/release`.
 **Note:** All `yarn run test ...` commands should be run from folder `web`.
@@ -111,7 +115,7 @@ Once there are no more release-blocking issues (as reported by the `release:stat
 
 - [ ] Notify the next release captain that they are on duty for the next release. They should complete the steps in this section.
 - [ ] Open a PR to update `dev/release/config.json` with the parameters for the current release.
-- [ ] Run `yarn build` to rebuild the release script (necessary, because `config.json` is compiled in).
+- [ ] Run `yarn build` to rebuild the release script.
 - [ ] Create release calendar events, tracking issue, and announcement for next release:
   ```sh
   # Add calendar events and reminders for key dates in the release cycle
@@ -121,6 +125,5 @@ Once there are no more release-blocking issues (as reported by the `release:stat
   yarn run release tracking:release-issue
   ```
 - [ ] Close this issue.
-- [ ] Close the milestone.
 
 *Note*: If a patch release are requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1) be filled out first.

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -127,4 +127,4 @@ Once there are no more release-blocking issues (as reported by the `release:stat
   ```
 - [ ] Close this issue.
 
-*Note*: If a patch release are requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1) be filled out first.
+*Note*: If a patch release are requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1%3A+) be filled out first.


### PR DESCRIPTION
* Tags no longer need to be created, milestones no longer need to be closed, due to changes in https://github.com/sourcegraph/sourcegraph/pull/15743 (closes https://github.com/sourcegraph/sourcegraph/issues/15323)
* Config no longer needs to be compiled, due to changes in https://github.com/sourcegraph/sourcegraph/pull/15729 (closes https://github.com/sourcegraph/sourcegraph/issues/15562)