### PR TITLE
release: remove build step, fix branch and candidate commands

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -55,7 +55,7 @@ Create and test release candidates:
 
 - [ ] Push a release candidate tag:
     ```
-    yarn run release release-candidate:create 1
+    yarn run release release:create-candidate 1
     ```
 - [ ] Wait for the release candidate Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags).
 - [ ] Ensure the release candidate starts for upgrades and new instances:
@@ -73,8 +73,8 @@ Create and test release candidates:
 ## Stage release
 
 - [ ] Tag the final release:
-    ```
-    yarn run release release-candidate:create final
+    ```sh
+    yarn run release release:create-candidate final
     ```
 - [ ] Wait for the release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags).
 - [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns)):

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -23,7 +23,7 @@ Arguments:
 ## Setup
 
 - [ ] Ensure release configuration in [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) on `main` is up to date with the parameters for the current release.
-- [ ] Ensure the latest version of the release tooling has been built before each step using `yarn run build` in `dev/release`.
+- [ ] Ensure you have the latest version of the release tooling and configuration by checking out and updating `sourcegraph@main`.
 
 ## Prepare release
 
@@ -97,7 +97,7 @@ Create and test release candidates:
 ## Post-release
 
 - [ ] Open a PR to update [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) with the parameters for the current release.
-- [ ] Run `yarn build` to rebuild the release script.
+- [ ] Ensure you have the latest version of the release tooling and configuration by checking out and updating `sourcegraph@main`.
 - [ ] Close this issue.
 
 **Note:** If another patch release is requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md) be filled out and approved first.

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -24,7 +24,7 @@ This release is scheduled for $RELEASE_DATE.
 ## Setup
 
 - [ ] Ensure release configuration in [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) on `main` is up to date with the parameters for the current release.
-- [ ] Ensure the latest version of the release tooling has been built before each step using `yarn run build` in `dev/release`.
+- [ ] Ensure you have the latest version of the release tooling and configuration by checking out and updating `sourcegraph@main`.
 
 ## $FIVE_WORKING_DAYS_BEFORE_RELEASE (5 work days before release): Prep for branch cut
 
@@ -116,7 +116,7 @@ Once there are no more release-blocking issues (as reported by the `release:stat
 
 - [ ] Notify the next release captain that they are on duty for the next release. They should complete the steps in this section.
 - [ ] Open a PR to update [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) with the parameters for the current release.
-- [ ] Run `yarn build` to rebuild the release script.
+- [ ] Ensure you have the latest version of the release tooling and configuration by checking out and updating `sourcegraph@main`.
 - [ ] Create release calendar events, tracking issue, and announcement for next release:
   ```sh
   # Add calendar events and reminders for key dates in the release cycle

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -84,8 +84,8 @@ Once there are no more release-blocking issues (as reported by the `release:stat
   `main` is accurate (no items should have been added since branch cut, but some items may need to
   be removed).
 - [ ] Tag the final release:
-  ```
-  yarn run release release-candidate:create final
+  ```sh
+  yarn run release release:create-candidate final
   ```
 - [ ] Wait for the release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags).
 - [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns)):


### PR DESCRIPTION
Documents https://github.com/sourcegraph/sourcegraph/pull/16519 , which removes the need to run `yarn run build` separately.

Makes fixes noted in https://github.com/sourcegraph/sourcegraph/issues/16207 , mainly the branch and create-candidate commands were wrong