### PR TITLE
Add Tech Ladies

### DIFF
--- a/handbook/people-ops/hiring/index.md
+++ b/handbook/people-ops/hiring/index.md
@@ -41,6 +41,17 @@ We cross-post our open positions to the following locations:
 - [LinkedIn](https://www.linkedin.com/jobs/search/?keywords=sourcegraph)
 - ["Ask HN: Who is Hiring" monthly thread](hacker-news-who-is-hiring.md)
 - [RemoteWoman](https://remotewoman.com/)
+- [Tech Ladies](https://www.hiretechladies.com/). With our current plan we can post up to 10 roles at a time (and can rotate out roles as they are filled). Here are the 10 roles that we post:
+  1. [Engineering Manager - Backend Platform and Cloud](../../engineering/hiring/engineering-manager-backend-platform)
+  1. [Software Engineer - Frontend](../../engineering/hiring/software-engineer-frontend.md)
+  1. [Software Engineer - Backend](../../engineering/hiring/software-engineer-backend.md)
+  1. [Software Engineer - Distribution](../../engineering/hiring/software-engineer-distribution.md)
+  1. [Software Engineer - Security](../../engineering/hiring/software-engineer-security.md)
+  1. [Director of Community](../../marketing/roles/director_of_community.md)
+  1. [Director of Product Marketing](../../marketing/roles/director_of_product_marketing.md)
+  1. [Account Executive](../../sales/roles/account_executive.md)
+  1. [Product Manager](../handbook/product/roles/product_manager.md)
+  1. [Product Designer](../handbook/product/roles/product_designer.md)
 
 We welcome suggestions for more places that we can post!
 

--- a/handbook/people-ops/hiring/index.md
+++ b/handbook/people-ops/hiring/index.md
@@ -50,8 +50,8 @@ We cross-post our open positions to the following locations:
   1. [Director of Community](../../marketing/roles/director_of_community.md)
   1. [Director of Product Marketing](../../marketing/roles/director_of_product_marketing.md)
   1. [Account Executive](../../sales/roles/account_executive.md)
-  1. [Product Manager](../handbook/product/roles/product_manager.md)
-  1. [Product Designer](../handbook/product/roles/product_designer.md)
+  1. [Product Manager](../../product/roles/product_manager.md)
+  1. [Product Designer](../../product/roles/product_designer.md)
 
 We welcome suggestions for more places that we can post!
 

--- a/handbook/people-ops/hiring/index.md
+++ b/handbook/people-ops/hiring/index.md
@@ -41,7 +41,7 @@ We cross-post our open positions to the following locations:
 - [LinkedIn](https://www.linkedin.com/jobs/search/?keywords=sourcegraph)
 - ["Ask HN: Who is Hiring" monthly thread](hacker-news-who-is-hiring.md)
 - [RemoteWoman](https://remotewoman.com/)
-- [Tech Ladies](https://www.hiretechladies.com/). With our current plan we can post up to 10 roles at a time (and can rotate out roles as they are filled). Here are the 10 roles that we post:
+- [Tech Ladies](https://www.hiretechladies.com/). With our current plan we can post up to 10 roles at a time (and can rotate out roles as they are filled). Nick owns this list and payments are made with Nick's Brex. Tech Ladies checks our open positions every month to see if there are updates, but we can request an update anytime by emailing jobpostings@hiretechladies.com. Here are the 10 roles that we post:
   1. [Engineering Manager - Backend Platform and Cloud](../../engineering/hiring/engineering-manager-backend-platform.md)
   1. [Software Engineer - Frontend](../../engineering/hiring/software-engineer-frontend.md)
   1. [Software Engineer - Backend](../../engineering/hiring/software-engineer-backend.md)

--- a/handbook/people-ops/hiring/index.md
+++ b/handbook/people-ops/hiring/index.md
@@ -42,7 +42,7 @@ We cross-post our open positions to the following locations:
 - ["Ask HN: Who is Hiring" monthly thread](hacker-news-who-is-hiring.md)
 - [RemoteWoman](https://remotewoman.com/)
 - [Tech Ladies](https://www.hiretechladies.com/). With our current plan we can post up to 10 roles at a time (and can rotate out roles as they are filled). Here are the 10 roles that we post:
-  1. [Engineering Manager - Backend Platform and Cloud](../../engineering/hiring/engineering-manager-backend-platform)
+  1. [Engineering Manager - Backend Platform and Cloud](../../engineering/hiring/engineering-manager-backend-platform.md)
   1. [Software Engineer - Frontend](../../engineering/hiring/software-engineer-frontend.md)
   1. [Software Engineer - Backend](../../engineering/hiring/software-engineer-backend.md)
   1. [Software Engineer - Distribution](../../engineering/hiring/software-engineer-distribution.md)


### PR DESCRIPTION
We can post up to 10 roles on Tech Ladies given our current plan and I think we should document the roles we post here in the handbook.

This is my proposed list. It includes all engineering roles, @kaciewj 's two marketing roles (per her request), AE role, and two product roles @christinaforney.