### PR TITLE
Add search growth EM job description

### DIFF
--- a/handbook/engineering/hiring/engineering-manager-search-growth.md
+++ b/handbook/engineering/hiring/engineering-manager-search-growth.md
@@ -6,7 +6,7 @@ The team will own unlocking new use cases of Sourcegraph search and improving ad
 
 - Adding [code monitoring](https://docs.google.com/document/d/1_R5DgpUkxyZilsJ9vBQm5cvRPT2udc3tZIPg2q3cnZU/edit) capabilities to Sourcegraph
 - Improving user onboarding to the Sourcegraph query language
-- Making Sourcegraph search aware of [contexs](https://docs.google.com/document/d/1mlxy7Fy19Q2yua7Fjg0xCda1c07f9RoR8rXxU22Ni60/edit) that help users search through the code they care about
+- Making Sourcegraph search aware of [contexts](https://docs.google.com/document/d/1mlxy7Fy19Q2yua7Fjg0xCda1c07f9RoR8rXxU22Ni60/edit) that help users search through the code they care about
 
 While some engineers will join the Search growth team immediately following the split, the team will likely need to grow to achieve its goals, and you own defining hiring needs and execuing on them.
 

--- a/handbook/engineering/hiring/engineering-manager-search-growth.md
+++ b/handbook/engineering/hiring/engineering-manager-search-growth.md
@@ -2,7 +2,7 @@
 
 As our [search team plans to split](../search/index.md#growth-plan), we are looking for an engineering manager to build and lead our [Search growth](../search/index.md#search-growth) team.
 
-The team will own unlocking new use cases of Sourcegraph search and improving adoption and retention of Sourcegraph search features for Cloud and Enerprise users alike, through projecs such as:
+The team will own unlocking new use cases of Sourcegraph search and improving adoption and retention of Sourcegraph search features for Cloud and Enterprise users alike, through projecs such as:
 
 - Adding [code monitoring](https://docs.google.com/document/d/1_R5DgpUkxyZilsJ9vBQm5cvRPT2udc3tZIPg2q3cnZU/edit) capabilities to Sourcegraph
 - Improving user onboarding to the Sourcegraph query language

--- a/handbook/engineering/hiring/engineering-manager-search-growth.md
+++ b/handbook/engineering/hiring/engineering-manager-search-growth.md
@@ -8,7 +8,7 @@ The team will own unlocking new use cases of Sourcegraph search and improving ad
 - Improving user onboarding to the Sourcegraph query language
 - Making Sourcegraph search aware of [contexts](https://docs.google.com/document/d/1mlxy7Fy19Q2yua7Fjg0xCda1c07f9RoR8rXxU22Ni60/edit) that help users search through the code they care about
 
-While some engineers will join the Search growth team immediately following the split, the team will likely need to grow to achieve its goals, and you own defining hiring needs and execuing on them.
+While some engineers will join the Search growth team immediately following the split, the team will likely need to grow to achieve its goals, and you own defining hiring needs and executing on them.
 
 ## Responsibilities
 

--- a/handbook/engineering/hiring/engineering-manager-search-growth.md
+++ b/handbook/engineering/hiring/engineering-manager-search-growth.md
@@ -48,7 +48,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
      - The interviewers will be [Nick Snyder](../../../company/team/index.md#nick-snyder-he-him) and another Engineering Manager except Loïc.
    - 1h [Technical experience](https://github.com/sourcegraph/interviews/blob/master/engineering/technical-experience.md) - We ask you about your past work and accomplishments.
      - The interviewers will be two of the following:
-       - [Juliana Peña](../../../company/team/index.md#keegan-pena-she-her)
+       - [Juliana Peña](../../../company/team/index.md##juliana-peña-she-her)
        - [Rijnard Van Tonder](../../../company/team/index.md#rijnard-van-tonder)
        - [Stefan Hengl](../../../company/team/index.md#stefan-hengl-he-him)
    - 1h [Team collaboration](https://github.com/sourcegraph/interviews/blob/master/engineering/team-collaboration.md). We ask you about how you work and communicate in a team setting, and how you handle tricky situations.

--- a/handbook/engineering/hiring/engineering-manager-search-growth.md
+++ b/handbook/engineering/hiring/engineering-manager-search-growth.md
@@ -1,0 +1,69 @@
+# Engineering Manager - Search growth team
+
+As our [search team plans to split](../search/index.md#growth-plan), we are looking for an engineering manager to build and lead our [Search growth](../search/index.md#search-growth) team.
+
+The team will own unlocking new use cases of Sourcegraph search and improving adoption and retention of Sourcegraph search features for Cloud and Enerprise users alike, through projecs such as:
+
+- Adding [code monitoring](https://docs.google.com/document/d/1_R5DgpUkxyZilsJ9vBQm5cvRPT2udc3tZIPg2q3cnZU/edit) capabilities to Sourcegraph
+- Improving user onboarding to the Sourcegraph query language
+- Making Sourcegraph search aware of [contexs](https://docs.google.com/document/d/1mlxy7Fy19Q2yua7Fjg0xCda1c07f9RoR8rXxU22Ni60/edit) that help users search through the code they care about
+
+While some engineers will join the Search growth team immediately following the split, the team will likely need to grow to achieve its goals, and you own defining hiring needs and execuing on them.
+
+## Responsibilities
+
+You will:
+
+- Facilitate an inclusive and cohesive team environment where everyone is happy, motivated, and productive.
+- Model, teach, and reinforce [our company values](../../../company/values.md) and [our guiding engineering principles](../index.md#guiding-principles).
+- Ensure the team has clear incremental goals that are documented and are always up-to-date.
+- Regularly communicate the team's progress toward their goals as well as changes in team goals to appropriate stakeholders.
+- Support and coach teammates to grow in their careers and fulfill their responsibilities.
+- Grow the team in a sustainable way so that the team can accomplish more over time.
+
+## Qualifications
+
+- You have 2+ years of experience directly managing at least 4 full-time software engineers. We expect you already know how to lead a team.
+- You have done some amount of coding in the past 2 years (for example: at work or on a personal project) to keep your skills up-to-date. We expect that you are able to review and provide valuable feedback on code, architecture, and designs.
+- You are able to clearly communicate your past accomplishments verbally (example: in an interview) and in writing (examples: in your resume, in your answers to our application questions).
+- You have experience breaking up complex technical problems into smaller achievable milestones that the team can iterate on.
+
+## Learn more about us
+
+To create a product that serves the needs of all developers, we are building a diverse [all-remote team](../../../company/remote/index.md) that is [distributed across the world](../../../company/team/index.md). Sourcegraph is an equal opportunity workplace; we welcome people from all backgrounds and communities.
+
+We provide [competitive compensation](../../people-ops/compensation.md) and [practical benefits](../../people-ops/benefits-and-perks.md) to keep you happy and healthy so that you can do your best work.
+
+Learn more about what it is like to work at Sourcegraph by reading [our handbook](../../index.md)
+
+## Interview process
+
+<!-- 1. You [apply here](#todo). --><!-- This is commented out because we will be focusing on referrals and outbound candidates at first. -->
+
+1. Intro calls
+   - 45m [Nick Snyder](../../../company/team/index.md#nick-snyder-he-him) (VP Engineering)
+   - 30m [Loïc Guychard](../../../company/team/index.md#loic-guychard) (Engineering Manager, Search)
+1. Interviews.
+   - 1h [Engineering leadership](engineering-leadership.md).
+     - The interviewers will be [Nick Snyder](../../../company/team/index.md#nick-snyder-he-him) and another Engineering Manager except Loïc.
+   - 1h [Technical experience](https://github.com/sourcegraph/interviews/blob/master/engineering/technical-experience.md) - We ask you about your past work and accomplishments.
+     - The interviewers will be two of the following:
+       - [Juliana Peña](../../../company/team/index.md#keegan-pena-she-her)
+       - [Rijnard Van Tonder](../../../company/team/index.md#rijnard-van-tonder)
+       - [Stefan Hengl](../../../company/team/index.md#stefan-hengl-he-him)
+   - 1h [Team collaboration](https://github.com/sourcegraph/interviews/blob/master/engineering/team-collaboration.md). We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
+     - The interviewers will be [Christina Forney](../../../company/team/index.md##christina-forney-she-her) (VP Product) and one of the following:
+       - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
+       - [Quinn Keast](../../../company/team/index.md#quinn-keast-he-him)
+       - [María Craig](../../../company/team/index.md#maría-craig-she-her)
+       - [Alicja Suska](../../../company/team/index.md#alicja-suska-she-her)
+   - 30m [Beyang Liu](../../../company/team/index.md#beyang-liu) (CTO)
+   - 30m [Quinn Slack](../../../company/team/index.md#quinn-slack) (CEO)
+
+If we want to move forward after these sets of interviews, we will setup 30-minute calls to meet any [members of the Search team](../search/index.md#members) that weren't already an interviewer. These calls are informal and don't have a script.
+
+We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
+
+<!-- **[Click here to apply](#todo)** --><!-- This is commented out because we will be focusing on referrals and outbound candidates at first. -->
+
+Go back to the [careers page](../../../company/careers.md) for all open positions.

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -84,17 +84,22 @@ Loïc will be at management capacity when we reach 7-8 engineers on the team, bu
 
 The search core team will focus on the capabilities, scalability and polish of our core feature set: search language and supporting UI, search backends.
 
-Examples:
+[Loïc Guychard](../../../company/team/index.md#loïc-guychard) will be the engineering manager of the Search core team. We are looking to hire a [Product Manager](../../product/roles/product_manager.md) for this team.
+
+Example projects:
 
 - Scale indexed search to 1m repositories.
 - Reduce latency and timeouts of search.
-- Implement streaming search.
+- Streaming search.
 
 ### Search growth
 
 The Search growth team will focus on initiatives aiming at growing usage or adoption of our search features, such as onboarding efforts or features unlocking new use cases.
 
-Examples:
+We are looking to hire an [engineering manager](../hiring/engineering-manager-search-growth.md) and a [Product Manager](../../product/roles/product_manager.md) for this team.
 
-- Implement code monitoring.
+Example projects:
+
+- Version contexts
+- Code monitoring.
 - Increase search weekly active users.

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -100,6 +100,6 @@ We are looking to hire an [engineering manager](../hiring/engineering-manager-se
 
 Example projects:
 
-- Version contexts
+- Version contexts.
 - Code monitoring.
 - Increase search weekly active users.


### PR DESCRIPTION
The search team will have 6+ engineers soon, and we need to start thinking about splitting it. This PR adds a job description for an engineering manager for the future Search growth team.