### PR TITLE
CE page updates

### DIFF
--- a/company/careers.md
+++ b/company/careers.md
@@ -24,12 +24,13 @@ We're hiring! Check out our open positions:
 
 - [Account Executive](../handbook/sales/roles/account_executive.md)
 
-### Customer engineering
+### Customer Engineering
 
 - [Customer Engineer](../handbook/ce/roles/customer_engineer.md)
 - [Training Engineer](../handbook/ce/roles/training_engineer.md)
-- [Head of Customer Success (Customer Engineering), East](https://jobs.lever.co/sourcegraph/82f595d8-9a88-40f6-b84a-b243c58754f0)
-- [Head of Customer Success (Customer Engineering), West](https://jobs.lever.co/sourcegraph/cb233f84-da0e-4c1d-8a75-c86e265609b1)
+- [Director of Customer Engineering, East](https://jobs.lever.co/sourcegraph/82f595d8-9a88-40f6-b84a-b243c58754f0)
+- [Director of Customer Engineering, West](https://jobs.lever.co/sourcegraph/cb233f84-da0e-4c1d-8a75-c86e265609b1)
+- VP Customer Engineering (to be posted very soon)
 
 ### Marketing
 

--- a/handbook/ce/index.md
+++ b/handbook/ce/index.md
@@ -1,4 +1,5 @@
 # Customer Engineering
+
 The Customer Engineering team partners with the [Sales team] (../sales/index.md) from a technical and product expertise perspective to ensure that all of Sourcegraph's prospects, customers, and users get the most possible value from it. This includes showing product demos, learning and understanding prospects' internal development environment and processes, helping companies integrate Sourcegraph into their engineering stack and internal processes to maximize value to their engineering teams, helping prospects run trials to recognize Sourcegraph value firsthand, building relationships with our accounts' champions and users, communicating the value of Sourcegraph, growing engagement and owning product training and technical support, and giving as many Sourcegraph "Aha!" moments as possible.
 
 * [Onboarding](onboarding.md)
@@ -21,22 +22,25 @@ The Customer Engineering team partners with the [Sales team] (../sales/index.md)
 	* [Campaign demo and training materials](https://docs.google.com/document/d/1xQxhdGaudydOn5nBGIG91F6Z4VR4NwBfuKFvgbmCjJo/edit?usp=drive_web&ouid=107037782400977645523)
 
 ## Goals
+
 TODO
 
 ## Members
 
-* Customer Engineers
-	* [Christine Lovett](../../company/team/index.md#christine-lovett-she-her)
-	* [Jonah Dueck](../../company/team/index.md#jonah-dueck-he-him)
-	* [Josh Saunders](../../company/team/index.md#josh-saunders)
-	* [Nick McMillen](../../company/team/index.md#nick-mcmillen-he-him)
-	* [Mike McLaughlin](../../company/team/index.md#mike-mclaughlin-he-him)
-	* [Emily Chapman](../../company/team/index.md#emily-chapman-she-her)
-
-* Customer Support
-	* [Virginia Ulrich](../../company/team/index.md#virginia-ulrich-she-her) Head of Customer Support
-	* We will be hiring support engineers soon. Our Customer Engineers will continue in their support rotation for now.
-* Training
+- Customer Engineers
+  - [Christine Lovett](../../company/team/index.md#christine-lovett-she-her)
+  - [Jonah Dueck](../../company/team/index.md#jonah-dueck-he-him)
+  - [Josh Saunders](../../company/team/index.md#josh-saunders)
+  - [Nick McMillen](../../company/team/index.md#nick-mcmillen-he-him)
+  - [Mike McLaughlin](../../company/team/index.md#mike-mclaughlin-he-him)
+  - [Emily Chapman](../../company/team/index.md#emily-chapman-she-her)
+- Customer Support
+  - [Virginia Ulrich](../../company/team/index.md#virginia-ulrich-she-her) (Head of Customer Support)
+  - We will be hiring support engineers soon. Our Customer Engineers will continue in their support rotation for now.
+- Training
+- [Quinn Slack](../../company/team/index.md#quinn-slack) (CEO) is leading Customer Engineering for now.
+  - We are hiring for VP Customer Engineering and will have the role posted very soon.
 
 ## Roles
+
 We're hiring! Join us. See [roles](./roles/index.md) page.

--- a/handbook/ce/roles/index.md
+++ b/handbook/ce/roles/index.md
@@ -1,8 +1,8 @@
-# Customer engineering roles
+# Customer Engineering roles
 
 - [Customer Engineer](./customer_engineer.md)
 - [Training Engineer](./training_engineer.md)
-- [Head of Customer Success (Customer Engineering), East](https://jobs.lever.co/sourcegraph/82f595d8-9a88-40f6-b84a-b243c58754f0)
-- [Head of Customer Success (Customer Engineering), West](https://jobs.lever.co/sourcegraph/cb233f84-da0e-4c1d-8a75-c86e265609b1)
+- [Director of Customer Engineering, East](https://jobs.lever.co/sourcegraph/82f595d8-9a88-40f6-b84a-b243c58754f0)
+- [Director of Customer Engineering, West](https://jobs.lever.co/sourcegraph/cb233f84-da0e-4c1d-8a75-c86e265609b1)
 
 See our [careers page](../../../company/careers.md) for open positions and more info.


### PR DESCRIPTION
- Update role names from `Head of Customer Success (Customer Engineering), East/West` to `Director of Customer Engineering, East/West`
- @sqs is interim leader of CE