### PR TITLE
no company meeting between Dec 23 and Jan 1

### DIFF
--- a/handbook/people-ops/holidays.md
+++ b/handbook/people-ops/holidays.md
@@ -11,5 +11,7 @@ We will reschedule any Monday [company meetings](../communication/company_meetin
 * Fourth of July - observed July 4th
 * Christmas Eve and Christmas - observed December 24th and 25th
 
+Also, there is no company meeting on or between December 26 and January 1. (Most team members will take that time off.)
+
 On all other holidays (e.g., US Memorial Day), company meeting will be held normally, although we anticipate a higher-than-usual number of team members being unable to attend. (That is OK! Have a great holiday!)
 

--- a/handbook/people-ops/holidays.md
+++ b/handbook/people-ops/holidays.md
@@ -11,7 +11,7 @@ We will reschedule any Monday [company meetings](../communication/company_meetin
 * Fourth of July - observed July 4th
 * Christmas Eve and Christmas - observed December 24th and 25th
 
-Also, there is no company meeting on or between December 26 and January 1. (Most team members will take that time off.)
+Also, there is no company meeting on or between December 23 and January 1. (Most team members will take that time off.)
 
 On all other holidays (e.g., US Memorial Day), company meeting will be held normally, although we anticipate a higher-than-usual number of team members being unable to attend. (That is OK! Have a great holiday!)
 


### PR DESCRIPTION
It wouldn't make sense to hold company meeting on, for example, December 28. Also, state that most team members will take that time off.