### PR TITLE
Propose more focus for web team

### DIFF
--- a/handbook/engineering/web/code_insights.md
+++ b/handbook/engineering/web/code_insights.md
@@ -1,0 +1,23 @@
+# Code insights
+
+Code insights is the first feature in Sourcegraph that can tell you things about your code at a **high level**. Here's [the original RFC](https://docs.google.com/document/d/1EHzor6I1GhVVIpl70mH-c10b1tNEl_p1xRMJ9qHQfoc/edit) and a [demo](https://www.youtube.com/watch?v=XqeRb6Mc4Co) of a code insights prototype.
+
+Sourcegraph is in the unique position to give these insights because we have universal code search: To know _anything_ about your code at a high level means you must know _everything_ about your code at a low level.
+
+Code insights connects a lot of features that Sourcegraph already has and builds on top of them.
+We go beyond single-step code intelligence and search to connect the full cycle of analyzing (code intelligence), monitoring (code insights), and actionably changing a codebase (campaigns).
+
+Code insights will also allow to combine these Sourcegraph-created metrics with other third-party data sources.
+
+Code insights is the first feature primarily built for non-search-based user personas.
+
+## Vision
+
+1. Expose the value of Sourcegraph's knowledge of your codebase to users at all levels of an organization.
+1. Expose generalizable metrics that let our users measure and track their own goals, whether those are migrations, code smells, test coverage,  security needs, cross-collaboration, or other information about code.
+1. Make these metrics scalable across thousands of repositories on a Sourcegraph instance.
+1. Expose features that let our users build their own insights.
+1. Expose features that let users drill down into insights by teams, repositories, or other sub-metrics.
+1. Connect code insights to other Sourcegraph features – make a campaign to take action on a metric or set up code monitoring to notify you about changes to an insight.
+1. Add plug-and-play integrations to Sourcegraph code insights that let users easily integrate third-party data into their insights.
+1. Discover new, validated code metrics that engineering teams should track (and let teams track them).

--- a/handbook/engineering/web/goals.md
+++ b/handbook/engineering/web/goals.md
@@ -4,9 +4,8 @@
 
 ### Long term
 
-**_The web team has four areas of focus:_**
+**_The web team has three areas of focus:_**
 
