### PR TITLE
Anchor link updates

### DIFF
--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -3,7 +3,7 @@ layout: markdown
 title: Sourcegraph Privacy Policy
 ---
 
-Last modified: February 21, 2020
+Last modified: January 15, 2021
 
 Sourcegraph, Inc. (**"Sourcegraph," "we," "our,"** or **"us"**) understands that privacy is important to our online visitors to our Sourcegraph.com website and users of our online services (collectively, for the purposes of this Privacy Policy, our **"Website"**), as well as users of our private or self-hosted Sourcegraph instances (collectively with our Website, our **"Service"** or **"Services"**). This Privacy Policy explains how we collect, use, share and protect your personal information that we collect through our Service. By using our Service, you agree to the terms of this Privacy Policy and our <a href="/terms">Terms of Service</a>.
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -82,7 +82,7 @@ We use third-party applications such as Google Cloud Platform, Honeycomb, and mo
 
 We use third-party applications such as Stripe and Xero to manage corporate billing and invoicing. These companies provide further information about their own privacy practices on their websites.
 
-We and our third-party partners may also use cookies and tracking technologies for the purpose of tracking the effectiveness of our own ads placed on Google, Twitter, etc. on Sourcegraph.com (never on private or self-hosted instances). For more information about tracking technologies, please see [“Third-party tracking and online advertising”](#Third-Party-Tracking-and-Online-Advertising) below.
+We and our third-party partners may also use cookies and tracking technologies for the purpose of tracking the effectiveness of our own ads placed on Google, Twitter, etc. on Sourcegraph.com (never on private or self-hosted instances). For more information about tracking technologies, please see [“Third-party tracking and online advertising”](#Third-party-tracking-and-online-advertising) below.
 
 <span style="color:#b200f8;">
 
@@ -120,7 +120,7 @@ Any information or content that you voluntarily disclose for posting to the Webs
 
 <span style="color:#b200f8;">
 
-## Third-Party Tracking and Online Advertising
+## Third-party tracking and online advertising
 
 </span>
 

--- a/docs/privacy.md
+++ b/docs/privacy.md
@@ -82,7 +82,7 @@ We use third-party applications such as Google Cloud Platform, Honeycomb, and mo
 
 We use third-party applications such as Stripe and Xero to manage corporate billing and invoicing. These companies provide further information about their own privacy practices on their websites.
 
-We and our third-party partners may also use cookies and tracking technologies for the purpose of tracking the effectiveness of our own ads placed on Google, Twitter, etc. on Sourcegraph.com (never on private or self-hosted instances). For more information about tracking technologies, please see [“Third party tracking and online advertising”](#third-party-tracking-and-online-advertising) below.
+We and our third-party partners may also use cookies and tracking technologies for the purpose of tracking the effectiveness of our own ads placed on Google, Twitter, etc. on Sourcegraph.com (never on private or self-hosted instances). For more information about tracking technologies, please see [“Third party tracking and online advertising”](#Third-Party-Tracking-and-Online-Advertising) below.
 
 <span style="color:#b200f8;">
 
@@ -118,7 +118,11 @@ We may also aggregate or otherwise strip data of all personally identifying char
 
 Any information or content that you voluntarily disclose for posting to the Website becomes available to the public, as controlled by any applicable privacy settings. If you remove information or content that you posted to the Website, copies may remain viewable in cached and archived pages of the Website, or if other Users have copied or saved that information.
 
-### Third Party Tracking and Online Advertising
+<span style="color:#b200f8;">
+
+## Third Party Tracking and Online Advertising
+
+</span>
 
 We participate in interest-based advertising and use third party advertising companies to serve you targeted advertisements based on your online browsing history and your interests. We permit third party online advertising networks, social media companies, and other third party services, to collect information about your use of our Service over time so that they may play or display ads for our products on other websites, apps, or services you may use and on other devices you may use. Typically, though not always, the information used for interest-based advertising is collected through cookies or similar tracking technologies. We and our third party partners use this information to make the advertisements you see online more relevant to your interests, as well as to provide advertising-related services such as reporting, attribution, analytics and market research.
 

--- a/handbook/sales/sdrteam.md
+++ b/handbook/sales/sdrteam.md
@@ -22,7 +22,7 @@ The SDR Team (fill in the blanks)
 
 ## Inbound Workflow
 
-See [How we use Salesforce](../../../sales/salesforce/index.md#how-we-use-salesforce) to learn more about SDR Inbound Workflow.
+See [How we use Salesforce](../../sales/salesforce/index.md#how-we-use-salesforce) to learn more about SDR Inbound Workflow.
 
 ## Outbound Workflow (TBD)
 

--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -65,13 +65,13 @@ module.exports = {
           {
             resolve: `gatsby-remark-autolink-headers`,
             options: {
-              offsetY: `100`,
-              icon: `<svg aria-hidden="true" height="20" version="1.1" viewBox="0 0 16 16" width="20"><path fill-rule="evenodd" d="M4 9h1v1H4c-1.5 0-3-1.69-3-3.5S2.55 3 4 3h4c1.45 0 3 1.69 3 3.5 0 1.41-.91 2.72-2 3.25V8.59c.58-.45 1-1.27 1-2.09C10 5.22 8.98 4 8 4H4c-.98 0-2 1.22-2 2.5S3 9 4 9zm9-3h-1v1h1c1 0 2 1.22 2 2.5S13.98 12 13 12H9c-.98 0-2-1.22-2-2.5 0-.83.42-1.64 1-2.09V6.25c-1.09.53-2 1.84-2 3.25C6 11.31 7.55 13 9 13h4c1.45 0 3-1.69 3-3.5S14.5 6 13 6z"></path></svg>`,
+              offsetY: `50`,
+              icon: `<svg aria-hidden="true" xmlns="http://www.w3.org/2000/svg" viewBox="0 18 95 120" height="18" width="18"><path d="M53.69,78.7H37.94l-5.85,25H21.74l5.85-25H15.89L18,69.1H29.84l4.65-19.65H23.39l2.1-9.6H36.74l5.7-23.7H52.79l-5.7,23.7H62.84l5.7-23.7H78.89l-5.7,23.7H84.74l-2.4,9.6H70.94L66.29,69.1H77.24l-2.4,9.6H64l-5.85,25H47.84Zm-13.5-9.6H55.94l4.65-19.65H44.84Z"/></svg>`,
               maintainCase: true,
               removeAccents: true,
- 	      elements: [`h1`, `h2`],
+              elements: [`h1`, `h2`],
             },
-         },
+          },
           `gatsby-remark-prismjs`,
           `gatsby-remark-copy-linked-files`,
           `gatsby-remark-unwrap-images`,


### PR DESCRIPTION
- fix anchor link on heading for Third-party link:
about.sourcegraph.com/privacy/#Third-Party-Tracking-and-Online-Advertising
https://deploy-preview-2310--sourcegraph.netlify.app/privacy/#Third-Party-Tracking-and-Online-Advertising
- use hashtag icon instead of the link icon, see images below.  
<img width="341" alt="Screen Shot 2021-01-11 at 9 22 05 PM" src="https://user-images.githubusercontent.com/2164916/104272970-1cf88580-5453-11eb-87eb-8452ececcae7.png">
<img width="373" alt="Screen Shot 2021-01-11 at 9 23 14 PM" src="https://user-images.githubusercontent.com/2164916/104273062-3e597180-5453-11eb-88f3-926ef7c10a7c.png">

