### PR TITLE
Indicate that Joel is acting PM for Web team

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -122,7 +122,7 @@ Before web team syncs, teammates and stakeholders should write down under "Discu
 
 ## Members
 
-- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager *](../../product/roles/product_manager.md))
+- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md)*)
 - [Jean du Plessis](../../../company/team/index.md#jean-du-plessis-he-him) ([Engineering Manager](../roles.md#engineering-manager))
   - [Felix Becker](../../../company/team/index.md#felix-becker)
   - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -122,11 +122,13 @@ Before web team syncs, teammates and stakeholders should write down under "Discu
 
 ## Members
 
-- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md))
+- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager *](../../product/roles/product_manager.md))
 - [Jean du Plessis](../../../company/team/index.md#jean-du-plessis-he-him) ([Engineering Manager](../roles.md#engineering-manager))
   - [Felix Becker](../../../company/team/index.md#felix-becker)
   - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
   - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
+  
+_* Joel is the acting PM for this team until we are able to hire a dedicated PM for it._  
 
 ## Growth plan
 

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -128,7 +128,7 @@ Before web team syncs, teammates and stakeholders should write down under "Discu
   - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
   - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
   
-_* Joel is the acting PM for this team until we are able to hire a dedicated PM for it._  
+_* Joel is the acting PM for this team until we are able to hire a dedicated PM for it. Once that happens, he will focus entirely on code insights._  
 
 ## Growth plan
 


### PR DESCRIPTION
As per my comment here, https://github.com/sourcegraph/about/pull/2140#discussion_r539194429, I suggest we update the Web team page to indicate that Joel is the acting PM until we hire a dedicated PM to replace him. This aligns with Joel's primary focus of driving the Code Insights team right now as we move to get everything in place for the formation of that team.