### PR TITLE
Updates to reflect current feedback process 

### DIFF
--- a/handbook/product/product_management/product_process.md
+++ b/handbook/product/product_management/product_process.md
@@ -7,6 +7,7 @@
 - [Tracking issues](../../engineering/tracking_issues.md) - how we keep track of planned and on-going work.
 - [Prioritizing](../prioritizing.md) - how we prioritize work, and how to get things prioritized.
 - [Tracking user feedback](../user_feedback.md) - sources of feedback and how we keep track of that feedback.
+- [Responding to user feedback](responding_to_user_feedback.md) - how we respond to user feedback for the feedback channels the product team owns.
 - [Feature rollout](../rollout_process.md) - how we test, rollout and launch new features.
 
 ## Definitions

--- a/handbook/product/product_management/responding_to_user_feedback.md
+++ b/handbook/product/product_management/responding_to_user_feedback.md
@@ -2,15 +2,23 @@
 
 The product team owns a number of [user feedback sources](../user_feedback.md). 
 
+## Cross-team communication and recording responses
+
+We check both HubSpot and Salesforce before replying to feedback to ensure another team has not already replied. We bcc all of our email replies to feedback into HubSpot and Salesforce so everyone can reference the communication. 
+
+If there are questions or takeaways that might impact a customer or prospect relationship, such as if the feedback is particularly strong (positive or negative) or timely, we also sometimes notify the relevant Sales/CE team member with a threaded reply in the `#feedback` channel in Slack. 
+
 ## Feedback rotation
 
