### PR TITLE
Seprate application links per team

### DIFF
--- a/handbook/engineering/hiring/software-engineer-backend.md
+++ b/handbook/engineering/hiring/software-engineer-backend.md
@@ -35,8 +35,10 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 
 ## Interview process
 
-1. You [apply here](https://jobs.lever.co/sourcegraph/895e2b30-9fd7-4b09-bf16-0fa6f9613684/apply).
-1. We schedule a 1 hour **Technical experience** interview with the hiring manager of one of the teams you expressed preference for. You'll talk about your past work and accomplishments in depth, how you worked with others, decisions you made and what you'd do differently today.
+1. You submit an application to the team you are most interested in:
+  - [Apply to Search](https://jobs.lever.co/sourcegraph/a0dba744-ed1d-4172-8a4a-0feb52609322/apply).
+  - [Apply to Code Intelligence](https://jobs.lever.co/sourcegraph/659daf65-bd1d-4392-a118-985a92debee7/apply).
+1. We schedule a 1 hour **Technical experience** interview with the hiring manager of the team. You'll talk about your past work and accomplishments in depth, how you worked with others, decisions you made and what you'd do differently today.
    - Read through [our handbook](https://about.sourcegraph.com/handbook) to learn more about how we operate and to find answers to common questions that you might have. We leave 10 minutes at the end of this interview for you to ask any additional questions.
 1. You complete a 2-hour [coding exercise in Go](software-engineer-coding-exercise.md#go-coding-exercise) that we designed to measure your understanding of concurrency and error handling.
    - Will be reviewed by 2 engineers chosen by the hiring manager of the team you expressed preference for.
@@ -63,7 +65,5 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 1. We make you a job offer.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
-
-**[Click here to apply](https://jobs.lever.co/sourcegraph/895e2b30-9fd7-4b09-bf16-0fa6f9613684)**
 
 Go back to the [careers page](../../../company/careers.md) for all open positions.


### PR DESCRIPTION
Having separate application links makes it clear which hiring manager is responsible for reviewing candidates.