### PR TITLE
Explicitly orient code intel goal around users

### DIFF
--- a/handbook/engineering/code-intelligence/goals.md
+++ b/handbook/engineering/code-intelligence/goals.md
@@ -1,8 +1,8 @@
-# Code Intelligence goals and priorities
+# Code Intelligence goals and roadmap
 
 ## Goals
 
-### Expand language support and adoption of precise code intelligence
+### Deliver precise code intelligence to as many users as possible
 
 Progress on adoption and usage is tracked in our [Looker dashboard](https://sourcegraph.looker.com/dashboards/131).
 


### PR DESCRIPTION
As Quinn mentioned in company meeting adoption (as measured by monthly visitors) is going to be a top level goal, in addition to revenue.

Given this company goal, I think it is valuable to explicitly call out in the goal that we are focused on maximizing the number of _users_ of precise code intelligence (as opposed to necessarily maximizing the number of languages, or API calls, for example). Of course if we maximize users, we will increase those other things too.

I don't think this rephrasing changes any immediate plans, but if you think it does that would be a great convo to have.