### PR TITLE
observability: clean up monitoring dev docs

### DIFF
--- a/handbook/engineering/cloud/index.md
+++ b/handbook/engineering/cloud/index.md
@@ -34,7 +34,7 @@ See [goals](goals.md)
 
 ## On-call
 
-- [Alerts owned by this team](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+ObservableOwnerCloud&patternType=literal)
+- [Alerts owned by this team](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+monitoring.ObservableOwnerCloud&patternType=literal)
 - [OpsGenie rotation](https://sourcegraph.app.opsgenie.com/teams/dashboard/01b8adfc-9b85-462b-a841-945791c17e9e/main)
 
 ## Processes

--- a/handbook/engineering/code-intelligence/index.md
+++ b/handbook/engineering/code-intelligence/index.md
@@ -129,7 +129,7 @@ Our team is growing and to help our new teammates have the best onboarding exper
 
 ## On-call
 
-- [Alerts owned by this team](https://sourcegraph.com/search?q=repo:%5Egithub.com/sourcegraph/sourcegraph%24+file:monitoring/.*+%7B:%5B_%5D%2C+Owner:+ObservableOwnerCodeIntel%2C+:%5B_%5D%7D+OR+%28:%5B_%5D%2C+ObservableOwnerCodeIntel%29+count:1000&patternType=structural)
+- [Alerts owned by this team](https://sourcegraph.com/search?q=repo:%5Egithub.com/sourcegraph/sourcegraph%24+file:monitoring/.*+%7B:%5B_%5D%2C+Owner:+monitoring.ObservableOwnerCodeIntel%2C+:%5B_%5D%7D+OR+%28:%5B_%5D%2C+monitoring.ObservableOwnerCodeIntel%29+count:1000&patternType=structural)
 - [OpsGenie rotation](https://sourcegraph.app.opsgenie.com/teams/dashboard/d0c10593-3edd-4d7e-8d1b-2ad29afeaa71)
 
 ## Growth plan

--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -20,24 +20,29 @@ See [Goals](goals.md)
 
 ## Details
 
+- [Product & personas](product.md)
 - [Ownership areas](ownership_areas.md)
 - [Recurring processes](recurring_processes.md)
 - [Internal infrastructure](internal_infrastructure.md)
-- [Product & personas](product.md)
 - [Tools](tools/index.md)
-- Tutorials
-  - [Observability developer guide](../observability/index.md)
-  - [Managed instances](managed/index.md)
-  - [Collecting and inspecting metrics dumps](metrics_dumps.md)
-  - [How to set up a separate website maintained by Sourcegraph](separate_website.md)
-  - [How to simulate k8s admin security restrictions](k8s_admin_custom_policy.md)
-  - [How to test the Gitlab native integration locally](gitlab_native_local.md)
-  - [How to make updates to global settings and configuration on sourcegraph.com](update_sourcegraph_website.md)
-  - [Create GCP commitments](gcp.md#committed-use-discounts)
-  - [Update various service tokens for sourcegraph.com](tokens.md)
-- FAQ
-  - [Why is there not a "stable" or "latest" Docker image tag?](faq.md#why-is-there-not-a-stable-or-latest-docker-image-tag)
-  - [Rollbacks](rollbacks.md)
+  
+### Resources
+
+- [Observability at Sourcegraph](../observability/index.md)
+- [Observability developer guide](https://docs.sourcegraph.com/dev/background-information/observability)
+- [Managed instances](managed/index.md)
+- [Collecting and inspecting metrics dumps](metrics_dumps.md)
+- [How to set up a separate website maintained by Sourcegraph](separate_website.md)
+- [How to simulate k8s admin security restrictions](k8s_admin_custom_policy.md)
+- [How to test the Gitlab native integration locally](gitlab_native_local.md)
+- [How to make updates to global settings and configuration on sourcegraph.com](update_sourcegraph_website.md)
+- [Create GCP commitments](gcp.md#committed-use-discounts)
+- [Update various service tokens for sourcegraph.com](tokens.md)
+- [Rollbacks](rollbacks.md)
+
+### FAQ
+
+- [Why is there not a "stable" or "latest" Docker image tag?](faq.md#why-is-there-not-a-stable-or-latest-docker-image-tag)
 
 ## Members
 
@@ -61,7 +66,7 @@ We have an OpsGenie rotation to respond to [incidents](../incidents/index.md) (e
 
 **Incidents on-call**
 
-- [Alerts owned by this team](https://sourcegraph.com/search?q=repo:%5Egithub.com/sourcegraph/sourcegraph%24+file:monitoring/.*+%7B:%5B_%5D%2C+Owner:+ObservableOwnerDistribution%2C+:%5B_%5D%7D+OR+%28:%5B_%5D%2C+ObservableOwnerDistribution%29+count:1000&patternType=structural)
+- [Alerts owned by this team](https://sourcegraph.com/search?q=repo:%5Egithub.com/sourcegraph/sourcegraph%24+file:monitoring/.*+%7B:%5B_%5D%2C+Owner:+monitoring.ObservableOwnerDistribution%2C+:%5B_%5D%7D+OR+%28:%5B_%5D%2C+monitoring.ObservableOwnerDistribution%29+count:1000&patternType=structural)
 - [OpsGenie rotation](https://sourcegraph.app.opsgenie.com/teams/dashboard/aa59eba4-9b34-45ea-9515-c4dab4cbdac9/main)
 
 ## Support rotation

--- a/handbook/engineering/distribution/ownership_areas.md
+++ b/handbook/engineering/distribution/ownership_areas.md
@@ -13,12 +13,14 @@ To see what Distribution is currently prioritizing, see the [Distribution Goals]
 
 **Related**
 
+- [Internal infrastructure](./internal_infrastructure.md)
 - [Instances](../deployments/instances.md)
 - [Managed instances](./managed/index.md)
 - [Infrastructure repository](https://github.com/sourcegraph/infrastructure): all sorts of Terraform stuff
 - [CI build scripts](https://sourcegraph.com/search?q=repo%3A%5Egithub%5C.com%2Fsourcegraph%2Fsourcegraph%24+file%3Abuild.sh%7C%2Fci%2F+count%3A1000&patternType=literal)
 - [CI pipeline generator](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:%5Eenterprise/dev/ci/ci+count:1000&patternType=literal)
 - [CI tests (QA, E2E, etc.)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/dev/ci/test)
+- [Tools](./tools/index.md)
 
 ## Release pipeline
 
@@ -85,18 +87,27 @@ To see what Distribution is currently prioritizing, see the [Distribution Goals]
 
 ## Observability
 
-### Monitoring
-
-- Monitoring & alerting infrastructure
-- Educating site admins about how to monitor Sourcegraph
-- Working with & ensuring engineering @ Sourcegraph adds needed monitoring
+- Sourcegraph [monitoring](#monitoring) and [debugging](#debugging) for site administrators and Sourcegraph engineers
 
 **Related**
 
-- [Monitoring handbook](../observability/monitoring.md)
-- [monitoring generator (dashboards/alerts)](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/monitoring)
-- [Grafana docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/grafana)
-- [Prometheus docker image](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/docker-images/prometheus)
+- [Observability developer guide](https://docs.sourcegraph.com/dev/background-information/observability)
+- [Observability for site admins](https://docs.sourcegraph.com/admin/observability)
+
+### Monitoring
+
+- Metrics & alerting infrastructure
+- Educating site admins about how to monitor Sourcegraph
+- Working with and ensuring engineering at Sourcegraph adds needed monitoring
+
+**Related**
+
+- [Monitoring at Sourcegraph](../observability/monitoring.md)
+- [Monitoring generator (dashboards/alerts)](https://docs.sourcegraph.com/dev/background-information/observability/monitoring-generator)
+- [Grafana docker image](https://docs.sourcegraph.com/dev/background-information/observability/grafana)
+- [Prometheus docker image](https://docs.sourcegraph.com/dev/background-information/observability/prometheus)
+
+Also see [observability](#observability).
 
 ### Debugging
 
@@ -113,4 +124,5 @@ To see what Distribution is currently prioritizing, see the [Distribution Goals]
 - [Jaeger in Kubernetes](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph%24+jaeger&patternType=literal)
 - [Jaeger in docker-compose/pure-docker](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/deploy-sourcegraph-docker%24+jaeger&patternType=literal)
 - [Jaeger in single-container](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:cmd/server+jaeger&patternType=literal) deployments
-- [admin docs](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+file:doc/admin/observability+jaeger%7Ctracing&patternType=regexp)
+
+Also see [observability](#observability).

--- a/handbook/engineering/distribution/tools/index.md
+++ b/handbook/engineering/distribution/tools/index.md
@@ -4,3 +4,4 @@ Tooling owned by the distribution team.
 
 - [Resources report](./resources_report.md)
 - [GHE Feeder](./ghe_feeder.md)
+- [Monitoring generator](https://docs.sourcegraph.com/dev/background-information/observability/monitoring-generator)

--- a/handbook/engineering/observability/index.md
+++ b/handbook/engineering/observability/index.md
@@ -1,23 +1,14 @@
-# Sourcegraph observability developer guide
+# Observability at Sourcegraph 
 
 > **Note:** Looking for _how to monitor Sourcegraph?_ See the [observability documentation](https://docs.sourcegraph.com/admin/observability).
 
-Observability includes:
+These pages document Sourcegraph-specific use cases, scenarios, and tools for developing observability, as well as some background information and guiding principles.
 
-- Monitoring - how you know _when something is wrong_, which includes:
-  - Dashboards & metrics
-  - Alerting
-  - Health checks
-- Debugging - how you debug _what is wrong_, which includes:
-  - Distributed tracing
-  - Logging
-
-## Developer guides
+For general observability development, please refer to the [observability development documentation](https://docs.sourcegraph.com/dev/background-information/observability) instead, which includes links to useful how-to guides.
 
 - [Monitoring developer guide](monitoring.md)
-  - [The five pillars of monitoring](monitoring_pillars.md)
+  - [Monitoring pillars](monitoring_pillars.md)
   - [Monitoring architecture](./monitoring_architecture.md)
 - [Cloudflare logging](cloudflare.md)
 - Distributed tracing developer guide (coming soon)
 - Logging developer guide (coming soon)
-

--- a/handbook/engineering/observability/monitoring.md
+++ b/handbook/engineering/observability/monitoring.md
@@ -1,61 +1,28 @@
-# Sourcegraph monitoring developer guide
+# Sourcegraph monitoring guide
+
+This page documents Sourcegraph-specific guides on developing monitoring for Sourcegraph.
+For general observability development, refer to the [observability developer documentation](https://docs.sourcegraph.com/dev/background-information/observability).
+
+For more context on monitoring at Sourcegraph, you should refer to:
+
+- [Sourcegraph monitoring pillars](./monitoring_pillars.md)
+- [Sourcegraph monitoring architecture](./monitoring_architecture.md)
 
 > **Note:** Looking for _how to monitor Sourcegraph?_ See the [observability documentation](https://docs.sourcegraph.com/admin/observability).
 
-This document describes how to develop Sourcegraph's monitoring.
-
 ![image](https://user-images.githubusercontent.com/3173176/82078081-65c62780-9695-11ea-954a-84e8e9686970.png)
 
-- [Sourcegraph monitoring developer guide](#sourcegraph-monitoring-developer-guide)
-  - [Overview](#overview)
-    - [Monitoring pillars](#monitoring-pillars)
-    - [Monitoring architecture](#monitoring-architecture)
-  - [Finding Monitoring](#finding-monitoring)
-    - [Alerts](#alerts)
-      - [Sourcegraph instances](#sourcegraph-instances)
-      - [Customer instances](#customer-instances)
-    - [Find available metrics](#find-available-metrics)
-    - [Queries](#queries)
-  - [Adding monitoring](#adding-monitoring)
-    - [Configure panel options](#configure-panel-options)
-    - [Add solution documentation](#add-solution-documentation)
-    - [Tracking a new service](#tracking-a-new-service)
-  - [Grafana](#grafana)
-    - [Connecting Grafana to a remote Prometheus instance](#connecting-grafana-to-a-remote-prometheus-instance)
-    - [Creating Cloud only Grafana dashboards](#creating-cloud-only-grafana-dashboards)
-    - [Upgrading Grafana](#upgrading-grafana)
-  - [Prometheus and Alertmanager](#prometheus-and-alertmanager)
-    - [Upgrading Prometheus or Alertmanager](#upgrading-prometheus-or-alertmanager)
-  - [Additional reading](#additional-reading)
-  - [Next steps](#next-steps)
+## Finding monitoring
 
-## Overview
+This section outlines how to leverage existing Sourcegraph monitoring for scenarios specific to engineers at Sourcegraph.
 
-Monitoring at Sourcegraph encapsulates:
+For general documentation on finding monitoring, refer to [how to find monitoring](https://docs.sourcegraph.com/dev/how-to/find_monitoring).
 
-- How site admins know something _is wrong_ or _may be wrong_.
-- Describing the overall health of Sourcegraph to site admins.
-- Making it clear to site admins _where to go next if Sourcegraph is not healthy._
-
-It does not include:
-
-- Significant detail about what went wrong: the goal is just to direct the site admin to the next step.
-- Solving a problem end-to-end: after looking at monitoring, admins MUST go elsewhere to solve the problem.
-- Identifying individual problem cases (e.g. the details of why a single request failed).
-
-Monitoring is just one piece of Sourcegraph's observability. See the [observability developer guide](index.md) for more information.
-
-### Monitoring pillars
-
-To learn more about our monitoring goals and principles, refer to: [monitoring pillars](monitoring_pillars.md).
-
-### Monitoring architecture
-
-To learn more about our monitoring stack and architecture, refer to: [monitoring architecture](./monitoring_architecture.md).
-
-## Finding Monitoring
+For documentation on how site administrators find monitoring, refer to the [Sourcegraph observability documentation](https://docs.sourcegraph.com/admin/observability).
 
 ### Alerts
+
+This section describes where Sourcegraph employees can find active alerts for Sourcegraph instances.
 
 #### Sourcegraph instances
 
@@ -99,135 +66,15 @@ The bug report page (`/site-admin/report-bug`) for each Sourcegraph instance has
 
 Data for recent alerts and metrics can be requested from customers from their Grafana dashboards (`/-/debug/grafana`).
 
-### Find available metrics
-
-If you need to find where metrics are declared or updated you can use Sourcegraph itself to search if you have a metric name. Sometimes
-the metrics are hard to find because their name declarations are not literal strings but are concatenated instead in code from variables.
-You can try a specialized tool called `promgrep` to find them. Run the tool in the root `sourcegraph/sourcegraph` source directory.
-
-```
-$ go get github.com/sourcegraph/promgrep
-$ promgrep <some_partial_metric_name>
-```
-
-If you run it in an Emacs shell buffer or in GoLand terminal then the results are clickable and get you to the locations in code
-where the metrics are declared.
-
-Running `promgrep` without any arguments lists all declared metrics.
-
-### Queries
-
-The quickest way to test these queries would be to access the Grafana instance exposed to admins at `/-/debug/grafana` via a reverse-proxy. You can then use any of [the Prometheus metric types](https://prometheus.io/docs/concepts/metric_types/) to extract useful information from the prometheus metrics mentioned above. For an example of queries we've found useful, you can see the [frontend monitoring queries here](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@64aa473/-/blob/monitoring/frontend.go#L12-43).
-
 ## Adding monitoring
 
-There are some steps involved, but it's easy and the development process is quite seamless:
+See the [how to add monitoring guide](https://docs.sourcegraph.com/dev/how-to/add_monitoring) for most use cases.
+This section describes guides specific to engineers at Sourcegraph.
 
-1. Get your Prometheus metric merged in our main codebase. You can find [examples](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24+prometheus.MustRegister%28&patternType=literal) throughout our code, and [learn about the Proemtheus metric types](https://prometheus.io/docs/concepts/metric_types/).
-   - If you are doing this for a new service, also refer to [tracking a new service](#tracking-a-new-service).
-2. Use the Grafana Explore page [on Sourcegraph.com](https://sourcegraph.com/-/debug/grafana/explore), [k8s.sgdev.org](https://k8s.sgdev.org/-/debug/grafana/explore), or [your local development server](http://localhost:3080/-/debug/grafana/explore) to start writing your Prometheus query.
-3. Make a guess about what a good/bad value for your query is. It's OK if this isn't perfect, just do your best. Some examples:
-   - `Warning: Alert{GreaterOrEqual: 50}`
-   - `Warning: Alert{LessOrEqual: 50}`
-4. Run a Sourcegraph `dev/start.sh` server and [visit Grafana](http://localhost:3080/-/debug/grafana).
-5. Look for an existing dashboard that your information should go in. Think "when this number shows something bad, which service's logs are likely to be most relevant?"
-6. Open that service's monitoring definition (e.g. `monitoring/frontend.go`, `monitoring/git_server.go`) in your editor.
-7. Declare your [`Observable`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+file:%5Emonitoring/+type+Observable&patternType=literal) by adding it to [an existing `Row` in the file](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@64aa473/-/blob/monitoring/frontend.go#L12-43), or by adding a new [`Row`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+file:%5Emonitoring/+type+Row&patternType=literal) or [`Group`](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+file:%5Emonitoring/+type+Group&patternType=literal) entirely. Here's an example `Observable` to get you started:
-
-```go
-{
-    Name:        "99th_percentile_search_request_duration",
-    Description: "99th percentile successful search request duration over 5m",
-    Query:       `histogram_quantile(0.99, sum by (le)(rate(search_request_duration{status="success}[5m])))`,
-    Warning:     Alert{GreaterOrEqual: 20},
-}
-```
-
-As soon as you save the file, everything is regenerated by `dev/start.sh` (Grafana dashboards, Prometheus alerting rules, documentation, etc.) and you can simply refresh on the dashboard you're editing to see your changes.
-
-### Configure panel options
-
-There are not many panel options (intentionally) to keep things simple. The primary thing you'll use is to change the Grafana display from plain numbers to a unit like seconds:
-
-```diff
-{
-    Name:        "99th_percentile_search_request_duration",
-    Description: "99th percentile successful search request duration over 5m",
-    Query:       `histogram_quantile(0.99, sum by (le)(rate(search_request_duration{status="success}[5m])))`,
-    Warning:     Alert{GreaterOrEqual: 20},
-+   PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
-}
-```
-
-This step is optional, but highly recommended.
-
-### Add solution documentation
-
-It's best if you also add some Markdown documentation with your best guess of what someone _might consider doing_ if they observe the alert firing (again, just your best guess is good enough here):
-
-```diff
-{
-    Name:        "99th_percentile_search_request_duration",
-    Description: "99th percentile successful search request duration over 5m",
-    Query:       `histogram_quantile(0.99, sum by (le)(rate(search_request_duration{status="success}[5m])))`,
-    Warning:     Alert{GreaterOrEqual: 20},
-    PanelOptions: PanelOptions().LegendFormat("duration").Unit(Seconds),
-+	PossibleSolutions: `
-+       - Look at the 'frontend' logs for details on the slow search queries.
-+   `,
-}
-```
-
-> **Tip:** In `PossibleSolutions` Markdown, you can use single quotes anywhere you would normally use backticks for code, and indention will automatically be removed for you.
-
-Once you save the file, `doc/admin/observability/alert_solutions.md` will automatically be regenerated and you can even preview your changes at [http://localhost:5080/admin/observability/alert_solutions](http://localhost:5080/admin/observability/alert_solutions).
-
-This step is optional, but highly recommended.
-
-### Tracking a new service
-
-Metrics should be made available over HTTP for [Prometheus](./monitoring_architecture.md#sourcegraph-prometheus) to scrape. By default, Prometheus expects metrics to be exported on `$SERVICEPORT/metrics` - for example, run your local Sourcegraph dev server and metrics should be available on `http://localhost:$SERVICEPORT/metrics`.
-
-In [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph), Prometheus uses the Kubernetes API to discover endpoints to scrape. Just add the following annotations to your service definition:
-
-```yaml
-metadata:
-  annotations:
-    prometheus.io/port: "$SERVICEPORT" # replace with the port your service runs on
-    sourcegraph.prometheus/scrape: "true"
-```
-
-In [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker), Prometheus relies on targets defined in the [`prometheus_targets`](https://github.com/sourcegraph/deploy-sourcegraph-docker/blob/master/prometheus/prometheus_targets.yml) configuration file - you will need to add your service here.
-
-## Grafana
-
-Sourcegraph uses a custom Grafana image, [`sourcegraph/grafana`](https://github.com/sourcegraph/sourcegraph/tree/master/docker-images/grafana), which contains minor changes from the vanilla Grafana image. Learn more about its role in our overall monitoring architecture [here](./monitoring_architecture.md#sourcegraph-grafana).
-
-### Connecting Grafana to a remote Prometheus instance
-
-You may wish to connect Grafana to a remote Prometheus instance, like Sourcegraph.com, to show more real data than is available on your dev server. You may do so by getting `kubectl` connected to a Sourcegraph cluster and then port-forwarding via:
-
-```sh
-kubectl port-forward svc/prometheus 30090:30090
-```
-
-Then make one of the following changes to the Grafana development datasources:
-
-* `url: http://host.docker.internal:30090` in [`dev/all/prometheus`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@master/-/blob/dev/grafana/all/prometheus.yaml) (non-Linux)
-* `url: http://127.0.0.1:30090` in [`dev/linux/prometheus`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@master/-/blob/dev/grafana/linux/prometheus.yaml) (Linux)
-
-and rerun `./dev/start.sh` or `./enterprise/dev/start.sh`.
-
-If you want to avoid spinning up in the entire Sourcegraph stack and just want to look at Grafana, you can also use `./dev/grafana.sh`. You can skip the datasource change above and just use the following port-forward to take the place of the normal development Prometheus instance and run a standalone Grafana instance:
-
-```sh
-kubectl port-forward svc/prometheus 9090:30090 -n prod
-./dev/grafana.sh
-```
-
-### Creating Cloud only Grafana dashboards
+### Creating Cloud-only Grafana dashboards
 
 While all dashboards required to troubleshoot our product should be shipped to customers, our Cloud deployment might require additional dashboards to the ones we ship to customers, for example:
+
 - When the additional dashboard is not ready yet to graduate to customers
 - When the additional dashboard applies only to our Cloud deployment
 
@@ -237,8 +84,6 @@ Once the dashboard is ready to be shipped to customers, we will need to port it 
 
 You can use a [local Grafana](#connecting-grafana-to-a-remote-prometheus-instance) or the Cloud Grafana to create a new dashboard and once its ready, export it by following these steps:
 
-> **Warning**: Cloud Grafana does not allow saving
-
 - Open "Dashboard Settings" (top right cog).
 - Select "JSON Model".
 - Select the JSON content and save to a `.json` file in `sourcegraph/deploy-sourcegraph-dot-com/dashboards/files`.
@@ -246,31 +91,24 @@ You can use a [local Grafana](#connecting-grafana-to-a-remote-prometheus-instanc
 
 Once deployed, you should be able to see your changes in [sourcegraph.com](https://sourcegraph.com/-/debug/grafana).
 
-### Upgrading Grafana
+> **Warning**: Sourcegraph's Grafana UI does not allow direct changes due to a CSRF issue ([sourcegraph#6075](https://github.com/sourcegraph/sourcegraph/issues/6075)).
 
-To upgrade Grafana, make the appropriate version change to the [`sourcegraph/grafana` Dockerfile](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+FROM+grafana/grafana:.*&patternType=regexp) and make sure to:
+## Grafana
 
-* Run `dev/start.sh` and verify that all generated Grafana dashboards still render correctly
+Sourcegraph uses a custom Grafana image, [`sourcegraph/grafana`](https://github.com/sourcegraph/sourcegraph/tree/master/docker-images/grafana), which contains minor changes from the vanilla Grafana image.
+Learn more about its role in our overall monitoring architecture [here](./monitoring_architecture.md#sourcegraph-grafana), and also see the dev documentation [here](https://docs/sourcegraph.com/dev/background-information/observability/grafana).
 
 ## Prometheus and Alertmanager
 
-Sourcegraph uses a custom Prometheus image, [`sourcegraph/prometheus`](https://github.com/sourcegraph/sourcegraph/tree/master/docker-images/prometheus), that bundles Alertmanager and a wrapper program for managing configuration changes. Learn more about its role in our overall monitoring architecture [here](./monitoring_architecture.md#sourcegraph-prometheus).
-
-### Upgrading Prometheus or Alertmanager
-
-To upgrade Prometheus or Alertmanager, make the appropriate version and sum changes to the [`sourcegraph/prometheus` Dockerfile](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+%28FROM+prom/prometheus:%29.*+OR+%28FROM+prom/alertmanager:%29.*&patternType=regexp) and make sure to:
-
-* Upgrade the [Alertmanager and Prometheus Go client dependencies](https://sourcegraph.com/search?q=repo:%5Egithub%5C.com/sourcegraph/sourcegraph%24%40master+file:go.mod+alertmanager+OR+prometheus/client_golang&patternType=literal), and make sure everything still builds
-* Run `dev/start.sh` and verify that:
-  * all generated Grafana dashboards still render (`localhost:3370`)
-  * all Prometheus rules are evaluated (`localhost:9090/rules`)
-  * Alertmanager starts up correctly (`localhost:9090/alertmanager/#/status`) and can be configured via `observability.alerts`
+Sourcegraph uses a custom Prometheus image, [`sourcegraph/prometheus`](https://github.com/sourcegraph/sourcegraph/tree/master/docker-images/prometheus), that bundles Alertmanager and a wrapper program for managing configuration changes.
+Learn more about its role in our overall monitoring architecture [here](./monitoring_architecture.md#sourcegraph-prometheus), and also see the dev documentation [here](https://docs/sourcegraph.com/dev/background-information/observability/prometheus).
 
 ## Additional reading
 
-- [How Sourcegraph's high-level alerting metrics work](https://docs.sourcegraph.com/admin/observability/metrics_guide)
-- [The difference between Warning and Critical alerts](https://docs.sourcegraph.com/admin/observability/alerting_custom_consumption#the-difference-between-critical-and-warning-alerts)
-- [How some organizations query our high-level alerts for integration with their own systems](https://docs.sourcegraph.com/admin/observability/alerting_custom_consumption)
+- [Observability development guide](https://docs.sourcegraph.com/dev/background-information/observability)
+- [Sourcegraph's high-level alerting metrics](https://docs.sourcegraph.com/admin/observability/metrics#high-level-alerting-metrics)
+- [The difference between Warning and Critical alerts](https://docs.sourcegraph.com/admin/observability/alerting#understanding-alerts)
+- [How some organizations query our high-level alerts for integration with their own systems](https://docs.sourcegraph.com/admin/observability/alerting_custom_consumption) and the related FAQ item, ["Can I consume Sourcegraph's metrics in my own monitoring system?"](https://docs.sourcegraph.com/admin/faq#can-i-consume-sourcegraph-s-metrics-in-my-own-monitoring-system-datadog-new-relic-etc)
 - [Admin documentation for observability](https://docs.sourcegraph.com/admin/observability)
 
 ## Next steps

--- a/handbook/engineering/observability/monitoring_architecture.md
+++ b/handbook/engineering/observability/monitoring_architecture.md
@@ -2,9 +2,9 @@
 
 > **Note:** Looking for _how to monitor Sourcegraph?_ See the [observability documentation](https://docs.sourcegraph.com/admin/observability).
 
-> **Note:** Looking for _how to develop Sourcegraph monitoring?_ See the [monitoring developer guide](./monitoring.md).
-
 This document describes the architecture of Sourcegraph's monitoring stack, and the technical decisions we have made to date and why.
+
+For development-related documentation, see the [Sourcegraph monitoring guide](./monitoring.md) and the [observability developer documentation](https://docs.sourcegraph.com/dev/background-information/observability).
 
 <!-- generated from monitoring_architecture.excalidraw -->
 ![architecture diagram](https://storage.googleapis.com/sourcegraph-assets/monitoring-architecture.png)

--- a/handbook/engineering/observability/monitoring_pillars.md
+++ b/handbook/engineering/observability/monitoring_pillars.md
@@ -1,13 +1,29 @@
-# Sourcegraph: The five pillars of monitoring
+# Sourcegraph monitoring pillars
 
 **Note:** Looking for _how to monitor Sourcegraph?_ See the [observability documentation](https://docs.sourcegraph.com/admin/observability).
 
-This document describes in-depth the background and pillars that drive how we development of our monitoring infrastructure at Sourcegraph. See [the monitoring developer guide](monitoring.md) for information on how to develop monitoring once you're convinced.
+This document describes the background and pillars that drive how we development of our monitoring infrastructure at Sourcegraph.
+Once you are convinced, see the [Sourcegraph monitoring guide](./monitoring.md) and the [observability developer documentation](https://docs.sourcegraph.com/dev/background-information/observability) for development-related documentation.
 
 - [Long-term vision](#long-term-vision)
   - [History](#history)
-- [The Sourcegraph monitoring pillars](#the-sourcegraph-monitoring-pillars)
+- [Monitoring pillars](#monitoring-pillars)
 - [Next steps](#next-steps)
+
+## Overview
+
+Monitoring at Sourcegraph encapsulates:
+
+- How site admins know something _is wrong_ or _may be wrong_.
+- Describing the overall health of Sourcegraph to site admins.
+- Making it clear to site admins _where to go next if Sourcegraph is not healthy_.
+
+It does *not* include:
+
+- Significant detail about what went wrong or the ability to identify individual problem cases: the goal is just to direct the site admin to the next step.
+- Solving a problem end-to-end: after looking at monitoring, admins MUST go elsewhere to solve the problem.
+
+Because of this, monitoring is just one piece of Sourcegraph's observability - see the [observability developer guide](index.md) for more information.
 
 ## Long-term vision
 
@@ -39,7 +55,7 @@ We can and should do better with monitoring than we have in the past, so we intr
 
 You can think of the restrictions we impose as a linter for preventing the issues described above. And, in many cases, our tooling does already prevent these issues by imposing these restrictions!
 
-## The Sourcegraph monitoring pillars
+## Monitoring pillars
 
 Monitoring tooling at Sourcegraph is developed to encourage the following guidelines:
 

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -67,7 +67,7 @@ Iterations start **every other Monday**.
 
 ## On-call
 
-- [Alerts owned by this team](https://sourcegraph.com/search?q=repo%3A%5Egithub.com%2Fsourcegraph%2Fsourcegraph%24+file%3Amonitoring%2F.*+%7B%3A%5B_%5D%2C+Owner%3A+ObservableOwnerSearch%2C+%3A%5B_%5D%7D+OR+%28%3A%5B_%5D%2C+ObservableOwnerSearch%29+count%3A1000&patternType=structural)
+- [Alerts owned by this team](https://sourcegraph.com/search?q=repo%3A%5Egithub.com%2Fsourcegraph%2Fsourcegraph%24+file%3Amonitoring%2F.*+%7B%3A%5B_%5D%2C+Owner%3A+monitoring.ObservableOwnerSearch%2C+%3A%5B_%5D%7D+OR+%28%3A%5B_%5D%2C+monitoring.ObservableOwnerSearch%29+count%3A1000&patternType=structural)
 - [OpsGenie rotation](https://sourcegraph.app.opsgenie.com/teams/dashboard/f482ef3e-f5dc-4bef-b7c4-307e0ad30d6a)
 
 ## Growth plan


### PR DESCRIPTION
This is a companion PR to https://github.com/sourcegraph/sourcegraph/pull/16965. Copied from that PR, the goal of these changes is to define a new split in our monitoring docs:

* docs.sourcegraph.com: general monitoring dev docs in the monorepo (adding monitoring, finding monitoring in the code, etc)
* about.sourcegraph.com: sourcegraph-specific monitoring dev docs (e.g. cloud dashboards, using opsgenie, other usage, etc), monitoring philosophy docs (pillars, architecture)

Closes https://github.com/sourcegraph/sourcegraph/issues/16938