### PR TITLE
Add user research info pages

### DIFF
--- a/handbook/product/user_research/index.md
+++ b/handbook/product/user_research/index.md
@@ -1,0 +1,4 @@
+# User research
+
+- [So you’re about to participate in user testing](user_research_participant.md)
+- [So you’re about to help us with user testing](user_research_observer.md)

--- a/handbook/product/user_research/user_research_observer.md
+++ b/handbook/product/user_research/user_research_observer.md
@@ -1,0 +1,39 @@
+# So you’re about to help us with user testing
+
+Thank you so much for helping us with our user research! Observing and notetaking during user interviews and testing sessions is an amazing way for you to get a first-hand look at how others use our products and ideas, and your role as a notetaker is a huge help for the team.
+
+Here’s everything you need to know ahead of time.
+
+## Prerequisites
+
+- We use Lookback to conduct the sessions. Lookback requires Chrome, so please make sure you have Chrome installed and ready.
+
+## What to expect
+
+- You will receive a link to join a session as an **observer** ahead of time. You can join anytime before the session begins.
+- As an observer, you will not be on camera or audio, and the participant will not have any indication that you’re observing the session. The participant will only interact with the moderator.
+- While the session is underway, there’s two things you can do: use the chat to talk with the moderator and other observers, and use the notetaking section to take notes.
+- All of your notes will be timestamped at the moment you begin typing.
+
+## How to take really good notes
+
+As an observer, you’re playing a critical role in making the session successful. The moderator is focused on running the session smoothly and asking questions and digging into answers. That means they can’t really take notes along the way. By helping by taking notes as an observer, we save so much time!
+
+Here’s some tips for taking really good notes:
+
+- Focus on **observations**, like what you see and hear.
+  - “They had trouble finding the button.”
+  - “Looks confused.”
+  - “Says they don’t understand the message.”
+
+- **Avoid extrapolation or interpretation** while taking notes.
+  - Instead of noting “They didn’t like the message,” capture “Describes the message as irritating.”
+  - Instead of “Blue doesn’t work for the button,” capture “Doesn’t notice the button.”
+- **Indicate priority** if it makes sense.
+  - “Totally failed to find the link 🚨”
+
+- **Nothing’s too small** to capture! After the session, the team will draw insights out of the observations.
+
+## What happens after the session’s done
+
+After the session is done (thank you!), we will have a session recording with all of the notes timestamped to the video. Synthesizing the results is always a bit different: sometimes you won’t have to do anything—the researcher might just do a quick pass and come up with action items. Other times, we might plan a debrief to discuss the session immediately after it’s done. We will always make sure you know exactly what to expect.

--- a/handbook/product/user_research/user_research_observer.md
+++ b/handbook/product/user_research/user_research_observer.md
@@ -1,18 +1,18 @@
 # So you’re about to help us with user testing
 
-Thank you so much for helping us with our user research! Observing and notetaking during user interviews and testing sessions is an amazing way for you to get a first-hand look at how others use our products and ideas, and your role as a notetaker is a huge help for the team.
+Thank you so much for helping us with our user research! Observing and notetaking during user interviews and testing sessions is an amazing way for you to get a first-hand look at how others use our products and ideas, and your role as a notetaker is a huge help for the team. You don't need to be a designer or product manager to get involved—all Sourcegraphers are welcome to participate!
 
 Here’s everything you need to know ahead of time.
 
 ## Prerequisites
 
