### PR TITLE
Fix reference to server vs. .com

### DIFF
--- a/handbook/communication/content_guidelines/style_and_mechanics.md
+++ b/handbook/communication/content_guidelines/style_and_mechanics.md
@@ -672,7 +672,7 @@ A common error when writing questions is not constructing the sentence as a ques
 We describe ourselves with a few different names depending on context, and we should use the right term at the right time.
 
 - **Sourcegraph**: Main product. Prefer using this name unless you need to be more precise.
-- **Self-hosted Sourcegraph instance**: Only if clarification between Sourcegraph Cloud, managed instances, and on-premises instances is required.
+- **Self-hosted Sourcegraph instance or Sourcegraph Server**: The self-hosted Sourcegraph instance maintained by customers. Only if clarification between Sourcegraph Cloud, managed instances, and on-premises instances is required.
 - **Sourcegraph Server**: Only if clarification between the Sourcegraph Cloud instance, self-hosted instances, and managed instances is required.
 - **Sourcegraph Cloud**: The public instance of Sourcegraph for open source code at [sourcegraph.com](https://sourcegraph.com).
 - **Sourcegraph integrations**: The general term for our integrations. When referencing specific integrations:

--- a/handbook/communication/content_guidelines/style_and_mechanics.md
+++ b/handbook/communication/content_guidelines/style_and_mechanics.md
@@ -673,8 +673,8 @@ We describe ourselves with a few different names depending on context, and we sh
 
 - **Sourcegraph**: Main product. Prefer using this name unless you need to be more precise.
 - **Self-hosted Sourcegraph instance**: Only if clarification between Sourcegraph Cloud, managed instances, and on-premises instances is required.
-- **Managed Sourcegraph instance**: Only if clarification between the Sourcegraph Cloud instance, self-hosted instances, and managed instances is required.
-- **Sourcegraph Server**: The public instance of Sourcegraph for open source code at [sourcegraph.com](https://sourcegraph.com).
+- **Sourcegraph Server**: Only if clarification between the Sourcegraph Cloud instance, self-hosted instances, and managed instances is required.
+- **Sourcegraph.com**: The public instance of Sourcegraph for open source code at [sourcegraph.com](https://sourcegraph.com).
 - **Sourcegraph integrations**: The general term for our integrations. When referencing specific integrations:
     - Sourcegraph(’s) Phabricator integration
     - Sourcegraph(’s) GitHub integration

--- a/handbook/communication/content_guidelines/style_and_mechanics.md
+++ b/handbook/communication/content_guidelines/style_and_mechanics.md
@@ -673,7 +673,7 @@ We describe ourselves with a few different names depending on context, and we sh
 
 - **Sourcegraph**: Main product. Prefer using this name unless you need to be more precise.
 - **Self-hosted Sourcegraph instance or Sourcegraph Server**: The self-hosted Sourcegraph instance maintained by customers. Only if clarification between Sourcegraph Cloud, managed instances, and on-premises instances is required.
-- **Sourcegraph Server**: Only if clarification between the Sourcegraph Cloud instance, self-hosted instances, and managed instances is required.
+- **Managed Sourcegraph instance**: A fully isolated Sourcegraph Server deployment maintained by the Sourcegraph team for a customer. Only use if clarification between the Sourcegraph Cloud instance, self-hosted instances, and managed instances is required.
 - **Sourcegraph Cloud**: The public instance of Sourcegraph for open source code at [sourcegraph.com](https://sourcegraph.com).
 - **Sourcegraph integrations**: The general term for our integrations. When referencing specific integrations:
     - Sourcegraph(’s) Phabricator integration

--- a/handbook/communication/content_guidelines/style_and_mechanics.md
+++ b/handbook/communication/content_guidelines/style_and_mechanics.md
@@ -674,7 +674,7 @@ We describe ourselves with a few different names depending on context, and we sh
 - **Sourcegraph**: Main product. Prefer using this name unless you need to be more precise.
 - **Self-hosted Sourcegraph instance**: Only if clarification between Sourcegraph Cloud, managed instances, and on-premises instances is required.
 - **Sourcegraph Server**: Only if clarification between the Sourcegraph Cloud instance, self-hosted instances, and managed instances is required.
-- **Sourcegraph.com**: The public instance of Sourcegraph for open source code at [sourcegraph.com](https://sourcegraph.com).
+- **Sourcegraph Cloud**: The public instance of Sourcegraph for open source code at [sourcegraph.com](https://sourcegraph.com).
 - **Sourcegraph integrations**: The general term for our integrations. When referencing specific integrations:
     - Sourcegraph(’s) Phabricator integration
     - Sourcegraph(’s) GitHub integration


### PR DESCRIPTION
This pull request fixes 'Managed Sourcegraph instance' being used to describe Sourcegraph server and ' Sourcegraph server' defined as Sourcegraph.com.