### PR TITLE
distribution(goals): add monitoring developer experience

### DIFF
--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -67,6 +67,16 @@ Creating a new release for our deployments is currently a semi-automated process
   - Document project and folder usage guidelines.
   - Set spending limits for dynamic environments.
 
+### Improve Sourcegraph monitoring developer experience
+
+- **Owner**: Gonza, Robert
+- **Status**: In progress. Estimated completion by end of FY21-Q1.
+- **Outcomes**:
+  - Our monitoring stack is compelling for engineers at Sourcegraph to interact with and build on top of.
+  - Our monitoring stack supports use cases specific to the needs of engineers at Sourcegraph and Sourcegraph Cloud.
+- **Milestones**:
+  - [Monitoring pillar redux](https://github.com/orgs/sourcegraph/projects/112)
+
 ## Future goals
 
 These are ideas for future goals that the team might work on. Just because something is on this list, does not mean it will be worked on next.


### PR DESCRIPTION
Adds an overarching goal of "improving monitoring developer experience", the first step of which is the [monitoring pillars redux](https://github.com/orgs/sourcegraph/projects/112) (which I've renamed to emphasize that it is more about reaching feature parity with our redefined [monitoring pillars](https://about.sourcegraph.com/handbook/engineering/observability/monitoring_pillars) than fulfilling all the stretch functionalities that have been pitched to us / are tangential to some of the work here)

I'm not entirely sure if the wording here encompasses everything, and there's only one strict milestone right now as well (maybe more will come up later on after teams have had a chance to try out the work that will come from the first milestone?)