### PR TITLE
add link post to blog for the monorepo doc

### DIFF
--- a/blogposts/2020/code-search-in-monorepos.md
+++ b/blogposts/2020/code-search-in-monorepos.md
@@ -1,0 +1,12 @@
+---
+title: "Why code search is still needed for monorepos."
+author: Quinn Slack
+authorUrl: https://twitter.com/sqs
+publishDate: 2020-11-13
+tags: [blog]
+published: true
+canonical: https://docs.sourcegraph.com/adopt/code_search_in_monorepos
+style: short-inline-title
+---
+
+We asked developers with monorepos why they use code search&mdash;then compiled the most convincing reasons.

--- a/website/src/components/blog/LinkPost.tsx
+++ b/website/src/components/blog/LinkPost.tsx
@@ -27,15 +27,29 @@ export const LinkPost: React.FunctionComponent<Props> = ({
         .replace(/^<p>/, '')
         .replace(/<\/p>$/, '')
 
+    const titleClassName = 'font-size-base font-family-base link-post__html d-inline'
+    const title = post.frontmatter.canonical ? (
+        <h2 className={titleClassName}>
+            <Link
+                to={post.frontmatter.canonical}
+                dangerouslySetInnerHTML={{
+                    __html: titleHTML,
+                }}
+            ></Link>
+        </h2>
+    ) : (
+        <h2
+            className={titleClassName}
+            dangerouslySetInnerHTML={{
+                __html: titleHTML,
+            }}
+        />
+    )
+
     return (
         <Tag className={`link-post ${className}`}>
             <div className="card-body">
-                <h2
-                    className="font-size-base font-family-base link-post__html d-inline"
-                    dangerouslySetInnerHTML={{
-                        __html: titleHTML,
-                    }}
-                />
+                {title}
                 <div className="link-post__html d-inline" dangerouslySetInnerHTML={{ __html: post.html }} />
             </div>
             <div className="card-footer bg-unset border-top-0 pt-0">

--- a/website/src/components/blog/postTypes.tsx
+++ b/website/src/components/blog/postTypes.tsx
@@ -69,14 +69,15 @@ export const POST_TYPE_TO_COMPONENT: Record<PostType, React.FunctionComponent<Po
 }
 
 export const postType = (post: Post): PostType =>
-    post.frontmatter.tags?.includes('release') ? PostType.ReleasePost
+    post.frontmatter.tags?.includes('release')
+        ? PostType.ReleasePost
         : post.frontmatter.tags?.includes('press')
-            ? PostType.PressReleasePost
-            : post.frontmatter.tags?.includes('podcast')
-                ? PostType.PodcastPost
-                : post.frontmatter.style === 'short-inline-title'
-                    ? PostType.LinkPost
-                    : PostType.BlogPost
+        ? PostType.PressReleasePost
+        : post.frontmatter.tags?.includes('podcast')
+        ? PostType.PodcastPost
+        : post.frontmatter.style === 'short-inline-title'
+        ? PostType.LinkPost
+        : PostType.BlogPost
 
 export enum BlogType {
     GopherCon = 'go',
@@ -93,7 +94,7 @@ export interface BlogTypeInfo {
     title: string
     belowTitle?: React.ReactFragment
     baseUrl: string
-    meta: { title: string; description: string; image?: string; }
+    meta: { title: string; description: string; image?: string }
 }
 
 export const BLOG_TYPE_TO_INFO: Record<BlogType, BlogTypeInfo> = {
@@ -111,8 +112,7 @@ export const BLOG_TYPE_TO_INFO: Record<BlogType, BlogTypeInfo> = {
         baseUrl: '/press-release',
         meta: {
             title: 'Sourcegraph - Press release',
-            description:
-                'Press release from Sourcegraph',
+            description: 'Press release from Sourcegraph',
         },
     },
     graphql: {
@@ -165,4 +165,7 @@ export const BLOG_TYPE_TO_INFO: Record<BlogType, BlogTypeInfo> = {
     },
 }
 
-export const urlToPost = (post: Post, blog: BlogTypeInfo): string => post.fields.permalink
+export const urlToPost = (post: Post, blog: BlogTypeInfo): string =>
+    post.frontmatter.style === 'short-inline-title' && post.frontmatter.canonical
+        ? post.frontmatter.canonical
+        : post.fields.permalink

--- a/website/src/pages/blog.tsx
+++ b/website/src/pages/blog.tsx
@@ -32,6 +32,7 @@ export const pageQuery = graphql`
                         heroImage
                         author
                         authorUrl
+                        canonical
                         tags
                         publishDate(formatString: "MMMM D, YYYY")
                         slug


### PR DESCRIPTION
This adds an entry to the blog for https://docs.sourcegraph.com/adopt/code_search_in_monorepos.

Also makes it so that link posts (`style: short-inline-title` in frontmatter) can have links.