### PR TITLE
Update reference call protocol

### DIFF
--- a/handbook/people-ops/hiring/reference_check_questions.md
+++ b/handbook/people-ops/hiring/reference_check_questions.md
@@ -1,6 +1,6 @@
 # Reference checks
 
-References will be requested by the hiring manager on a case by case basis and the hiring manager is responsible for deciding which specific references they would like to speak to based on the candidate's work experience.
+References will be requested by the hiring manager on a case by case basis and the hiring manager is responsible for deciding which specific references they would like to speak to based on the candidate's work experience and interview performance.
 
 Ultimately, the goal behind our reference checks is to ensure that we are setting up the new hire for success and know how to best work with them.
 

--- a/handbook/people-ops/hiring/reference_check_questions.md
+++ b/handbook/people-ops/hiring/reference_check_questions.md
@@ -21,3 +21,4 @@ People Ops will coordinate a calls with references and hiring managers. People O
 * If you were writing their annual review today, where would they have an opportunity to improve or build on their skills?
 * Do you have any advice for their future manager?
 * Was there ever a time where [candidate] was disrespectful in any way to other members of the team?
+* (HM then jumps in with any specific questions they have for the reference)

--- a/handbook/people-ops/hiring/reference_check_questions.md
+++ b/handbook/people-ops/hiring/reference_check_questions.md
@@ -12,7 +12,7 @@ Requested references will typically be a former manager(s) and/or colleague(s) a
 
 ## Reference call
 
-People Ops will coordinate a calls with references and hiring managers. People Ops will conduct the reference calls with the hiring manager present to address any potential concerns or follow-up questions.
+The recruiter will coordinate a calls with references and hiring managers. The recruiter will conduct the reference calls with the hiring manager present to address any potential concerns or follow-up questions.
 
 ## Reference call questions
 

--- a/handbook/people-ops/hiring/reference_check_questions.md
+++ b/handbook/people-ops/hiring/reference_check_questions.md
@@ -1,8 +1,8 @@
 # Reference checks
 
-As part of our hiring process, we conduct a reference check. We will request specific references prior to making an offer to the candidate and will inform them that references will be conducted by People Ops and the hiring manager within their first week.
+References will be requested by the hiring manager on a case by case basis and the hiring manager is responsible for deciding which specific references they would like to speak to based on the candidate's work experience.
 
-We will conduct references calls within each new hire's first week at Sourcegraph. Ultimately, the goal behind our reference checks is to ensure that we are setting up the new hire for success, and doing them within their first week will keep reference calls from being a blocker for sending candidates their offer letter and establishing a start date.
+Ultimately, the goal behind our reference checks is to ensure that we are setting up the new hire for success and know how to best work with them.
 
 ## Reference requirements
 
@@ -12,11 +12,9 @@ Requested references will typically be a former manager(s) and/or colleague(s) a
 
 ## Reference call
 
-People Ops will reach out to each reference to schedule calls. People Ops will conduct the reference calls with the hiring manager present to address any potential concerns or follow-up questions.
+People Ops will coordinate a calls with references and hiring managers. People Ops will conduct the reference calls with the hiring manager present to address any potential concerns or follow-up questions.
 
-## Template
-
-Call intro: "We already think [candidate name] is great, and are looking forward to working with them, so the call of this is to learn how we can best work with them and make them successful here at Sourcegraph."
+## Reference call questions
 
 * In what context did you two work together? What was your role/their role at the time?
 * What would make [candidate] happy and motivated in a role?


### PR DESCRIPTION
References are a big bottleneck (mainly due to People Ops bandwidth)– they take a lot of roundtrip coordination, involve playing phone tag, and accumulate very quickly based on the number of offers we have going out these days. (It is also extremely rare that reference checks have actually affected someone's offer).

New proposal for reference call protocol (this is subject to change in the future, but for now is solving for bandwidth on the recruiting team):

- HM requests references on ad-hoc basis (only if you have any specific concerns about a candidate or their experience).
- HM requests specific references (ex: former manager at X company or team lead at current company), ideally no more than two, whoever you think will give you the most insight on your concerns.
- HM decides the timeline for the reference call (s)– whether it should to be prior to an offer, concurrently to an offer, after an offer, or after hire.
- Recruiter coordinates calls and invites the HM to join all reference calls so they can dig into the areas of concern.
- HM must be present for reference call(s).