### PR TITLE
Updates the Web team's daily Slack updates process

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -52,7 +52,7 @@ We do regular updates to communicate our progress to members of the team, and to
 
 Collaborating across timezones requires regular communication to keep each other updated on our progress, and coordinate work handoff if needed. We also use this opportunity to build camaraderie between team members by sharing some non-work related aspects of our lives with each other.   
 
-We use [Geekbot](https://geekbot.com/) to facilitate all this and these updates are purely for coordination within the team (as opposed to for external stakeholders). At the start of each working day, Geekbot will ask each teammate a set of questions and the responses will be posted in the #web-internal Slack channel.  
+We use [Geekbot](https://geekbot.com/) to facilitate all this and these updates are purely for coordination within the team (as opposed to for external stakeholders). At the start of each working day, Geekbot will ask each teammate a set of questions and the responses will be posted in the #web-chat Slack channel.  
 
 All teammates are expected to be part of this channel, and should read the updates, to learn what your teammates have been working on, and check if they need your help.
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -50,20 +50,11 @@ We do regular updates to communicate our progress to members of the team, and to
 
 #### Daily Slack updates
 
-Collaborating across timezones requires regular communication to keep each other updated on our progress, and coordinate work handoff if needed. We use daily Slack updates to achieve this.
-These updates are purely for coordination within the team (as opposed to for external stakeholders).
+Collaborating across timezones requires regular communication to keep each other updated on our progress, and coordinate work handoff if needed. We also use this opportunity to build camaraderie between team members by sharing some non-work related aspects of our lives with each other.   
 
-Every day, Slackbot will post a reminder in the #web channel to write your daily update.
+We use [Geekbot](https://geekbot.com/) to facilitate all this and these updates are purely for coordination within the team (as opposed to for external stakeholders). At the start of each working day, Geekbot will ask each teammate a set of questions and the responses will be posted in the #web-internal Slack channel.  
 
-**At the end of each working day**, you should post your update as a threaded response to the Slackbot message.
-
-You should include in your update:
-
-- What you worked on during your day.
-- Whether you're blocked on anything to make progress (a code review, input in an RFC or in a GitHub issue...).
-- What you plan on tackling next.
-
-**At the beginning of each working day**, you should read the updates thread for the previous working day, to learn what your teammates have been working on, and check if they need your help.
+All teammates are expected to be part of this channel, and should read the updates, to learn what your teammates have been working on, and check if they need your help.
 
 ### Retrospectives
 


### PR DESCRIPTION
@sourcegraph/web please review this proposed process change to the way we do daily updates.

I propose we use [Geekbot](https://geekbot.com/) going forward.

The proposed daily questions will be:
- Mon
   - How was your weekend? What did you get up to?
   - What are your goals for this week?
   - Who do you need to sync up with specifically this week to achieve your goals?
   - Any asks from the team to unblock you?
- Tue-Fri
   - What did you do outside of work yesterday?
   - Discover anything new or interesting you want to share?
   - What progress did you manage to make yesterday?
   - What's your goal for today?
   - Any asks from the team to unblock you on anything?

This PR also introduces a new channel, #web-internal, where the responses to the daily questions will be posted but also where we can have some social chatter, share interesting articles, etc with each other. This channel should be used purely for non-work related matters, with all work-related matters still being discussed in the #web channel. The intention is for the #web-internal channel to be public, however, I am happy to consider making it private if the team would be more comfortable with that.

Further reading: https://geekbot.com/customer-story/gitlab-builds-camaraderie-across-its-remote-teams-using-geekbot/