-A single product manager owns the general feedback channels for 2-4 weeks at a time, and then rotates this responsibility to the next-in-line product manager. 
+A single product manager owns the below general feedback channels for 2-4 weeks at a time, and then rotates this responsibility to the next-in-line product manager. 
 
 The [feedback workflow doc](https://docs.google.com/document/d/1TTRjK-CL38fdCvrVUgRL70agUiwDbQFJXCo8IuJmLls/edit#) lists the current responder. 
 
 ### NPS Feedback
 
-> _TODO copy over some stuff from doc_
+We do our best to respond to any actionable feedback within 24 hours. 
+
+A detailed explanation of the current process and the suggested reply structures can be found in the [feedback workflow doc](https://docs.google.com/document/d/1TTRjK-CL38fdCvrVUgRL70agUiwDbQFJXCo8IuJmLls/edit#heading=h.vihl64g0qa6a). 
 
 ### Github issues created by third parties
 

--- a/handbook/product/product_management/responding_to_user_feedback.md
+++ b/handbook/product/product_management/responding_to_user_feedback.md
@@ -1,0 +1,21 @@
+# Responding to user feedback 
+
+The product team owns a number of [user feedback sources](../user_feedback.md). 
+
+## Feedback rotation
+
+A single product manager owns the general feedback channels for 2-4 weeks at a time, and then rotates this responsibility to the next-in-line product manager. 
+
+The [feedback workflow doc](https://docs.google.com/document/d/1TTRjK-CL38fdCvrVUgRL70agUiwDbQFJXCo8IuJmLls/edit#) lists the current responder. 
+
+### NPS Feedback
+
+> _TODO copy over some stuff from doc_
+
+### Github issues created by third parties
+
+We label and forward issues that others create to the right teams, because those outside the Sourcegraph GitHub organization cannot add labels. [This GitHub search](https://github.com/sourcegraph/sourcegraph/issues?page=2&q=is%3Aissue+no%3Alabel+is%3Aopen) is a fast way to find these issues. 
+
+## Browser uninstall form feedback
+
+See the [browser uninstall feedback section](https://docs.google.com/document/d/1TTRjK-CL38fdCvrVUgRL70agUiwDbQFJXCo8IuJmLls/edit#bookmark=id.hmb2g29ltsnr) of the feedback workflow doc. 

--- a/handbook/product/user_feedback.md
+++ b/handbook/product/user_feedback.md
@@ -58,23 +58,18 @@ We have a few different email lists that are used to send us feedback.
 
 - **Purpose:** Customers and prospects often give product feedback on calls with sales members. 
 
-> **Owner:** _TODO Process update coming soon_
+- **Owner:** The Sales team owns feedback from sales calls. 
 
 ### Hubspot forms
 
-> **Purpose/Owner:** _TODO what hubspot forms do we have that are not NPS or Browser uninstall?_
-
-### NPS Survey
+#### NPS Survey
 
 - **Purpose:** We prompt customers to provide NPS ratings from within the Sourcegraph UI. 
-- **Owner:** The product manager on feedback rotation owns responding to or forwarding NPS feedback. 
+- **Owner:** The product manager on [feedback rotation](product_management/responding_to_user_feedback.md#feedback-rotation) owns responding to or forwarding NPS feedback. 
 
-### Browser Extension Uninstall Feedback 
+#### Browser Extension Uninstall Feedback 
 - **Purpose:** We ask everyone who uninstalls the browser extension why they no longer want it. 
 - **Owner:** The browser extension product manager (currently the [Web team product manager](../engineering/web/index.md#members)) owns responding to this feedback. 
-
-### Product Feedback
-> _TODO_ I'm not sure what this refers to; is there a channel not covered here? Is this covered by slack `#feedback`?
 
 ## Productboard
 

--- a/handbook/product/user_feedback.md
+++ b/handbook/product/user_feedback.md
@@ -34,6 +34,47 @@ We have a few different email lists that are used to send us feedback.
 - **Purpose:** This email list is for customers to request help and creates tickets in JIRA for our Customer Engineering team.
 - **Owner:** The Customer Engineering team is responsible for all support issues and will pull in as needed engineering teams or product to help answer questions.
 
+### GitHub issues
+
+- **Purpose:** Anyone within or outside of Sourcegraph can file issues (like bugs or feature requests) is often a developer's default place to leave feedback. 
+- **Owner:** For issues filed by Sourcegraph teammates, the filing teammate is responsible for making sure the issue follows the relevant team's process. For issues filed by someone outside Sourcegraph, the product manager on feedback rotation is responsible for labelling or raising to the right team. 
+
+### Twitter
+
+- **Purpose:** Anyone can tweet about @Sourcegraph for public feedback. All tweets are in `#twitter` on Slack. 
+- **Owner:** Marketing. 
+
+### Slack
+
+- **Purpose:** Slack is a fast way for existing customers and Sourcegraph teammates to provide feedback. 
+- **Owner:** Most feedback in Slack appears in or gets forwarded into a relevant channel that already has clear owners. For feedback that does not have an obvious other location, whoever comes across it should post to the `#feedback` Slack channel.This channel is owned by the Product team. 
+
+### Support tickets
+
+- **Purpose:** A path for existing customers to get responsive support. 
+- **Owner:** CE team owns support tickets in a Jira project. 
+
+### Sales feedback 
+
+- **Purpose:** Customers and prospects often give product feedback on calls with sales members. 
+
+> **Owner:** _TODO Process update coming soon_
+
+### Hubspot forms
+
+> **Purpose/Owner:** _TODO what hubspot forms do we have that are not NPS or Browser uninstall?_
+
+### NPS Survey
+
+- **Purpose:** We prompt customers to provide NPS ratings from within the Sourcegraph UI. 
+- **Owner:** The product manager on feedback rotation owns responding to or forwarding NPS feedback. 
+
+### Browser Extension Uninstall Feedback 
+- **Purpose:** We ask everyone who uninstalls the browser extension why they no longer want it. 
+- **Owner:** The browser extension product manager (currently the [Web team product manager](../engineering/web/index.md#members)) owns responding to this feedback. 
+
+### Product Feedback
+> _TODO_ I'm not sure what this refers to; is there a channel not covered here? Is this covered by slack `#feedback`?
 
 ## Productboard
 


### PR DESCRIPTION
**I plan to leave this in draft state through the end of the week (due to the sales convo Friday) so no rush on review.**

A few catalysts for this PR: 
- The community site RFC reminded me about general community things like [unlabeled third-party github issues](https://sourcegraph.slack.com/archives/C07KZF47K/p1603160148448100?thread_ts=1603142063.446000&cid=C07KZF47K) that I had in my backlog to document still 
- We've made some good changes/updates (like feedback rotation) that aren't documented anywhere outside of a google doc 
- We're going to be making more changes to feedback processes or are [having conversations this week](https://docs.google.com/document/d/1gcgzdvIX9exZJWLraIsH5wjkmqHKLZ4q2Z5M4J_H3yA/edit#) about feedback which means that people involved in those conversations need a source of truth for "what exists now"

Changes: 

- Add all the feedback sources listed on the /user_feedback page to the list of purpose/owner details, since some are owned by non-product teams and others are owned by different aspects of the product team now
- Create a 'responding to feedback' page that I've intentionally put in the product_management subfolder because it only holds response processes relevant to the product-owned feedback channels 

TODOS listed as notes inline. 


