### PR TITLE
first format take of an EM-PM partnership responsibility page

### DIFF
--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -31,6 +31,7 @@ Build an exceptional team that achieves results.
 - Own the end-to-end hiring process for the team and grow the team according to the hiring plan.
 - Make [compensation](../people-ops/compensation.md) decisions for direct reports and candidate offers to ensure that everyone is appropriately compensated at all times.
 - Hold teammates accountable for fulfilling their responsibilities.
+- If your team has a product manager, uphold your end of the [PM – EM partnership responsibilities](../product/roles/product_manager_engineering_manager_responsibilities.md).
 
 ## VP Engineering
 

--- a/handbook/product/roles/product_manager.md
+++ b/handbook/product/roles/product_manager.md
@@ -18,6 +18,7 @@ You will **own an area of the product**\* and:
 - Maintain a roadmap, backlog, and curate and solicit feedback for the product area.
 - Communicate product ideas clearly by focusing on the problems that are being solved, the outcomes, and how we will measure success.
 - Be transparent in your internal and external communication. Sourcegraph is open source, so most discussions are public or in channels where you communicate directly with our customers.
+- Uphold your side of the [PM – EM partnership responsibilities](product_manager_engineering_manager_responsibilities.md).
 
 \* Product ownership areas (current teams): [Campaigns](../../engineering/campaigns/index.md), [Cloud](../../engineering/cloud/index.md), [Distribution](../../engineering/distribution/index.md), [Security](../../engineering/security/index.md)
 

--- a/handbook/product/roles/product_manager_engineering_manager_responsibilities.md
+++ b/handbook/product/roles/product_manager_engineering_manager_responsibilities.md
@@ -6,6 +6,7 @@ An effective partnership between the EM and PM is fundamental to the success of 
 **Accountable**: The accountability for the responsibility stops with this person. Being accountable doesn’t mean you have to do all the tasks yourself; however, you should ensure it gets done.
 
 **Expectations**: This outlines the expectation that the EM/PM agrees to *proactively* fulfill in relation to the responsibility in the team. The EM/PM is encouraged to delegate and/or share these tasks with other teammates for the following reasons:
+
 - Share the load
 - Encourage collective ownership of the success of the team
 - Reduce the bus factor risk
@@ -17,176 +18,114 @@ An effective partnership between the EM and PM is fundamental to the success of 
 
 **Product managers**: you are doing well if you have clearly defined the goal of your team, the incremental milestones toward that goal, the timeline for achieving those milestones, and the progress so far (all likely in the handbook). 
 