-  1. **_Creating and maintaining a highly usable and intentionally designed webapp interface_**
   1. **_Delivering the full, unique value of Sourcegraph [extensions](https://docs.sourcegraph.com/extensions)_**
   1. **_Maintaining and expanding_ [_code host integrations_](https://docs.sourcegraph.com/dev/background-information/web/code_host_integrations)**
   1. **_Developing code insights into an entirely new featureset_**

--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -2,20 +2,34 @@
 
 # Web team
 
-The web team owns the maintenance and expansion of our web application and code host integrations as vehicles to deliver the value of [extensions](https://docs.sourcegraph.com/extensions) to our users.
+This is a product team that owns two areas of our product: integrations and code insights.
 
-This is a large ownership area, so the team creates a focused plan each iteration, by agreeing on an appropriately small set of [iteration goals](../../../company/goals/index.md). Each goal should have more than one teammate working on it.
+
+## Code insights
+
+Code insights surface high level information about code that is valuable for both devs and engineering leaders. [Learn more here](code_insights.md).
+
+## Integrations
+
+Integrations connect Sourcegraph to other developer tools so that Sourcegraph becomes a hub of all the information that developers care about, and so that that developers have access to all of the power of Sourcegraph in all their other dev tools.
+
+Examples:
+
+- Surface code intelligence (and other Sourcegraph data) in code hosts through user installed browser extensions.
+- Add native support for Sourcegraph in code hosts (for example: GitLab) or popular sites where developer look at code examples (e.g. https://reactjs.org, https://pkg.go.dev/) so users don't have to install our browser extensions to get code intelligence.
+- Build an extension API for Sourcegraph that enables developers to bring data from their favorite dev tools (for example: code coverage, exception tracking, tracing, code quality) into their Sourcegraph workflow.
+- Build useful Sourcegraph extensions on top of the Sourcegraph extension API (for example: Codecov, Datadog, Sentry, Lightstep)
 
 <div style="clear: both"/>
+
+## [Goals](goals.md)
+
+See this team's [goals](goals.md) for what work is being done for each of these ownership areas.
 
 ## Contact
 
 - #web channel or @web-team in Slack.
 - [team/web](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/web) label and [@sourcegraph/web](https://github.com/orgs/sourcegraph/teams/web) team on GitHub.
-
-## [Goals](goals.md)
-
-See [goals](goals.md)
 
 ## Tech stack
 
@@ -29,6 +43,31 @@ Here are some of the technologies we use to deliver on our goals:
 - [WebExtensions](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API)
 - [RxJS](https://rxjs-dev.firebaseapp.com/guide/overview)
 - [Web workers](https://developer.mozilla.org/en-US/docs/Web/API/Web_Workers_API)
+
+## Members
+
+- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md))
+- [Jean du Plessis](../../../company/team/index.md#jean-du-plessis-he-him) ([Engineering Manager](../roles.md#engineering-manager))
+  - [Felix Becker](../../../company/team/index.md#felix-becker)
+  - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
+  - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
+
+## Growth plan
+
+_Updated 2020-12-09_
+
+We are growing the web team by hiring [frontend engineers](../hiring/software-engineer-frontend.md) who are interested to work on code insights and web platform work. When this team reaches sufficient size, we will create dedicated teams for code insights, integrations, and web platform.
+
+### Web platform
+
+This future team will be accountable for ensuring that our product engineering teams have the tools and components they need to quickly build high quality user experiences everywhere we use web technologies (for example: web application, browser extensions). The primary customers of this team are other engineers at Sourcegraph.
+
+Examples:
+
+- Creating a standard component library.
+- Documentation to enable product teams and new hires to quickly learn how we do web development at Sourcegraph.
+- Product improvements that affect our entire app and don't have a clear product team owner (for example: new nav bar, complete site redesign)
+- Efficiency and reliability of frontend CI pipeline steps.
 
 ## Processes
 
@@ -119,47 +158,3 @@ The web team holds weekly syncs.
 The meeting notes of web team syncs can be found [in this doc](https://docs.google.com/document/u/1/d/1IUsjbtYdGiAHvRUB1yf4eqnynin9WsxFR2zFCMm78jw/edit#).
 
 Before web team syncs, teammates and stakeholders should write down under "Discussion items" in the meeting notes document anything that they'd like to bring up for discussion with the whole team.
-
-## Members
-
-- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md))
-- [Jean du Plessis](../../../company/team/index.md#jean-du-plessis-he-him) ([Engineering Manager](../roles.md#engineering-manager))
-  - [Felix Becker](../../../company/team/index.md#felix-becker)
-  - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
-  - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
-
-## Growth plan
-
-_Updated 2020-11-18_
-
-We are growing the web team by hiring [frontend engineers](../hiring/software-engineer-frontend.md). When this team gets big enough, we expect to spin off two teams (code insights, and extensions and integrations) and convert the web team into an infrastructure team.
-
-### Web platform
-
-This team is accountable for ensuring that our product engineering teams have the tools and components they need to quickly build high quality user experiences everywhere we use web technologies (for example: web application, browser extensions). The primary customers of this team are other engineers at Sourcegraph.
-
-Examples:
-
-- Creating a standard component library.
-- Documentation to enable product teams and new hires to quickly learn how we do web development at Sourcegraph.
-- Product improvements that affect our entire app and don't have a clear product team owner (for example: new nav bar, complete site redesign)
-- Efficiency and reliability of frontend CI pipeline steps.
-
-### Code insights
-
-This team is responsible for building and delivering [**code insights**](https://docs.google.com/document/d/1EHzor6I1GhVVIpl70mH-c10b1tNEl_p1xRMJ9qHQfoc/edit) to engineering leaders, empowering data-driven decisions.
-
-This team will not be created until we have identified a dedicated engineering manager and a dedicated product manager.
-
-### Extensions and integrations
-
-This team is responsible for how we bring the value of Sourcegraph to other developer tools as well as how we bring the value of other developers tools into Sourcegraph.
-
-Examples:
-
-- Surface code intelligence (and other Sourcegraph data) in code hosts through user installed browser extensions.
-- Add native support for Sourcegraph in code hosts (for example: GitLab) or popular sites where developer look at code examples (e.g. https://reactjs.org, https://pkg.go.dev/) so users don't have to install our browser extensions to get code intelligence.
-- Build an extension API for Sourcegraph that enables developers to bring data from their favorite dev tools (for example: code coverage, exception tracking, tracing, code quality) into their Sourcegraph workflow.
-- Build useful Sourcegraph extensions on top of the Sourcegraph extension API (for example: Codecov, Datadog, Sentry, Lightstep)
-
-This team will not be created until we have identified a dedicated engineering manager and a dedicated product manager.


### PR DESCRIPTION
This PR is in response to two pieces of feedback.
1. [The team feels like code insights is buried too deep](https://github.com/sourcegraph/about/pull/2140/files#r538486398) to be effective for attracting candidates.
2. The web team currently feels like a "bucket/catch all" team that owns too much given its size. This creates a feeling of overwhelm on the team.

The PR proposes a few changes:
1. Explicitly removing web platform work as an ownership area of this team. While this team has done web platform work, it has been incidental and in service to other goals. Especially looking at the documented roadmap, I think we should just be explicit that this team is not functioning as a web platform team today. We need to create that team.
2. Condense "extensions and integrations" into "integrations". This is just a naming change to avoid awkward sentences like "extensions and integrations, and code insights". In this PR "integrations" has bidirectional implications (dev tools integrating with Sourcegraph via our extension API, and Sourcegraph integrating with code hosts via our browser extensions).
3. It lifts the exciting product areas that this team owns to the top of the page, which is the most relevant content to readers outside of the team, including candidates.

I also have an opinion that we should rebrand/rename the web team to "Integrations and code insights" (or, if we are already ready to declare code insights to be a separate team, then rebrand the remaining web team to "Integrations and extensions" or something similar). This change is not implemented in this PR because that would involve a lot of renames.