### PR TITLE
Add page for seeking and giving better feedback

### DIFF
--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -120,6 +120,10 @@ Most meetings at Sourcegraph are video calls. We prefer [Zoom](https://zoom.us) 
 - FY\_\_-Q3 is August 1 through October 31
 - FY\_\_-Q4 is November 1 through January 31
 
+## Seeking and giving feedback
+
+- [Seeking and giving feedback](./seeking-and-giving-feedback.md)
+
 ## Handling conflict
 
 - [Conflict resolution](./code_of_conduct.md#conflict-resolution)

--- a/handbook/communication/seeking-and-giving-feedback.md
+++ b/handbook/communication/seeking-and-giving-feedback.md
@@ -1,0 +1,50 @@
+# Seeking and giving feedback
+
+Seeking and acting on feedback is crucial for making good decisions and delivering our best work. Good feedback is a product of an intentional environment with positive feedback loops.
+
+## Seeking feedback
+
+When seeking feedback at Sourcegraph, it's important to:
+
+- Specifically say what *kind* of feedback you're seeking. A thumbs-up, thumbs-down? A gut call on the better of two approaches? A detailed critique?
+- Ask *specific questions* that you want feedback about.
+- Provide *context*. Make sure the specific problem and goal is clear.
+- Seek feedback according to [project roles](#project-roles).
+- After receiving feedback, follow up. Recognize contributions and share how you will move forward.
+
+### Great examples of requesting feedback
+
+(To be added!)
+
+## Giving feedback
+
+When giving feedback, it's important to:
+
+- Make sure you understand what kind of feedback is sought. If it's not clear what kind of feedback is sought, clarify before giving feedback.
+- Focus feedback on the specific feedback sought. Other feedback may be valuable, but should be separated into a distinct conversation.
+- Provide feedback in terms of **why**, not **how** (unless specifically sought).
+- Clarify where the feedback is coming from: is it based on a heuristic or best practice? Is it from a previous decision? Is it rooted in personal opinion?
+- Focus on the work, not the individual.
+
+Keep in mind that providing ongoing feedback is distinct from [disagreeing with a decision](code_of_conduct.md#conflict-resolution). Typically, feedback is sought when a decision is yet to be made.
+
+### Great examples of providing feedback
+
+(To be added!)
+
+## Project roles
+
+When a project has multiple stakeholders, it's useful to identify specific levels of participation through project roles. Each project should clearly state who is:
+
+1. **Responsible:** Those who do the work to get things done.
+2. **Accountable:** The individual who is ultimately responsible for the project outcome. There must only be one person in this role.
+3. **Consulted:** Those who are subject matter experts, who are consulted throughout the project through feedback cycles.
+4. **Informed:** Those who are kept up-to-date on the project, but aren't involved in providing feedback while the project is underway.
+
+One person can have multiple roles: someone may be both responsible for delivering on a project, and accountable for its outcome.
+
+By identifying these roles up-front, before a project is underway, the team will have clarity on who to get input from when [making decisions](decisions.md) and what level of participation is expected from each stakeholder.
+
+## Create a positive environment
+
+As a globally-distributed, asynchronous-first company, each of us is responsible for creating positive, respectful, and safe environments for seeking and giving feedback, by being mindful of how our voice and tone may be perceived.

--- a/handbook/communication/seeking-and-giving-feedback.md
+++ b/handbook/communication/seeking-and-giving-feedback.md
@@ -22,7 +22,7 @@ When giving feedback, it's important to:
 
 - Make sure you understand what kind of feedback is sought. If it's not clear what kind of feedback is sought, clarify before giving feedback.
 - Focus feedback on the specific feedback sought. Other feedback may be valuable, but should be separated into a distinct conversation.
-- Provide feedback in terms of **why**, not **how** (unless specifically sought).
+- Always start with **why**, not **how**. Potential solutions can be useful to clarify your feedback, but aren't feedback in themselves.
 - Clarify where the feedback is coming from: is it based on a heuristic or best practice? Is it from a previous decision? Is it rooted in personal opinion?
 - Focus on the work, not the individual.
 


### PR DESCRIPTION
We have a great open culture around seeking and giving feedback. But sometimes, the feedback cycles aren't as strong as they could be, because the environment isn't clearly structured. This sometimes leads to circular conversations, unclear decision ownership, and can make folks less likely to seek or give feedback.

I've created a simple starting point for how to seek and give better feedback, with the idea that it's a frameworkable skill we can all work at improving.