-**Engineering managers**: you are doing well if your team is doing well (TODO add more detail here? Like how short but not sure it's clear enough). 
+**Engineering managers**: you are doing well if your team is doing well. 
 
-## Product managers (PMs)
+<!-- some styling to make the tables a bit more readable -->
+<style>
+th:first-of-type {
+    width: 50%;
+}
+td {
+    vertical-align: top;
+    padding: 10px 30px;
+}
+</style>
 
-### PMs are accountable for: 
+## Product managers (PMs) are accountable for: 
 
-#### Product marketing
+### Product marketing
 
-- Speak to customers about upcoming features 
-- Promote new features internally in the company
-- Communicate with marketing + sales around upcoming or recent feature releases
-- Reach out to customers when heavily-requested features are released 
-- Make sure the CE + Sales team understands and is excited to sell new features	
+| PM expectations | EM expectations |
+| --- | --- |
+| - Speak to customers about upcoming features <br/> - Promote new features internally in the company <br/> - Communicate with marketing + sales around upcoming or recent feature releases <br/> - Reach out to customers when heavily-requested features are released <br/> - Make sure the CE + Sales team understands and is excited to sell new features | - Look out for instances of gaps in product trust and understanding <br/> - Encourage engineers to provide demos of newly delivered features |
+<br/>
 
-#### Product research 
+### Product research 
 
-- Keeping relevant customer feedback up to date
-- Identify what customers are asking for most / prioritization based on customer needs
+| PM expectations | EM expectations |
+| --- | --- |
+| - Keep relevant customer feedback up to date <br/> - Identify what customers are asking for most / prioritization based on customer needs | - Ensure that capturing usage events and the data capture integrity is top of mind when implementing/maintaining features |
+<br/>
 
-#### Team goals
+### Team goals
 
-- Keep the team’s goals page up-to-date in the handbook, which included progress updates at the end of iterations
-- Communicating team goals internally and externally
-- Continually validating that team goals are right and that we are making progress on those goals at a metrics level 
-- Making sure we have data and feedback to prioritize our roadmap 
+| PM expectations | EM expectations |
+| --- | --- | 
+| - Keep the team’s goals page up-to-date in the handbook, which included progress updates at the end of iterations <br/> - Communicating team goals internally and externally <br/> - Continually validate that team goals are right and that we are making progress on those goals at a metrics level  <br/> - Make sure we have data and feedback to prioritize our roadmap | - Ensure that engineers are engaged in setting and stay connected with the team goals |
+<br/>
 
-#### Iteration planning
+### Iteration planning
 
-- Make sure iteration goals align with team goals
-- Set the iteration goals in consultation with the team
-- Prioritize the work for the iteration
+| PM expectations | EM expectations |
+| --- | --- |
+- Make sure iteration goals align with team goals <br/> - Set the iteration goals in consultation with the team <br/> - Prioritize the work for the iteration | - Refine issues to the point where an engineer can pick it up and have all the information needed to get started <br/> - Balance iteration goals with available capacity <br/> - Balance iteration goals with passive goals (backlog, technical debt) <br/> - Keep the team’s handbook page up-to-date with the process for planning iterations |
+<br/>
 
-#### Technical partnerships
+### Technical partnerships
 
-- Communicate with technical partners (like GitLab) around bugs or version updates 
-- Handle communication with Firefox/Chrome/Safari around extensions approvals if issues arise
-- Correspond with customers when having issues requiring direct contact (which will come from a CE “first point of contact” but then becomes a separate task)
-- Ensure customer delivery plans are set when relevant
+| PM expectations | EM expectations |
+| --- | --- |
+- Communicate with technical partners (like GitLab) around bugs or version updates  <br/> - Handle communication with Firefox/Chrome/Safari around extensions approvals if issues arise <br/> - Correspond with customers when having issues requiring direct contact (which will come from a CE “first point of contact” but then becomes a separate task) <br/> - Ensure customer delivery plans are set when relevant | - Look out for technical releases from partners that will cause potential issues with our integrations (e.g., a new version of Chrome affecting an extension) |
+<br/>
 
-#### Sales + customer engineering collaboration
+### Sales + customer engineering collaboration
 
-- Answer questions from the sales and CE teams
-- Analyze the needs of the sales and CE teams as they relate to our goals
-- First point of contact for customer issues
-- First “team point of contact” for customers unless otherwise specified 
+| PM expectations | EM expectations |
+| --- | --- |
+- Answer questions from the sales and CE teams <br/> - Analyze the needs of the sales and CE teams as they relate to our goals <br/> - First point of contact for customer issues <br/> - First “team point of contact” for customers unless otherwise specified | _no proactive responsibilities_
+<br/>
 
-#### Design
+### Design
 
-- Prioritize design requirements for future iterations
-- Collaborate on user research requirements
-- Working alongside designers to prototype new features
-- Working alongside designers in team-related design reviews  
+| PM expectations | EM expectations |
+| --- | --- |
+| - Prioritize design requirements for future iterations <br/> - Collaborate on user research requirements <br/> - Working alongside designers to prototype new features <br/> - Work alongside designers in team-related design reviews | - Leave design feedback comments on anything that seems like it might be a “lopsided value tradeoff” (a significant amount of engineering work for little design/user impact when compared to the easier solution) so that the PM and designers are aware <br/> - Encourage the rest of the team to do so as well |  
+<br/>
 
-#### Other engineering team collaborations
+### Other engineering team collaborations
 
-- Communicate and prioritize inter-team dependencies
+| PM expectations | EM expectations |
+| --- | --- |
+| - Communicate and prioritize inter-team dependencies | - Drive inter-team dependency collaboration and execution |
+<br/>
 
-### PMs are expected to help EMs with:
+## Engineering managers (EMs) are accountable for: 
 
-#### Hiring
+### Hiring
 
-- Ensure there is a clear roadmap so the EM knows who we need to hire and how to pitch the vision of the team to candidates. 
+| EM expectations | PM expectations |
+| --- | --- |
+| - Define hiring requirements based on team goals <br/> - Keep job spec up-to-date <br/> - Source candidates <br/> - Screen candidate applications <br/> - Define and maintain the hiring process | - Ensure there is a clear roadmap so the EM knows who we need to hire and how to pitch the vision of the team to candidates. |
+<br/>
 
-#### Iteration execution
+### Iteration execution
+| EM expectations | PM expectations |
+| --- | --- |
+| - Keep the team’s handbook page up-to-date with the process for executing iterations <br/> - Track progress of the iteration and alert PM when we need to scope up/down <br/> - Manage/escalate technical blockers on work <br/> - Ensure the work delivered is of a high quality <br/> - Scope and prioritize bugs escalated by CE team | - Scope and prioritize bugs escalated by CE team <br/> - Protect the team’s focus during an iteration |
+<br/>
 
-- Scope and prioritize bugs escalated by CE team
-- Protecting team’s focus during an iteration
+### Productivity
+| EM expectations | PM expectations |
+| --- | --- |
+| - Hold retrospectives after each iteration <br/> - Continuously optimize processes | - Update handbook owned pages (goals or roadmap) with relevant action items after retrospectives |
+<br/>
 
-#### Productivity
+### Reporting
+| EM expectations | PM expectations |
+| --- | --- |
+| - Provide weekly status report to engineering leadership | - Look over weekly update by EOD [the day before it gets sent] and supplement any info |
+<br/>
 
-- Update handbook owned pages (goals or roadmap) with relevant action items after retrospectives
+### Career development and performance management
+| EM expectations | PM expectations |
+| --- | --- |
+| - Hold weekly 1-1s with team members <br/> - Mentor team members to make progress towards their career goals <br/> - Measure the performance of the team and individuals and provide regular feedback to team members | - Make the EM aware of any career-related conversations that come up when working with engineers directly <br/> - Provide continuous insight to EM on what areas engineers excel in and what areas they can grow in |
+<br/>
 
-#### Reporting
-
-- Look over weekly update by EOD Monday (the day before it gets sent) and supplement any info
-
-#### Career development and performance management
-
-- Make the EM aware of any career-related conversations that come up when working with engineers directly
-- Provide continuous insight to EM on what areas engineers excel in and what areas they can grow in
-
-#### Team morale 😊
-
-- Bringing in customer feedback to make the team excited about what we’re building
-- Following up on data/analytics to prove the impact of what we’ve built, so the team feels like we’re having an impact
-- Come up with or maintain team “rituals” (even as simple as adding a fun question to the start of syncs)
-
-## Engineering managers (EMs)
-
-### EMs are accountable for: 
-
-#### Hiring
-
-- Define hiring requirements based on team goals
-- Keep job spec up-to-date
-- Source candidates
-- Screen candidate applications
-- Define and maintain the hiring process
-
-#### Iteration execution
-
-- Keep the team’s handbook page up-to-date with the process for executing iterations
-- Track progress of the iteration and alert PM when we need to scope up/down
-- Manage/escalate technical blockers on work
-- Ensure the work delivered is of a high quality
-- Scope and prioritize bugs escalated by CE team
-
-#### Productivity
-
-- Hold retrospectives after each iteration
-- Continuously optimize processes 
-
-#### Reporting
-
-- Provide weekly status report to engineering leadership
-
-#### Career development and performance management
-
-- Hold weekly 1-1s with team members
-- Mentor team members to make progress towards their career goals
-Measure the performance of the team and individuals and provide regular feedback to team members
-
-#### Team morale 😊
-
-- Team social events
-- Come up with or maintain team “rituals” (even as simple as adding a fun question to the start of syncs)
-
-### EMs are expected to help PMs with: 
-
-#### Product marketing 
-
-- Look out for instances of gaps in product trust and understanding
-- Encourage engineers to provide demos of newly delivered features
-
-#### Research
-
-- Ensure that capturing usage events and the data capture integrity is top of mind when implementing/maintaining features
-
-#### Team goals
-
-- Ensure that engineers are engaged in setting and stay connected with the team goals
-
-#### Iteration planning
-
-- Refine issues to the point where an engineer can pick it up and have all the information needed to get started
-- Balance iteration goals with available capacity
-- Balance iteration goals with passive goals (backlog, technical debt)
-- Keep the team’s handbook page up-to-date with the process for planning iterations
-
-#### Technical partnerships
-
-Look out for technical releases from partners that will cause potential issues with our integrations (e.g., a new version of Chrome affecting an extension) 
-
-#### Design
-
-- Leave design feedback comments on anything that seems like it might be a “lopsided value tradeoff” (a significant amount of engineering work for little design/user impact when compared to the easier solution) so that the PM and designers are aware
-- Encourage the rest of the team to do so as well
-
-#### Other engineering team collaborations
-
-- Drive inter-team dependency collaboration and execution
-
-<!-- this was an alternative proposal -->
-
-<!-- 
-### Product marketing 
-| PM expectations | EM expectations | Stakeholders |
-| --- | --- | --- |
-| - Speak to customers about upcoming features <br/> - Promote new features internally in the company <br/> - Communicate with marketing + sales around upcoming or recent feature releases <br/> - Reach out to customers when heavily-requested features are released <br/> - Make sure the CE + Sales team understands and is excited to sell new features | - Look out for instances of gaps in product trust and understanding <br/> - Encourage engineers to provide demos of newly delivered features | - VP of Product <br/> - VP of Marketing 
- -->
+### Team morale 😊
+| EM expectations | PM expectations |
+| --- | --- |
+| - Team social events <br/> - Come up with or maintain team “rituals” (even as simple as adding a fun question to the start of syncs) | - Bringing in customer feedback to make the team excited about what we’re building <br/> - Following up on data/analytics to prove the impact of what we’ve built, so the team feels like we’re having an impact <br/> - Come up with or maintain team “rituals” (even as simple as adding a fun question to the start of syncs) |
 
 
 

--- a/handbook/product/roles/product_manager_engineering_manager_responsibilities.md
+++ b/handbook/product/roles/product_manager_engineering_manager_responsibilities.md
@@ -1,0 +1,193 @@
+# Product manager + engineering manager: partnership responsibilities 
+
+An effective partnership between the EM and PM is fundamental to the success of any product engineering team. At the core of having an effective partnership is having a clear understanding of the responsibilities in the team, who is accountable for it, and the expectation of what each party will contribute towards that responsibility. If both parties fulfill their role’s expectations, trust develops – not only between each other, but in the team as a whole.
+
+## Definitions
+**Accountable**: The accountability for the responsibility stops with this person. Being accountable doesn’t mean you have to do all the tasks yourself; however, you should ensure it gets done.
+
+**Expectations**: This outlines the expectation that the EM/PM agrees to *proactively* fulfill in relation to the responsibility in the team. The EM/PM is encouraged to delegate and/or share these tasks with other teammates for the following reasons:
+- Share the load
+- Encourage collective ownership of the success of the team
+- Reduce the bus factor risk
+- Facilitate career development growth of teammates
+
+**Stakeholders**: These are the teammates that either have domain accountability, knowledge or insight related to the responsibility and who should be consulted and informed on the efforts of the team. 
+
+## Summary
+
+**Product managers**: you are doing well if you have clearly defined the goal of your team, the incremental milestones toward that goal, the timeline for achieving those milestones, and the progress so far (all likely in the handbook). 
+
+**Engineering managers**: you are doing well if your team is doing well (TODO add more detail here? Like how short but not sure it's clear enough). 
+
+## Product managers (PMs)
+
+### PMs are accountable for: 
+
+#### Product marketing
+
+- Speak to customers about upcoming features 
+- Promote new features internally in the company
+- Communicate with marketing + sales around upcoming or recent feature releases
+- Reach out to customers when heavily-requested features are released 
+- Make sure the CE + Sales team understands and is excited to sell new features	
+
+#### Product research 
+
+- Keeping relevant customer feedback up to date
+- Identify what customers are asking for most / prioritization based on customer needs
+
+#### Team goals
+
+- Keep the team’s goals page up-to-date in the handbook, which included progress updates at the end of iterations
+- Communicating team goals internally and externally
+- Continually validating that team goals are right and that we are making progress on those goals at a metrics level 
+- Making sure we have data and feedback to prioritize our roadmap 
+
+#### Iteration planning
+
+- Make sure iteration goals align with team goals
+- Set the iteration goals in consultation with the team
+- Prioritize the work for the iteration
+
+#### Technical partnerships
+
+- Communicate with technical partners (like GitLab) around bugs or version updates 
+- Handle communication with Firefox/Chrome/Safari around extensions approvals if issues arise
+- Correspond with customers when having issues requiring direct contact (which will come from a CE “first point of contact” but then becomes a separate task)
+- Ensure customer delivery plans are set when relevant
+
+#### Sales + customer engineering collaboration
+
+- Answer questions from the sales and CE teams
+- Analyze the needs of the sales and CE teams as they relate to our goals
+- First point of contact for customer issues
+- First “team point of contact” for customers unless otherwise specified 
+
+#### Design
+
+- Prioritize design requirements for future iterations
+- Collaborate on user research requirements
+- Working alongside designers to prototype new features
+- Working alongside designers in team-related design reviews  
+
+#### Other engineering team collaborations
+
+- Communicate and prioritize inter-team dependencies
+
+### PMs are expected to help EMs with:
+
+#### Hiring
+
+- Ensure there is a clear roadmap so the EM knows who we need to hire and how to pitch the vision of the team to candidates. 
+
+#### Iteration execution
+
+- Scope and prioritize bugs escalated by CE team
+- Protecting team’s focus during an iteration
+
+#### Productivity
+
+- Update handbook owned pages (goals or roadmap) with relevant action items after retrospectives
+
+#### Reporting
+
+- Look over weekly update by EOD Monday (the day before it gets sent) and supplement any info
+
+#### Career development and performance management
+
+- Make the EM aware of any career-related conversations that come up when working with engineers directly
+- Provide continuous insight to EM on what areas engineers excel in and what areas they can grow in
+
+#### Team morale 😊
+
+- Bringing in customer feedback to make the team excited about what we’re building
+- Following up on data/analytics to prove the impact of what we’ve built, so the team feels like we’re having an impact
+- Come up with or maintain team “rituals” (even as simple as adding a fun question to the start of syncs)
+
+## Engineering managers (EMs)
+
+### EMs are accountable for: 
+
+#### Hiring
+
+- Define hiring requirements based on team goals
+- Keep job spec up-to-date
+- Source candidates
+- Screen candidate applications
+- Define and maintain the hiring process
+
+#### Iteration execution
+
+- Keep the team’s handbook page up-to-date with the process for executing iterations
+- Track progress of the iteration and alert PM when we need to scope up/down
+- Manage/escalate technical blockers on work
+- Ensure the work delivered is of a high quality
+- Scope and prioritize bugs escalated by CE team
+
+#### Productivity
+
+- Hold retrospectives after each iteration
+- Continuously optimize processes 
+
+#### Reporting
+
+- Provide weekly status report to engineering leadership
+
+#### Career development and performance management
+
+- Hold weekly 1-1s with team members
+- Mentor team members to make progress towards their career goals
+Measure the performance of the team and individuals and provide regular feedback to team members
+
+#### Team morale 😊
+
+- Team social events
+- Come up with or maintain team “rituals” (even as simple as adding a fun question to the start of syncs)
+
+### EMs are expected to help PMs with: 
+
+#### Product marketing 
+
+- Look out for instances of gaps in product trust and understanding
+- Encourage engineers to provide demos of newly delivered features
+
+#### Research
+
+- Ensure that capturing usage events and the data capture integrity is top of mind when implementing/maintaining features
+
+#### Team goals
+
+- Ensure that engineers are engaged in setting and stay connected with the team goals
+
+#### Iteration planning
+
+- Refine issues to the point where an engineer can pick it up and have all the information needed to get started
+- Balance iteration goals with available capacity
+- Balance iteration goals with passive goals (backlog, technical debt)
+- Keep the team’s handbook page up-to-date with the process for planning iterations
+
+#### Technical partnerships
+
+Look out for technical releases from partners that will cause potential issues with our integrations (e.g., a new version of Chrome affecting an extension) 
+
+#### Design
+
+- Leave design feedback comments on anything that seems like it might be a “lopsided value tradeoff” (a significant amount of engineering work for little design/user impact when compared to the easier solution) so that the PM and designers are aware
+- Encourage the rest of the team to do so as well
+
+#### Other engineering team collaborations
+
+- Drive inter-team dependency collaboration and execution
+
+<!-- this was an alternative proposal -->
+
+<!-- 
+### Product marketing 
+| PM expectations | EM expectations | Stakeholders |
+| --- | --- | --- |
+| - Speak to customers about upcoming features <br/> - Promote new features internally in the company <br/> - Communicate with marketing + sales around upcoming or recent feature releases <br/> - Reach out to customers when heavily-requested features are released <br/> - Make sure the CE + Sales team understands and is excited to sell new features | - Look out for instances of gaps in product trust and understanding <br/> - Encourage engineers to provide demos of newly delivered features | - VP of Product <br/> - VP of Marketing 
+ -->
+
+
+
+

--- a/handbook/product/roles/product_manager_engineering_manager_responsibilities.md
+++ b/handbook/product/roles/product_manager_engineering_manager_responsibilities.md
@@ -27,7 +27,6 @@ th:first-of-type {
 }
 td {
     vertical-align: top;
-    padding: 10px 30px;
 }
 </style>
 


### PR DESCRIPTION
This is one formatting attempt for the [EM/PM matrix](https://docs.google.com/document/d/1qtF3wfIG00I3MIiOpDO0hffJl4CJFoC_0IcAjJEGo6M/edit?ts=5fa52a34#) we want in the handbook.

I cut the "stakeholders" out because I felt like they were obvious in nearly all cases, they were just a few roles just listed repeatedly, and don't want to create a culture of "someone needs to be listed somewhere in the handbook for you to feel comfortable contacting them, if you think they are relevant." We hire smart people and they likely know when to inform the VP of Product or VP of Eng.

-----

_**Update 2020-11-19 3:41pm PT:** People prefer the alternate chart format for the "partnership" definition of this page, but there's a discussion about what the purpose of the page should be. You can [probably skip to the discussion](https://github.com/sourcegraph/about/pull/2043#issuecomment-730705178)._

------

### What I like about this format

- It makes it really easy to understand the responsibilities of the role (see [this conversation](https://docs.google.com/document/d/1qtF3wfIG00I3MIiOpDO0hffJl4CJFoC_0IcAjJEGo6M/edit?disco=AAAAKqBAdhM))
- It makes it clear there are "accountable" and "responsible, but someone else is accountable" sections
- The formatting is easy to read. 

### What I don't like about this format

I'm not sure it gets at the "partnership" angle enough, and it repeats some sections in both the PM and EM area. I have an alternate proposal for a format (currently commented-out) at the end of the `product_manager_engineering_manager_responsibilities` page, where we keep the EM/PM section-level split but rather than have the "EMs help PMs with" sections, we just put all that in an "EMs help" column of a table that goes in the PM section, and vice versa. For example, in the "PM accountable" section you would have: 

#### Product marketing 
| PM expectations | EM expectations | 
| --- | --- | 
| - Speak to customers about upcoming features <br/> - Promote new features internally in the company <br/> - Communicate with marketing + sales around upcoming or recent feature releases <br/> - Reach out to customers when heavily-requested features are released <br/> - Make sure the CE + Sales team understands and is excited to sell new features | - Look out for instances of gaps in product trust and understanding <br/> - Encourage engineers to provide demos of newly delivered features 

And then you would have no "Product marketing" section repeated on the page again in the EM section. 

I like that this alternative gets more at the partnership. I don't like that this alternative means the role descriptions are now split across both sections (some in the owned section, some in the "help the other manager with" column of the other manager's section). *But* my opinion is that perhaps the purpose of this page is to show how EM+PM partner on a specific task rather than give separate role descriptions. I also don't love that without adding a bunch of html+css (which I will do if we want to go this way) the table format here will be a bit uglier and less readable.  

### Other questions

We separately have PM and EM role descriptions (in the other two modified pages in this PR). This project started as a way for @jeanduplessis and I to figure out how to best work together. I'm worried it is morphing in to "here is a PM role description" and "here is an EM role description" and I wonder, is that useful in this page as well as the descriptions we already have in the handbook on the dedicated role pages? 

I justify this with "yes, this is additionally useful because it is about the partnership," in which case I return to my above concern that this format is best for "role description" rather than "partnership description." I think the core question here, if we agree this page should be partnership focused, is just what others find to be most readable/clear: the current format, or the suggested alternate format with 1/2 as many sections that have little table/columns in each section. 


 