### PR TITLE
Several update to the Campaigns Team's page

### DIFF
--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -45,27 +45,39 @@ When I create a campaign to make large-scale code changes I want to _focus on th
 
 ## Process
 
-For each iteration (currently one month long), we follow this process:
-
-* Before the iteration begins, we do pre-planning to make the most of our the planning meeting:
-  * EM creates a [tracking issue](https://about.sourcegraph.com/handbook/engineering/tracking_issues) for the iteration which will hold our goals and plans, in addition to tracking the issues we intend to address. EM also creates the milestone for sprint N+1 and a `planned/CampaignsSprintN` label for things that didn't get finished in the previous sprint.
-  * Everyone on the team looks through [our backlog](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Ateam%2Fcampaigns+milestone%3ABacklog) for any issues they think we should consider for the next sprint, and set the corresponding Campaigns Sprint milestone.
-  * Everyone on the team looks through the current tracking issue for any issues they do not expect to finish by the end of the sprint (EOD Tuesday), and set the next sprint's milestone so they will show up on  the new tracking issue.
-  * Engineers add estimates to issues in the new tracking issue if they are missing.
-  * Everyone on the team reviews the roadmap doc and comments their thoughts. Replace estimate placeholders with your actual estimates (and a best-guess range is fine: "3-5d"). For any items without linked Github issues, please create those issues and link them.
-
-* We then have our planning meeting to determine our common goals for the iteration.
-  * First we verify that any unfinished items in the old sprint will be finished by EOD.
-  * Next, we look at all of the items in the new sprint, to verify that these are our highest priority items that we definitely want to finish this sprint. (These tend to be smaller items, like bug fixes, or work carrying over from the previous sprint.)
-  * Then we look at our roadmap doc to discuss comments people had, verify estimates, and ultimately to sort the items in terms of priority. *The goal is to have a freshly prioritized roadmap.*
-  * Finally, we work down that list, adding the highest priority items to our tracking issue (creating issues if needed), assigning them to engineers until we are at capacity (leaving some slack in the sprint for customer support and other unexpected issues).
-
-* After sprint planning, the team has a retro to discuss how the previous sprint went, and what changes we might want to our working agreements.
+* We prioritize our work in [this project](https://github.com/sourcegraph/sourcegraph/projects/10). It is the responsibility of the PM and EM to keep this updated and correct.
 
 * Each day, Slack reminds us to do our text check-in, which consists of a *short* message (it shouldn't take longer than a minute to write) in the reminder's thread. This should be a recap of what we have finished that day.
 
 * On Tuesdays, each engineer posts a status update in the current tracking issue with any additional info regarding what they accomplished in the previous week, as well as what they intend to accomplish in the coming week. The EM then rolls this up into a status update that is emailed to engineering leadership.
   * Since most of the "what we accomplished" details have already been recorded in the daily Slack check-ins, it is not necessary for engineers to repeat any of those items. The status update could still include any additional info or color that the engineer wishes to record (if any), but would primarily be forward-looking.
+
+* One Big Thing: Each sprint, each engineer gets one big thing to work on — one significant chunk of work scoped to be doable in a single sprint (leaving some slack in the sprint for customer support and other unexpected issues). When it is completed, engineers will pull P0 items from [our planning project](https://github.com/sourcegraph/sourcegraph/projects/10) into the current sprint to work on (or P1 if there are no P0s).
+
+* Invariants and assumptions:
+  * Issues have the current milestone set if-and-only-if they are P0.
+  * An issue assigned to an engineer means that engineer is committing to finishing *in the current sprint*. Issues should be unassigned by default.
+
+### Sprint planning
+
+Our two-week sprints start every other Wednesday. We follow this process:
+
+* Before the iteration begins, we do pre-planning to make the most of our the planning meeting:
+  * EM creates a [tracking issue](https://about.sourcegraph.com/handbook/engineering/tracking_issues) for the iteration which will track our progress through the iteration. EM also creates the milestone for sprint N+1 and a `planned/CampaignsSprintN` label for things that didn't get finished in the previous sprint.
+  * Everyone on the team looks through [our backlog](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Ateam%2Fcampaigns+milestone%3ABacklog) for any issues they think we should consider for the next sprint. To to so, add the issue to the "Needs prioritization" column of [our planning project](https://github.com/sourcegraph/sourcegraph/projects/10).
+  * Everyone on the team looks through the current tracking issue for any issues they do not expect to finish by the end of the sprint (EOD Tuesday), and set the next sprint's milestone so they will show up on the new tracking issue. (Feel free to un-assign these if you wish.) Make sure to set the relevant `planned` label on issues that move to the next sprint, for tracking and accountability.
+  * Engineers add/refine estimates to issues in the new tracking issue and the planning project. All estimates in GitHub are assumed to be upper-bound estimates. (A missing estimate means "between 1 second and 1 trillion years.")
+  * Everyone on the team reviews the roadmap doc and comments their thoughts. Replace estimate placeholders with your actual estimates (and a best-guess range is fine: "3-5d"). For any items without linked Github issues, please create those issues and link them. **(NOTE: When we move to Productboard, this step will become obsolete.)**
+
+* We then have our planning meeting to determine our common goals for the iteration.
+  * First we verify that any unfinished items in the old sprint will be finished by EOD.
+  * Next, we look at all of the items in the new sprint, to verify that these are our highest priority items that we definitely want to finish this sprint. (These tend to be smaller items, like bug fixes, or work carrying over from the previous sprint.) These should all be prioritized as P0s in the planning project. (If they are not P0s, then we remove the milestone and assing the correct priority.)
+  * Then we look at our roadmap doc to discuss comments people had, verify estimates, and ultimately to sort the items in terms of priority. *The goal is to have a freshly prioritized roadmap.* **(NOTE: When we move to Productboard, this step will become obsolete.)**
+  * We work as a team to assign One Big Thing to each engineer.
+  * Finally, we verify that the sum of the estimates of our P0 column is does not exceed 2 days per engineer. In other words:
+    * `issues.filter(p0).map(estimate).sum <= (num_engineers * 2).days`
+
+* After sprint planning, the team has a retro to discuss how the previous sprint went, and what changes we might want to our working agreements.
 
 ## Working Agreements
 

--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -60,9 +60,12 @@ For each iteration (currently one month long), we follow this process:
   * Then we look at our roadmap doc to discuss comments people had, verify estimates, and ultimately to sort the items in terms of priority. *The goal is to have a freshly prioritized roadmap.*
   * Finally, we work down that list, adding the highest priority items to our tracking issue (creating issues if needed), assigning them to engineers until we are at capacity (leaving some slack in the sprint for customer support and other unexpected issues).
 
-* Each day, Slack reminds us to do our stand-up, which consists of a *short* message (it shouldn't take longer than 30s to write) in the reminder's thread. As we are a globally distributed team, this can be a statement of intent for the day, or a recap of what we have finished that day.
-
 * After sprint planning, the team has a retro to discuss how the previous sprint went, and what changes we might want to our working agreements.
+
+* Each day, Slack reminds us to do our text check-in, which consists of a *short* message (it shouldn't take longer than a minute to write) in the reminder's thread. This should be a recap of what we have finished that day.
+
+* On Tuesdays, each engineer posts a status update in the current tracking issue with any additional info regarding what they accomplished in the previous week, as well as what they intend to accomplish in the coming week. The EM then rolls this up into a status update that is emailed to engineering leadership.
+  * Since most of the "what we accomplished" details have already been recorded in the daily Slack check-ins, it is not necessary for engineers to repeat any of those items. The status update could still include any additional info or color that the engineer wishes to record (if any), but would primarily be forward-looking.
 
 ## Working Agreements
 

--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -49,7 +49,7 @@ When I create a campaign to make large-scale code changes I want to _focus on th
 
 * Each day, Slack reminds us to do our text check-in, which consists of a *short* message (it shouldn't take longer than a minute to write) in the reminder's thread. This should be a recap of what we have finished that day.
 
-* On Tuesdays, each engineer posts a status update in the current tracking issue with any additional info regarding what they accomplished in the previous week, as well as what they intend to accomplish in the coming week. The EM then rolls this up into a status update that is emailed to engineering leadership.
+* On Tuesdays, each engineer posts a status update in the current tracking issue with any additional info regarding what they accomplished in the previous week that wasn't captured in their daily status updates, as well as what they intend to accomplish in the coming week. The EM then rolls this up into a status update that is emailed to engineering leadership.
   * Since most of the "what we accomplished" details have already been recorded in the daily Slack check-ins, it is not necessary for engineers to repeat any of those items. The status update could still include any additional info or color that the engineer wishes to record (if any), but would primarily be forward-looking.
 
 * One Big Thing: Each sprint, each engineer gets one big thing to work on — one significant chunk of work scoped to be doable in a single sprint (leaving some slack in the sprint for customer support and other unexpected issues). When it is completed, engineers will pull P0 items from [our planning project](https://github.com/sourcegraph/sourcegraph/projects/10) into the current sprint to work on (or P1 if there are no P0s).

--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -70,8 +70,9 @@ For each iteration (currently one month long), we follow this process:
 ## Working Agreements
 
 * To avoid siloing of knowledge and to keep teammates happy, we make sure that everyone gets a chance to work in different areas of the codebase. In particular, we don't want tasks in area X to always default to person P.
-* If a process isn't serving us, we are quick to shut it down.
 * We do not schedule team meetings on Fridays. (Folks are free to pair on Fridays if they want.)
+* We do not scramble to get last-minute changes in before branch-cut. (If it's a blocking issue, there's [a process for that](https://about.sourcegraph.com/handbook/engineering/releases#issues).)
+* If a process isn't serving us, we are quick to shut it down.
 
 ## Team Communication
 


### PR DESCRIPTION
- Documented our weekly status updates.
- Weekly status update no longer need to include items from daily stand-ups. (Chris will pull those in.)
- New working agreement: no last-minute scrambles to get things in before branch cut.
- Documented our new sprint model: One Big Thing per engineer per sprint.