### PR TITLE
Web Team Main Page Cleanup 

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -2,15 +2,30 @@
 
 # Web team
 
-The web team owns the maintenance and expansion of our web application and code host integrations as vehicles to deliver the value of [extensions](https://docs.sourcegraph.com/extensions) to our users.
+The Web team owns two areas of the product: 
+
+1. **Frontend platform:** the maintenance and expansion of the Sourcegraph web application. We also define and maintain the standards and tooling for how we do web development at Sourcegraph.
+2. **Extensibility:** our code host and third-party integrations (including our browser extension) and our [Sourcegraph extensions](https://docs.sourcegraph.com/extensions). 
 
 This is a large ownership area, so the team creates a focused plan each iteration, by agreeing on an appropriately small set of [iteration goals](../../../company/goals/index.md). Each goal should have more than one teammate working on it.
 
 <div style="clear: both"/>
 
+## Members
+
+- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md)*)
+- [Jean du Plessis](../../../company/team/index.md#jean-du-plessis-he-him) ([Engineering Manager](../roles.md#engineering-manager))
+  - [Felix Becker](../../../company/team/index.md#felix-becker)
+  - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
+  - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
+  - [T.R.](../../../company/team/index.md##full-name-optional-pronouns) _(Starts 2021-01-11)_
+  - [F.J.](../../../company/team/index.md##full-name-optional-pronouns) _(Starts 2021-01-11)_
+
+_* Joel is the acting PM for this team until we are able to hire a dedicated PM for it. Once that happens, he will focus entirely on code insights._  
+
 ## Contact
 
-- #web channel or @web-team in Slack.
+- [#web](https://sourcegraph.slack.com/archives/CMT39K56Z) channel or @web-team in Slack.
 - [team/web](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/web) label and [@sourcegraph/web](https://github.com/orgs/sourcegraph/teams/web) team on GitHub.
 
 ## [Goals](goals.md)
@@ -34,11 +49,15 @@ Here are some of the technologies we use to deliver on our goals:
 
 ### Backlog
 
-The web team keeps a [backlog Github project board](https://github.com/orgs/sourcegraph/projects/98).
+The web team keeps a backlog GitHub project board for each of our focus areas: [frontend platform backlog](https://github.com/orgs/sourcegraph/projects/117) and [extensibility backlog](https://github.com/orgs/sourcegraph/projects/116). 
 
-We use the backlog for tracking bugs, small features, and unplanned work. We don't use the backlog for tracking work that is expressly planned in our [roadmap](../../product/roadmap.md#web).
+We use the backlogs for tracking bugs, small features, and unplanned work. We don't use the backlog for tracking work that is expressly planned in our [roadmap](goals.md#roadmap). 
 
 To add an issue, tag it `team/web` to notify the web team PM and put it in the "to triage" column of the board. Unless you're directly asked, only web team members should move issues out of the "to triage" column on the board. A web team member will confirm the issue is web team-related, and then move it to the appropriate column.
+
+#### Product Feedback
+
+Specific product feedback about well-defined, small features can be found directly in the backlog boards. More general product feedback that applies to larger features, or that needs more research and planning to be actionable, is kept in Productboard, separated by focus area: [extensibility feedback](https://sourcegraph.productboard.com/feature-board/2330167-web-extensibility) and [frontend platform feedback](https://sourcegraph.productboard.com/feature-board/2330177-web-frontend-platform). 
 
 ### Iterations
 
@@ -120,47 +139,53 @@ The meeting notes of web team syncs can be found [in this doc](https://docs.goog
 
 Before web team syncs, teammates and stakeholders should write down under "Discussion items" in the meeting notes document anything that they'd like to bring up for discussion with the whole team.
 
-## Members
-
-- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md)*)
-- [Jean du Plessis](../../../company/team/index.md#jean-du-plessis-he-him) ([Engineering Manager](../roles.md#engineering-manager))
-  - [Felix Becker](../../../company/team/index.md#felix-becker)
-  - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
-  - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
-  
-_* Joel is the acting PM for this team until we are able to hire a dedicated PM for it. Once that happens, he will focus entirely on code insights._  
-
 ## Growth plan
 
-_Updated 2020-11-18_
+_Updated 2020-01-08*_
 
-We are growing the web team by hiring [frontend engineers](../hiring/software-engineer-frontend.md). When this team gets big enough, we expect to spin off two teams (code insights, and extensions and integrations) and convert the web team into an infrastructure team.
+*Updated by Joel on behalf of Jean.
 
-### Web platform
+We are actively hiring [frontend engineers](../hiring/software-engineer-frontend.md) to grow the Web team. 
+When this team team gets big enough, we expect to split into two teams **Frontend platform** and **Extensibility**. We will only make this split once we have identified a dedicated engineering manager and a dedicated product manager.
 
-This team is accountable for ensuring that our product engineering teams have the tools and components they need to quickly build high quality user experiences everywhere we use web technologies (for example: web application, browser extensions). The primary customers of this team are other engineers at Sourcegraph.
+_In January 2021, [Code Insights](../code-insights/index.md) moved out of the Web Team into its own team, lead by Felix Becker (Interim EM) and Joel Kwartler (PM)._
 
-Examples:
+### Frontend platform: frontend web platform and code browsing 
 
-- Creating a standard component library.
-- Documentation to enable product teams and new hires to quickly learn how we do web development at Sourcegraph.
-- Product improvements that affect our entire app and don't have a clear product team owner (for example: new nav bar, complete site redesign)
-- Efficiency and reliability of frontend CI pipeline steps.
+This team is responsible for:
 
-### [Code insights](../code-insights/index.md)
+1. Defining how we do web development at Sourcegraph and ensuring that our product engineering teams have the tools and components they need to quickly build high quality user experiences everywhere we use web technologies (for example: web application, browser extensions).
+1. The core user experience of the Sourcegraph product
 
-This team is responsible for building and delivering **code insights** to engineering leaders, empowering data-driven decisions in engineering organizations.
-Learn all about this team on the [code insights team page](../code-insights/index.md).
+The team's areas of responsibility include:
 
-### Extensions and integrations
+- Frontend platform
+   - Creating and maintaining a standard Sourcegraph UI component library.
+   - Sourcegraph web tech stack, tools, patterns, documentation, education (e.g. webpack, TypeScript, React, RxJS).
+   - Documentation and training material to enable product teams and new hires to quickly learn how we do web development at Sourcegraph.
+   - Define and maintain how we test frontend code.
+   - Ensuring an efficiency and reliabile frontend CI pipeline.
+- Code browsing
+   - Application navigation and information hierarchy
+   - Syntax highlighting and file viewing
+   - Repository landing pages and file directory pages
+   - Basic code host-like features (e.g. viewing diffs, commits, history)
+   - Sourcegraph application homepage
+   - Accessibility support
 
-This team is responsible for how we bring the value of Sourcegraph to other developer tools as well as how we bring the value of other developers tools into Sourcegraph.
+### Extensibility: Sourcegraph extensions and code host integrations
 
-Examples:
+This team is responsible for: 
 
-- Surface code intelligence (and other Sourcegraph data) in code hosts through user installed browser extensions.
-- Add native support for Sourcegraph in code hosts (for example: GitLab) or popular sites where developer look at code examples (e.g. https://reactjs.org, https://pkg.go.dev/) so users don't have to install our browser extensions to get code intelligence.
-- Build an extension API for Sourcegraph that enables developers to bring data from their favorite dev tools (for example: code coverage, exception tracking, tracing, code quality) into their Sourcegraph workflow.
-- Build useful Sourcegraph extensions on top of the Sourcegraph extension API (for example: Codecov, Datadog, Sentry, Lightstep)
+1. Bringing the value of Sourcegraph to other developer tools
+1. Bringing the value of other developer tools into Sourcegraph
 
-This team will not be created until we have identified a dedicated engineering manager and a dedicated product manager.
+The team's areas of responsibility include:
+
+- Sourcegraph extensions
+   - Providing a Sourcegraph extension API that enables developers to bring data from their favorite developer tools into their Sourcegraph workflow.
+   - Building useful Sourcegraph extensions on top of the Sourcegraph extension API (for example: Codecov, Datadog, Sentry, Lightstep)
+   - Documentation and tutorials that enable third party developers to create extensions that are actively used.
+- Integrations   
+   - Surface code intelligence (and other Sourcegraph data) in code hosts through user installed browser extensions. 
+   - Add native support for Sourcegraph in code hosts (for example: GitLab) or popular sites where developer look at code examples (e.g. https://reactjs.org, https://pkg.go.dev/) so users don't have to install our browser extensions to get code intelligence.


### PR DESCRIPTION
From #2166 on behalf of Jean + new changes to reflect productboard and code insights links. 

Changes: 
- Add new hires' initials to member section 
- Move member section higher on the page
- Make Jean's updates to the growth plan description areas
- Add links to the separate GitHub backlog boards and Productboard boards
- Formalize use of "extensibility" and "frontend platform" which Jean and I agreed on as the (at least initial) focus area names 