### PR TITLE
Update interview details for distribution

### DIFF
--- a/handbook/engineering/hiring/software-engineer-coding-exercise.md
+++ b/handbook/engineering/hiring/software-engineer-coding-exercise.md
@@ -74,7 +74,7 @@ We designed this exercise to measure your skills at integrating build and deploy
 - You should have a recent version of Go (≥ 1.13) installed on your computer.
 - You should have a simple Kubernetes local cluster ([kind](https://kind.sigs.k8s.io/), [k3d](https://github.com/rancher/k3d), [minikube](https://minikube.sigs.k8s.io/docs/start/))
 - You can look up documentation on the internet while you are coding.
-- After two hours, you will email us your solution as a zip file and we will get back to you on next steps within 2 business days.
+- After three hours, you will email us your solution as a zip file and we will get back to you on next steps within 2 business days.
 
 If we decide to move forward, we will schedule a 30-minute followup call to discuss your code.
 

--- a/handbook/engineering/hiring/software-engineer-coding-exercise.md
+++ b/handbook/engineering/hiring/software-engineer-coding-exercise.md
@@ -65,12 +65,12 @@ We designed [this synchronous exercise](https://github.com/sourcegraph/interview
 
 If we device to move forward, we will schedule interviews with team members.
 
-## Kubernetes exercise
+## Distribution exercise
 
-We designed this exercise to measure your skills at integrating build and deployment workflows into a development lifecycle.
+We designed this exercise to measure your skills at integrating build and deployment workflows into a development lifecycle, as well as your ability to code a simple HTTP service.
 
-- You will choose a two hour timeframe to independently work on the exercise. You can choose any day and time that works for you; there are no scheduling constraints.
-- At your chosen date and time, we will send you detailed instructions. You will be building a simple pipeline to build and deploy a set of Go services.
+- You will choose a three hour timeframe to independently work on the exercise. You can choose any day and time that works for you; there are no scheduling constraints.
+- At your chosen date and time, we will send you detailed instructions. You will be building a simple pipeline to build and deploy a set of Go services and create a simple HTTP client in the language of your choice. We prefer to use Go or Typescript, but you can choose the language you feel more comfortable with.
 - You should have a recent version of Go (≥ 1.13) installed on your computer.
 - You should have a simple Kubernetes local cluster ([kind](https://kind.sigs.k8s.io/), [k3d](https://github.com/rancher/k3d), [minikube](https://minikube.sigs.k8s.io/docs/start/))
 - You can look up documentation on the internet while you are coding.

--- a/handbook/engineering/hiring/software-engineer-coding-exercise.md
+++ b/handbook/engineering/hiring/software-engineer-coding-exercise.md
@@ -65,6 +65,19 @@ We designed [this synchronous exercise](https://github.com/sourcegraph/interview
 
 If we device to move forward, we will schedule interviews with team members.
 
+## Kubernetes exercise
+
+We designed this exercise to measure your skills at integrating build and deployment workflows into a development lifecycle.
+
+- You will choose a two hour timeframe to independently work on the exercise. You can choose any day and time that works for you; there are no scheduling constraints.
+- At your chosen date and time, we will send you detailed instructions. You will be building a simple pipeline to build and deploy a set of Go services.
+- You should have a recent version of Go (≥ 1.13) installed on your computer.
+- You should have a simple Kubernetes local cluster ([kind](https://kind.sigs.k8s.io/), [k3d](https://github.com/rancher/k3d), [minikube](https://minikube.sigs.k8s.io/docs/start/))
+- You can look up documentation on the internet while you are coding.
+- After two hours, you will email us your solution as a zip file and we will get back to you on next steps within 2 business days.
+
+If we decide to move forward, we will schedule a 30-minute followup call to discuss your code.
+
 ## FAQ
 
 ### Why do you do a coding exercise?

--- a/handbook/engineering/hiring/software-engineer-distribution.md
+++ b/handbook/engineering/hiring/software-engineer-distribution.md
@@ -38,7 +38,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
    - **CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
 1. We check your references.
-4. We make you a job offer.
+1. We make you a job offer.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-distribution.md
+++ b/handbook/engineering/hiring/software-engineer-distribution.md
@@ -30,15 +30,15 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
 1. We set up a 30-minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
 1. We evaluate relevant technical skills that you have via an asynchronous coding exercise.
    - We will give you an overview of the exercise in advance.
-   - We will send you the details at a time of your choosing and you will have up to 2 hours to work on the exercise.
+   - We will send you the details at a time of your choosing and you will have up to 2 hours to work on each of the two exercises.
    - You will be able to use your own development environment and lookup documentation on the internet.
-1. We schedule 4 hours of remote interviews over video chat across multiple days.
+2. We schedule 4 hours of remote interviews over video chat across multiple days.
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
    - **Technical experience:** We ask you about your past work and accomplishments.
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
    - **CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
-1. We check your references.
-1. We make you a job offer.
+3. We check your references.
+4. We make you a job offer.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
 

--- a/handbook/engineering/hiring/software-engineer-distribution.md
+++ b/handbook/engineering/hiring/software-engineer-distribution.md
@@ -37,7 +37,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - **Technical experience:** We ask you about your past work and accomplishments.
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
    - **CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
-3. We check your references.
+1. We check your references.
 4. We make you a job offer.
 
 We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.

--- a/handbook/engineering/hiring/software-engineer-distribution.md
+++ b/handbook/engineering/hiring/software-engineer-distribution.md
@@ -32,7 +32,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - We will give you an overview of the exercise in advance.
    - We will send you the details at a time of your choosing and you will have up to 2 hours to work on each of the two exercises.
    - You will be able to use your own development environment and lookup documentation on the internet.
-2. We schedule 4 hours of remote interviews over video chat across multiple days.
+1. We schedule 4 hours of remote interviews over video chat across multiple days.
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
    - **Technical experience:** We ask you about your past work and accomplishments.
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.


### PR DESCRIPTION
- Add Kubernetes exercise description.
- Use local Kubernetes clusters.

I believe using a local cluster will be an easier way for candidates to provide code that we can replicate locally. The exercise will mention that this should be treated as a remote environment.