### PR TITLE
Update front-end engineer experience requirements

### DIFF
--- a/handbook/engineering/hiring/software-engineer-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-frontend.md
@@ -4,7 +4,7 @@ We are looking for frontend engineers who know how to build intuitive user exper
 
 The following engineering teams are currently hiring for this role:
 
-1. [Web](../web/index.md#growth-plan) - all experience levels
+1. [Web](../web/index.md#growth-plan) - experienced (2+ years) and senior engineers
 2. [Cloud](../cloud/index.md#growth-plan) - senior experience level
 
 ## About you


### PR DESCRIPTION
The Web team is not in a position to take on junior/starter engineers at the moment. 

We need engineers who have professional working experience in the tech stack we use as our codebase is not the easiest to onboard onto. 

While I would love nothing more than to give bright juniors/starters an opportunity to prove themselves at Sourcegraph and invest in them, we are not in a position to do that currently.

Our aim is to maintain a 2:1 ratio of experienced to inexperienced engineers during our time of rapid growth in the Web team and we need to make a few experienced appointments and give those team members time to onboard before we bring on inexperienced engineers.

We can still choose to approach more inexperienced engineers in our outbound recruiting efforts if they show potential (e.g. they maintain a popular open-source project)