### PR TITLE
Temp fixing an issue with emphasis and underscores in links 

### DIFF
--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -8,7 +8,7 @@
 
   1. **_Creating and maintaining a highly usable and intentionally designed webapp interface_**
   1. **_Delivering the full, unique value of Sourcegraph [extensions](https://docs.sourcegraph.com/extensions)_**
-  1. **_Maintaining and expanding [code host integrations](https://docs.sourcegraph.com/dev/background-information/web/code_host_integrations)_**
+  1. **_Maintaining and expanding_ [_code host integrations_](https://docs.sourcegraph.com/dev/background-information/web/code_host_integrations)**
   1. **_Developing code insights into an entirely new featureset_**
 
 **Outcome**: 


### PR DESCRIPTION
It seems that if trying to emphasize text, the underscores in any url paths break our docsite handling of the underscore string (VSCode preview and Github's own comment fields seem to handle this, so it doesn't seem like a limitation of markdown in general). 

The temporary solution is just to wrap the emphasized strings in a way that the url underscores aren't enclosed. 

In other words, before this change, this line looked like: 
  1. **\_Maintaining and expanding [code host integrations](https://docs.sourcegraph.com/dev/background-information/web/code_host_integrations)\_**