### PR TITLE
Add standard vesting schedule and ISO/NSO info

### DIFF
--- a/handbook/people-ops/compensation.md
+++ b/handbook/people-ops/compensation.md
@@ -26,6 +26,8 @@ We are an early-stage technology company, and you can have a huge impact on our 
 
 Equity grants vest monthly with a 1 year cliff.
 
+Teammates within the US receive incentive stock options (ISOs) and teammates outside of the US receive non-qualified stock option (NSOs).
+
 TODO(@sourcegraph/people-ops): add more detail here about the kind of options and how to understand their value.
 
 ## Benefits and perks

--- a/handbook/people-ops/compensation.md
+++ b/handbook/people-ops/compensation.md
@@ -26,7 +26,7 @@ We are an early-stage technology company, and you can have a huge impact on our 
 
 Equity grants vest monthly with a 1 year cliff.
 
-Teammates within the US receive incentive stock options (ISOs) and teammates outside of the US receive non-qualified stock option (NSOs).
+Teammates classified as employees receive incentive stock options (ISOs) to the maximum degree possible, while teammates classified as contractors receive non-qualified stock option (NSOs).
 
 TODO(@sourcegraph/people-ops): add more detail here about the kind of options and how to understand their value.
 

--- a/handbook/people-ops/compensation.md
+++ b/handbook/people-ops/compensation.md
@@ -24,7 +24,7 @@ We pay salaries in USD.
 
 We are an early-stage technology company, and you can have a huge impact on our success. We want to make sure that you have a financial stake in the success and that your contributions are rewarded.
 
-Equity grants vest monthly with a 1 year cliff.
+By default, all equity grants vest monthly with a 1-year cliff.
 
 Teammates classified as employees receive incentive stock options (ISOs) to the maximum degree possible, while teammates classified as contractors receive non-qualified stock option (NSOs).
 

--- a/handbook/people-ops/compensation.md
+++ b/handbook/people-ops/compensation.md
@@ -24,6 +24,8 @@ We pay salaries in USD.
 
 We are an early-stage technology company, and you can have a huge impact on our success. We want to make sure that you have a financial stake in the success and that your contributions are rewarded.
 
+Equity grants vest monthly with a 1 year cliff.
+
 TODO(@sourcegraph/people-ops): add more detail here about the kind of options and how to understand their value.
 
 ## Benefits and perks


### PR DESCRIPTION
A candidate had questions about this. We should include this info in offer summary, but seems like it should be in our handbook as well.