### PR TITLE
distribution: add tech stack overview

### DIFF
--- a/handbook/engineering/distribution/index.md
+++ b/handbook/engineering/distribution/index.md
@@ -25,7 +25,8 @@ See [Goals](goals.md)
 - [Recurring processes](recurring_processes.md)
 - [Internal infrastructure](internal_infrastructure.md)
 - [Tools](tools/index.md)
-  
+- [Tech stack](tech_stack.md)
+
 ### Resources
 
 - [Observability at Sourcegraph](../observability/index.md)

--- a/handbook/engineering/distribution/tech_stack.md
+++ b/handbook/engineering/distribution/tech_stack.md
@@ -39,3 +39,7 @@ Also see [internal infrasturcture](./internal_infrastructure.md) and [tools](./t
 **Best practices:**
 
 - Adhere to the [Sourcegraph Terraform style guide](../languages/terraform.md)
+
+## Kubernetes
+
+**Use cases:** Deploying services

--- a/handbook/engineering/distribution/tech_stack.md
+++ b/handbook/engineering/distribution/tech_stack.md
@@ -1,0 +1,41 @@
+# Distribution tech stack
+
+This document lists the technologies used by the Distribution team, what they are used for, and best practices for each within Distribution.
+
+Also see [internal infrasturcture](./internal_infrastructure.md) and [tools](./tools/index.md) for specific infrastructure and tools.
+
+## Golang
+
+**Use cases:** Services and applicatons
+
+**Best practices:**
+
+- Adhere to the [Sourcegraph Golang style guide](../languages/go.md)
+
+## Typescript
+
+**Use cases:** Complex automation and scripting
+
+**Best practices:**
+
+- We use **[Deno](https://deno.land/)** as our Typescript runtime instead of Node
+  - Typsecript is not a core part of our expertise, so Deno takes care of tooling and formatting
+- Adhere to `deno fmt`, add a CI workflow that validates the result of `deno fmt --check`
+- Avoid using third-party dependencies (try to stick to the [standard library](https://deno.land/std))
+- Scripts should be executable (`chmod +x`) and have some variation of `#!/usr/bin/env deno run` as the sha-bang
+
+## Bash
+
+**Use cases:** Simple automation and scripting
+
+**Best practices:**
+
+- Adhere to the [Sourcegraph Bash style guide](../languages/bash.md)
+
+## Terraform
+
+**Use cases:** Infrastructure provisioning
+
+**Best practices:**
+
+- Adhere to the [Sourcegraph Terraform style guide](../languages/terraform.md)


### PR DESCRIPTION
This stems from today's Distribution sync about use of Typescript in the team. Couldn't find a good place to put this, so went with a full-blown "tech stack" page for the team and some quick links.