### PR TITLE
Refresh engineer responsibilities

### DIFF
--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -9,7 +9,7 @@ Software engineers build our product and infrastructure.
 ### Responsibilities
 
 - Model [our company values](../../company/values.md) and apply our [guiding engineering principles](index.md#guiding-principles) throughout all your interactions and work.
-- Iteratively create and maintain high quality architecture, code, tests, and documentation that aligns with team goals.
+- Iteratively create, ship, and maintain high quality architecture, code, tests, and documentation that aligns with team goals.
 - Document and share your progress in relevant locations at least once a week (for example: in GitHub issues, team slack channel, #progress, [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)).
 - Prioritize unblocking and supporting your teammates (for example: sharing knowledge, answering questions, providing feedback).
 - Help build a great team by referring people who you would like to work with, interviewing candidates, and suggesting improvements to our hiring process.

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -12,7 +12,7 @@ Software engineers build our product and infrastructure.
 - Iteratively create and maintain high quality architecture, code, tests, and documentation that aligns with team goals.
 - Document and share your progress in relevant locations at least once a week (for example: in GitHub issues, team slack channel, #progress, [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)).
 - Prioritize unblocking and supporting your teammates (for example: sharing knowledge, answering questions, providing feedback).
-- Help us build a great team by referring people who you would like to work with, interviewing candidates, and suggesting improvements to our hiring process.
+- Help build a great team by referring people who you would like to work with, interviewing candidates, and suggesting improvements to our hiring process.
 
 ## Engineering Manager
 

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -8,13 +8,11 @@ Software engineers build our product and infrastructure.
 
 ### Responsibilities
 
-- Commit to a reasonable amount of work that you are going to get done for each [monthly release](releases/index.md), and then reliably get it done.
-- Post weekly updates about your progress on the [monthly release tracking issue](tracking_issues.md) for your team.
-- Ensure that your work is directly contributing to [our goals](../../company/goals/index.md).
-- Write [RFCs](../communication/rfcs/index.md) to recommend solutions to product and engineering problems.
-- Create and maintain high quality code, tests, and documentation.
-- Support your teammates by reviewing their [code](code_reviews.md) and [RFCs](../communication/rfcs/index.md).
-- Help us build a great team by referring people who you would like to work with again, interviewing candidates, and suggesting improvements to our hiring process.
+- Model [our company values](../../company/values.md) and apply our [guiding engineering principles](index.md#guiding-principles) throughout all your interactions and work.
+- Iteratively create and maintain high quality architecture, code, tests, and documentation that aligns with your team's goals.
+- Document and share your progress in relevant locations at least once a week (for example: in GitHub issues, team slack channel, #progress, [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)).
+- Unblock and support your teammates by answering questions, reviewing their [code](code_reviews.md), and providing feedback on [RFCs](../communication/rfcs/index.md).
+- Help us build a great team by referring people who you would like to work with, interviewing candidates, and suggesting improvements to our hiring process.
 
 ## Engineering Manager
 

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -11,7 +11,7 @@ Software engineers build our product and infrastructure.
 - Model [our company values](../../company/values.md) and apply our [guiding engineering principles](index.md#guiding-principles) throughout all your interactions and work.
 - Iteratively create and maintain high quality architecture, code, tests, and documentation that aligns with your team's goals.
 - Document and share your progress in relevant locations at least once a week (for example: in GitHub issues, team slack channel, #progress, [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)).
-- Unblock and support your teammates by answering questions, reviewing their [code](code_reviews.md), and providing feedback on [RFCs](../communication/rfcs/index.md).
+- Prioritize unblocking and supporting your teammates (for example: sharing knowledge, answering questions, providing feedback).
 - Help us build a great team by referring people who you would like to work with, interviewing candidates, and suggesting improvements to our hiring process.
 
 ## Engineering Manager

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -9,7 +9,7 @@ Software engineers build our product and infrastructure.
 ### Responsibilities
 
 - Model [our company values](../../company/values.md) and apply our [guiding engineering principles](index.md#guiding-principles) throughout all your interactions and work.
-- Iteratively create and maintain high quality architecture, code, tests, and documentation that aligns with your team's goals.
+- Iteratively create and maintain high quality architecture, code, tests, and documentation that aligns with team goals.
 - Document and share your progress in relevant locations at least once a week (for example: in GitHub issues, team slack channel, #progress, [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)).
 - Prioritize unblocking and supporting your teammates (for example: sharing knowledge, answering questions, providing feedback).
 - Help us build a great team by referring people who you would like to work with, interviewing candidates, and suggesting improvements to our hiring process.


### PR DESCRIPTION
The old documented responsibilities were too implementation specific (as evidenced by the fact that some are outdated and no longer relevant). A good list of responsibilities should be general enough that it stands the test of time.

Feedback welcome!

(I plan on making a similar change for Engineering Managers, but that will be a separate PR.)