### PR TITLE
Add link to Sourcegraph LinkedIn banner image

### DIFF
--- a/handbook/people-ops/onboarding/general_onboarding.md
+++ b/handbook/people-ops/onboarding/general_onboarding.md
@@ -50,3 +50,5 @@
 - Go through the [analytics onboarding](https://sourcegraph.looker.com/projects/sourcegraph_events/files/1_home.md). This onboarding is within Looker, so if you don't have an account you can ask for access in #analytics.
 - Watch Dan's [Sourcegraph Demo](https://drive.google.com/file/d/1VUZ0rnZQpNgjtGDI0tMC-h-OtL0Czz8H/view)
 - Learn how we can (and cannot) [reference our customers externally](../../sales/index.md#customer)
+
+Bonus: you can celebrate joining Sourcegraph by changing your LinkedIn background to the [Sourcegraph banner](https://drive.google.com/file/d/1Fgrn_vaVVHVcKTaX9g5fDh9_Bwk9jL3E/view?usp=sharing)!


### PR DESCRIPTION
New team members can celebrate joining Sourcegraph by changing their LinkedIn banner. This PR adds information about the bonus activity and link to the asset.

**Why?**
After we've updated the social media assets, some of our team members asked us to provide a banner image for the individual LinkedIn profile as well. More in this [slack thread](https://sourcegraph.slack.com/archives/C02FSM7DU/p1607539658253200). Onboarding seems to be a good point to add this bonus activity. From day 1, newly hired team members can feel like a part of the team on social media!