### PR TITLE
Make usage of React and GraphQL clearer

### DIFF
--- a/handbook/engineering/hiring/software-engineer-coding-exercise.md
+++ b/handbook/engineering/hiring/software-engineer-coding-exercise.md
@@ -24,7 +24,7 @@ We designed this exercise to measure your understanding of building web UIs.
 
 - You will choose a three hour timeframe to independently work on the exercise. You can choose any day and time; we just schedule an email.
 - The exercise asks you to implement a UI in a scaffold TypeScript **React** app.
-- We provide you with the code of the scaffold app, the URL of a working **GraphQL API** to fetch data from and a link to a Figma **design** for the UI.
+- We provide you with the code of the scaffold app, the URL of a working **GraphQL API** to fetch data from and a link to a **Figma design** for the UI.
 - You can use your own development environment and lookup documentation on the internet.
 - You should have Node.js (>=14.0.0) installed on your computer.
 

--- a/handbook/engineering/hiring/software-engineer-coding-exercise.md
+++ b/handbook/engineering/hiring/software-engineer-coding-exercise.md
@@ -23,9 +23,13 @@ If we decide to move forward, we will schedule a 30-minute followup call to disc
 We designed this exercise to measure your understanding of building web UIs.
 
 - You will choose a three hour timeframe to independently work on the exercise. You can choose any day and time; we just schedule an email.
-- The exercise asks you to implement a UI in a scaffold TypeScript React app.
-- We provide you with the code of the scaffold app, the URL of a working GraphQL API to fetch data from and a link to a Figma design for the UI.
+- The exercise asks you to implement a UI in a scaffold TypeScript **React** app.
+- We provide you with the code of the scaffold app, the URL of a working **GraphQL API** to fetch data from and a link to a Figma **design** for the UI.
 - You can use your own development environment and lookup documentation on the internet.
+- You should have Node.js (>=14.0.0) installed on your computer.
+
+If you have never worked with React or GraphQL or it's been a long time, we recommend brushing up on their basics a bit before taking the exercise.
+There are no "advanced" features needed from either of the two to pass the exercise.
 
 We will grade your submission on both the code (implementation) and the result (UI, functionality, etc), so we recommend to not compromise one over the other.
 Apply the same standards to your solution you would to any solution you implement in a real-world production-ready app.


### PR DESCRIPTION
We get a decent number of candidates that claim they didn't finish because they had to spend significant time at the beginning getting their way around in GraphQL and React because they had never used it before, or only a long time ago. We don't require any advanced features, only basics that should map quite well from other frameworks and technologies (which are a qualification requirement to know). So just a little "brushing up" is enough, but when that takes time from the exercise, it's still costly and can present a significant disadvantage I want to avoid.

This _does_ add a bit more time investment for these candidates, but the reality was that this was already "required" before because it was hard to succeed without. I think this is okay because we really only require "take a look at a hello world example"-level basics and it's not "wasted" time (they'll learn something useful). There was also precedent in the previous TypeScript exercise for this kind of suggestion.

I also bolded the technologies, because apparently some candidates read over them.