### PR TITLE
Document Gerrit deployment

### DIFF
--- a/handbook/engineering/distribution/internal_infrastructure.md
+++ b/handbook/engineering/distribution/internal_infrastructure.md
@@ -34,6 +34,13 @@ Git URL: gitolite.sgdev.org
 
 Credentials: [1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/allitems/i5bm6syw45w2c33cvfrrlt4fhu)
 
+### Gerrit
+
+URL: https://gerrit.sgdev.org
+Git URL: gerrit-ssh.sgdev.org
+
+Credentials: Google Auth
+
 ## Customer environment replicas
 
 We maintain separate AWS accounts with Sourcegraph instances and other infrastructure that mimic various customers' environments for testing purposes. See "[Customer environment replicas and managed instances](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme45a/003/ctqvj7zcmdiujmfh2mxzffdlym)" on 1Password for the list.

--- a/handbook/engineering/distribution/internal_infrastructure.md
+++ b/handbook/engineering/distribution/internal_infrastructure.md
@@ -37,6 +37,7 @@ Credentials: [1Password](https://my.1password.com/vaults/dnrhbauihkhjs5ag6vszsme
 ### Gerrit
 
 URL: https://gerrit.sgdev.org
+
 Git URL: gerrit-ssh.sgdev.org
 
 Credentials: Google Auth


### PR DESCRIPTION
We deployed a dogfood Gerrit instance in https://github.com/sourcegraph/infrastructure/pull/2264.

/cc @sourcegraph/web 