### PR TITLE
Re-introduce technical experience panel interview

### DIFF
--- a/handbook/engineering/hiring/software-engineer-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-frontend.md
@@ -55,16 +55,45 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 1. You [apply here](https://jobs.lever.co/sourcegraph/b2f9a8b0-cc06-4629-81a0-0f2fa64271c7/apply).
 1. The **Hiring Manager** reviews all the information you provided on your application to determine if you meet our qualifications for this role (if there is another open role we think you would be better qualified for, we will let you know).
 1. A **Recruiter** sets up a 30 minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
-1. We set up a 1 hour interview with the **Hiring Manager**, who will tell you more about the role in the team. They will ask you about your past work and accomplishments and assess your suitability for the role.
+1. We set up a 45 minutes interview with the **Hiring Manager**, who will tell you more about the available role in the team. They will ask you about your past work experience, accomplishments and assess your suitability for the role and alignment with [Sourcegraph's values](../../../company/values.md).
 1. You complete a 3 hour [coding excercise](software-engineer-coding-exercise.md#frontend-coding-exercise) that we designed to test your technical ability and the responsibilities of the role as [listed above](#your-responsibilities).
    - _Note: while we do not disqualify candidates who do not have React and TypeScript experience from taking the excercise, you will be required to use these for the excercise._
 1. An **Engineer** and a **Designer** will review and grade your submission.
 1. We schedule a **1 hour follow-up call** to discuss your submission and ask any questions we might have to clarify our understanding of your technical capability and sutiability for the role.
+   - You will interview with one teammate from each of the following 2 lists
+      - **Engineer**:
+         - [Felix Becker](../../../company/team/index.md#felix-becker)
+         - [Erik Seliger](../../../company/team/index.md#erik-seliger)
+      - **Designer**:
+         - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
+         - [Alicja Suska](../../../company/team/index.md#alicja-suska-she-her)
+         - [Quinn Keast](../../../company/team/index.md#quinn-keast-he-him)
 1. We schedule the following additional interviews, in no particular order, across multiple days:
+   - 1 hour **Technical experience:** We ask you about your past work and accomplishments in depth, how you worked with others, decisions you made, and what you'd do differently today.
+      - You will interview with two teammates from the following list
+        - [Felix Becker](../../../company/team/index.md#felix-becker)
+        - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
+        - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
+        - [Erik Seliger](../../../company/team/index.md#erik-seliger)
    - 1 hour **Team collaboration:** We ask you about how you work and communicate in a team setting, how you handle tricky situations, decisions you made, and what you'd do differently today.
-   - 30 minutes **VP Engineering**
-   - 30 minutes **CTO**
-   - 30 minutes **CEO**
+      - You will interview with one teammate from each of the following 2 lists
+         - **Engineer**:
+            - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
+            - [Loïc Guychard](../../../company/team/index.md#lo%c3%afc-guychard)
+            - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
+         - **Non-engineer**:
+            - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
+            - [Alicja Suska](../../../company/team/index.md#alicja-suska-she-her)
+            - [Quinn Keast](../../../company/team/index.md#quinn-keast-he-him)
+            - [María Craig](../../../company/team/index.md#mar%c3%ada-craig-she-her)
+            - [Eric Brody-Moore](../../../company/team/index.md#eric-brody-moore)
+            - [Jonah Dueck](../../../company/team/index.md#jonah-dueck-he-him)
+            - [Josh Saunders](../../../company/team/index.md#josh-saunders)
+            - [Nick McMillen](#nick-mcmillen-he-him)
+            - [Christine Lovett](../../../company/team/index.md#christine-lovett-she-her)
+   - 30 minutes [VP Engineering](../../../company/team/index.md#nick-snyder-he-him)
+   - 30 minutes [CTO](../../../company/team/index.md#beyang-liu)
+   - 30 minutes [CEO](../../../company/team/index.md#quinn-slack)
 1. We check your references.
 1. We make you a job offer.
 

--- a/handbook/engineering/hiring/software-engineer-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-frontend.md
@@ -89,7 +89,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
             - [Eric Brody-Moore](../../../company/team/index.md#eric-brody-moore)
             - [Jonah Dueck](../../../company/team/index.md#jonah-dueck-he-him)
             - [Josh Saunders](../../../company/team/index.md#josh-saunders)
-            - [Nick McMillen](#nick-mcmillen-he-him)
+            - [Nick McMillen](../../../company/team/index.md#nick-mcmillen-he-him)
             - [Christine Lovett](../../../company/team/index.md#christine-lovett-she-her)
    - 30 minutes [VP Engineering](../../../company/team/index.md#nick-snyder-he-him)
    - 30 minutes [CTO](../../../company/team/index.md#beyang-liu)

--- a/handbook/engineering/hiring/software-engineer-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-frontend.md
@@ -93,7 +93,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
             - [Christine Lovett](../../../company/team/index.md#christine-lovett-she-her)
    - 30 minutes [VP Engineering](../../../company/team/index.md#nick-snyder-he-him)
    - 30 minutes [CTO](../../../company/team/index.md#beyang-liu)
-   - 30 minutes [CEO](../../../company/team/index.md#quinn-slack)
+   - [30 minutes CEO](../../ceo/index.md#interviews-with-me)
 1. We check your references.
 1. We make you a job offer.
 


### PR DESCRIPTION
Also specifies the list of teammates to choose from for scheduling panel interviews. This allows us to remove it from the interviews repo: https://github.com/sourcegraph/interviews/pull/165

## Why

1. After taking part in a recent candidate's technical experience interview I've come to the conclusion that there is much value to be gained from this interview in helping understand whether a candidate is suitable to join Sourcegraph. 
2. While I tried to incorporate the signal checks in the hiring manager interview, it simply does not allow enough time to go into the level of detail required to get confidence in someone's technical experience. 
3. This interview is also very valuable in helping evaluate the seniority of a candidate