### PR TITLE
moving refrence checks to after the job offer

### DIFF
--- a/handbook/engineering/hiring/software-engineer-backend.md
+++ b/handbook/engineering/hiring/software-engineer-backend.md
@@ -60,7 +60,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - 30m **CTO**
    - 30m **CEO**
 1. We make you a job offer.
-1. We check your references.
+1. By default, [we check your references during your first week at Sourcegraph](https://about.sourcegraph.com/handbook/people-ops/hiring/reference_check_questions).
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-backend.md
+++ b/handbook/engineering/hiring/software-engineer-backend.md
@@ -59,8 +59,8 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - 30m **VP Engineering**
    - 30m **CTO**
    - 30m **CEO**
-1. We check your references.
 1. We make you a job offer.
+1. We check your references.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-code-intelligence.md
+++ b/handbook/engineering/hiring/software-engineer-code-intelligence.md
@@ -40,7 +40,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
    - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
 1. We make you a job offer.
-1. We check your references.
+1. By default, [we check your references during your first week at Sourcegraph](https://about.sourcegraph.com/handbook/people-ops/hiring/reference_check_questions).
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-code-intelligence.md
+++ b/handbook/engineering/hiring/software-engineer-code-intelligence.md
@@ -39,8 +39,8 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - **Technical experience:** We ask you about your past work and accomplishments.
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
    - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
-1. We check your references.
 1. We make you a job offer.
+1. We check your references.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-distribution.md
+++ b/handbook/engineering/hiring/software-engineer-distribution.md
@@ -37,8 +37,8 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - **Technical experience:** We ask you about your past work and accomplishments.
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
    - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
-1. We check your references.
 1. We make you a job offer.
+1. We check your references.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-distribution.md
+++ b/handbook/engineering/hiring/software-engineer-distribution.md
@@ -38,7 +38,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
    - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
 1. We make you a job offer.
-1. We check your references.
+1. By default, [we check your references during your first week at Sourcegraph](https://about.sourcegraph.com/handbook/people-ops/hiring/reference_check_questions).
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-frontend.md
@@ -66,7 +66,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - 30 minutes **CTO**
    - 30 minutes **CEO**
 1. We make you a job offer.
-1. We check your references.
+1. By default, [we check your references during your first week at Sourcegraph](https://about.sourcegraph.com/handbook/people-ops/hiring/reference_check_questions).
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-frontend.md
@@ -65,8 +65,8 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - 30 minutes **VP Engineering**
    - 30 minutes **CTO**
    - 30 minutes **CEO**
-1. We check your references.
 1. We make you a job offer.
+1. We check your references.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-security.md
+++ b/handbook/engineering/hiring/software-engineer-security.md
@@ -49,8 +49,8 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - 30m **VP Engineering**
    - 30m **CTO**
    - 30m **CEO**
-1. We check your references.
 1. We make you a job offer.
+1. We check your references.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-security.md
+++ b/handbook/engineering/hiring/software-engineer-security.md
@@ -50,7 +50,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - 30m **CTO**
    - 30m **CEO**
 1. We make you a job offer.
-1. We check your references.
+1. By default, [we check your references during your first week at Sourcegraph](https://about.sourcegraph.com/handbook/people-ops/hiring/reference_check_questions).
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 


### PR DESCRIPTION
Moving reference checks to reflect that they happen after the offer is signed. This is to reflect the fact that a reference check does not hold up offers or joining Sourcegraph