-- We use Lookback to conduct the sessions. Lookback requires Chrome, so please make sure you have Chrome installed and ready.
+- We use [Lookback](https://lookback.io) to conduct the sessions. Lookback requires Chrome, so please make sure you have Chrome installed and ready, and you've accepted the emailed invitation to join the Sourcegraph team on Lookback.
 
 ## What to expect
 
 - You will receive a link to join a session as an **observer** ahead of time. You can join anytime before the session begins.
 - As an observer, you will not be on camera or audio, and the participant will not have any indication that you’re observing the session. The participant will only interact with the moderator.
-- While the session is underway, there’s two things you can do: use the chat to talk with the moderator and other observers, and use the notetaking section to take notes.
+- While the session is underway, there are two things you can do: use the chat to talk with the moderator and other observers, and use the notetaking section to write down observations.
 - All of your notes will be timestamped at the moment you begin typing.
 
 ## How to take really good notes
@@ -36,4 +36,4 @@ Here’s some tips for taking really good notes:
 
 ## What happens after the session’s done
 
-After the session is done (thank you!), we will have a session recording with all of the notes timestamped to the video. Synthesizing the results is always a bit different: sometimes you won’t have to do anything—the researcher might just do a quick pass and come up with action items. Other times, we might plan a debrief to discuss the session immediately after it’s done. We will always make sure you know exactly what to expect.
+After the session is done (thank you!), a recording with all of the notes timestamped to the video will be saved on LookBack. The moderator will synthesize the results. Sometimes, we might also plan a debrief to discuss the session immediately after it’s done. We will always make sure you know exactly what to expect.

--- a/handbook/product/user_research/user_research_participant.md
+++ b/handbook/product/user_research/user_research_participant.md
@@ -1,0 +1,18 @@
+# So you’re about to participate in user testing
+
+Thank you so much for helping with our user research! Remote moderated hallway testing is a great way for us to quickly test and iterate on our ideas so that we can identify opportunities and challenges early.
+Here’s everything you need to know ahead of time.
+
+## Prerequisites
+
+- The tool we use, Lookback, works with Chrome. You’ll need to use Chrome to join the session.
+- Please make sure you install the [Participate by Lookback](https://chrome.google.com/webstore/detail/participate-by-lookback/ppapgcbnefafdghpfglgilaghielefgn/related) extension for Chrome.
+- Before joining the session, please make sure to turn on “Do not disturb” and hide any windows you don’t want others to see.
+
+## What to expect
+
+1. You will receive a link to join the session ahead of time. You can join anytime before the session begins. Whoever’s running the session will see you’ve joined and will start the session when they’re ready.
+2. The session will be recorded (audio, video, and screen) so we can refer to it in the future. We won’t share it outside the team.
+3. You can leave at any time, ask questions at any time, and share as much or as little information as you’d like.
+4. While you can ask questions at any time, we might not be able to answer! Often, we’re interested in seeing how you answer that question for yourself.
+5. We’re testing our ideas, **not you**! You can’t do anything wrong.

--- a/handbook/product/user_research/user_research_participant.md
+++ b/handbook/product/user_research/user_research_participant.md
@@ -5,7 +5,7 @@ Here’s everything you need to know ahead of time.
 
 ## Prerequisites
 
-- The tool we use, Lookback, works with Chrome. You’ll need to use Chrome to join the session.
+- The tool we use, [Lookback](https://lookback.io/), works with Chrome. You’ll need to use Chrome to join the session.
 - Please make sure you install the [Participate by Lookback](https://chrome.google.com/webstore/detail/participate-by-lookback/ppapgcbnefafdghpfglgilaghielefgn/related) extension for Chrome.
 - Before joining the session, please make sure to turn on “Do not disturb” and hide any windows you don’t want others to see.
 
@@ -16,3 +16,4 @@ Here’s everything you need to know ahead of time.
 3. You can leave at any time, ask questions at any time, and share as much or as little information as you’d like.
 4. While you can ask questions at any time, we might not be able to answer! Often, we’re interested in seeing how you answer that question for yourself.
 5. We’re testing our ideas, **not you**! You can’t do anything wrong.
+6. When the project is over, we’ll share the outcome so you can see where things ended up!


### PR DESCRIPTION
I'd like to expand on this to also include unmoderated sessions with usertesting.com, but getting something up and then iterating is better than waiting.