### PR TITLE
added page for supporting campaigns

### DIFF
--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -104,26 +104,14 @@ The Campaigns team is the current owner of [src-cli](https://github.com/sourcegr
   - [Thorsten Ball](../../../company/team/index.md#thorsten-ball-he-him)
   - [Adam Harvey](../../../company/team/index.md#adam-harvey-he-him)
   - [Erik Seliger](../../../company/team/index.md#erik-seliger)
-  
-## Onboarding
-  
-We're excited to have you on the team! Your perspective as both a new user of the campaigns product and a new teammate is very valuable to us. Please keep notes on any issues you encounter as you are learning the product. We'll use those notes to improve the product and process.
 
-We've compiled the following list of resources to help you learn about the product, how it's sold and how to get started using it:
-
-- Read the product marketing document to understand the high level talking points and landscape surrounding campaigns
-- Watch a [recorded training session](https://chorus.ai/meeting/3C6D73BB499F41E9815AB540CFA54CBD?tab=summary)
-  - A less technical demo can be found [here](https://chorus.ai/meeting/D15E98AF1C434E41B47B7CA1B43BB30B?tab=summary) (demo starts at 8:17)
-- Watch the [demoing campaigns presentation](https://drive.google.com/drive/u/0/folders/18Sa_NpsVRvVV8MIvuXyoDEinpEf8fbGn) to learn how we think about the unique selling points of the product and how to present them
-- Read the [campaigns product documentation](https://docs.sourcegraph.com/campaigns)
-  - Pay special attention to [how src excecutes a campaign spec](https://docs.sourcegraph.com/campaigns/explanations/how_src_executes_a_campaign_spec)
-  - Read the [quickstart](https://docs.sourcegraph.com/campaigns/quickstart) and create the hello world campaign
-- Review the [demoing campaigns document](https://docs.google.com/document/d/1xQxhdGaudydOn5nBGIG91F6Z4VR4NwBfuKFvgbmCjJo/edit) and consume the resources found there, then create a few campaigns in the demo
 
 ## Related links
 
 - [User-facing documentation](https://docs.sourcegraph.com/campaigns)
 - [Developer documentation](https://docs.sourcegraph.com/dev/background-information/campaigns)
+- [Onboarding](onboarding.md)
+- [Supporting Campaigns](supporting-campaigns.md)
 
 ## Growth plan
 

--- a/handbook/engineering/campaigns/onboarding.md
+++ b/handbook/engineering/campaigns/onboarding.md
@@ -1,0 +1,14 @@
+# Onboarding
+
+We're excited to have you on the team! Your perspective as both a new user of the campaigns product and a new teammate is very valuable to us. Please keep notes on any issues you encounter as you are learning the product. We'll use those notes to improve the product and process.
+
+We've compiled the following list of resources to help you learn about the product, how it's sold and how to get started using it:
+
+- Read the product marketing document to understand the high level talking points and landscape surrounding campaigns
+- Watch a [recorded training session](https://chorus.ai/meeting/3C6D73BB499F41E9815AB540CFA54CBD?tab=summary)
+  - A less technical demo can be found [here](https://chorus.ai/meeting/D15E98AF1C434E41B47B7CA1B43BB30B?tab=summary) (demo starts at 8:17)
+- Watch the [demoing campaigns presentation](https://drive.google.com/drive/u/0/folders/18Sa_NpsVRvVV8MIvuXyoDEinpEf8fbGn) to learn how we think about the unique selling points of the product and how to present them
+- Read the [campaigns product documentation](https://docs.sourcegraph.com/campaigns)
+  - Pay special attention to [how src excecutes a campaign spec](https://docs.sourcegraph.com/campaigns/explanations/how_src_executes_a_campaign_spec)
+  - Read the [quickstart](https://docs.sourcegraph.com/campaigns/quickstart) and create the hello world campaign
+- Review the [demoing campaigns document](https://docs.google.com/document/d/1xQxhdGaudydOn5nBGIG91F6Z4VR4NwBfuKFvgbmCjJo/edit) and consume the resources found there, then create a few campaigns in the demo

--- a/handbook/engineering/campaigns/supporting-campaigns.md
+++ b/handbook/engineering/campaigns/supporting-campaigns.md
@@ -1,0 +1,29 @@
+# Supporting Campaigns
+
+## Campaigns documentation
+
+The best place to start is to read through all of the [Campaigns docs](https://docs.sourcegraph.com/campaigns). Of particular importance:
+
+- [Introduction to campaigns](https://docs.sourcegraph.com/campaigns/explanations/introduction_to_campaigns): understand what the product is all about
+- [Quickstart](https://docs.sourcegraph.com/campaigns/quickstart): create your first campaign!
+- [How `src` executes a campaign spec](https://docs.sourcegraph.com/campaigns/explanations/how_src_executes_a_campaign_spec): this is what happens under the hood when the user previews or applies a campaign
+- [Troubleshooting](https://docs.sourcegraph.com/campaigns/references/troubleshooting): this (along with the above doc on how `src` works) holds common first steps for troubleshooting; _always feel free to add to this page!_
+- [Requirements](https://docs.sourcegraph.com/campaigns/references/requirements): make sure customers understand and meet our requirements
+
+## Support quests
+
+These are some ideas for onboarding quests, to be run in our dogfood or testing environments. (For inspiration, be sure to check out our [current demo campaigns](https://k8s.sgdev.org/campaigns) as well.)
+- Create a campaign over 5+ repos for each of the following:
+  - Run [Comby](https://comby.dev/) to replace `fmt.Sprintf("%d", :[v])` with `strconv.Itoa(:[v])` in Go files (`*.go`)
+  - Run `go fmt ./...` in the repository
+  - Replace problematic language (such as changing blacklist/whitelist to blocklist/allowlist)
+- Create a “monorepo” campaign: a campaign that creates at least 5 changesets in a single repository
+- Create a “manual” campaign: a campaign that imports at least 5 changesets, and does not create any
+
+## Support pairing
+
+In order to stay in sync, support engineers and campaigns engineers should have periodic pairing sessions. The goals of these sessions:
+
+- Keep support informed about upcoming changes/features.
+- Keep Campaigns team informed about common problems and support themes.
+- Give support engineers an opportunity to dig deeper into the tech, to further empower them. This can reduce the need for escalations, and deliver solutions to customers faster.


### PR DESCRIPTION
This adds a page with support enablement docs. (It also moves the campaigns onboarding to another page.)