### PR TITLE
added to our working agreements

### DIFF
--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -84,6 +84,7 @@ Our two-week sprints start every other Wednesday. We follow this process:
 * To avoid siloing of knowledge and to keep teammates happy, we make sure that everyone gets a chance to work in different areas of the codebase. In particular, we don't want tasks in area X to always default to person P.
 * We do not schedule team meetings on Fridays. (Folks are free to pair on Fridays if they want.)
 * We do not scramble to get last-minute changes in before branch-cut. (If it's a blocking issue, there's [a process for that](https://about.sourcegraph.com/handbook/engineering/releases#issues).)
+* If there is no agenda in our sync doc for our Wednesday and Thursday syncs by 5 minutes before the meeting starts, the meeting is automatically cancelled.
 * If a process isn't serving us, we are quick to shut it down.
 
 ## Team Communication


### PR DESCRIPTION
Added: "If there is no agenda in our sync doc for our Wednesday and Thursday syncs by 5 minutes before the meeting starts, the meeting is automatically cancelled."