### PR TITLE
CEO no longer interviews every candidate

### DIFF
--- a/handbook/engineering/hiring/engineering-manager-cloud.md
+++ b/handbook/engineering/hiring/engineering-manager-cloud.md
@@ -54,7 +54,6 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - 1h [Technical experience](https://github.com/sourcegraph/interviews/blob/master/engineering/technical-experience.md) - We ask you about your past work and accomplishments.
    - 1h [Team collaboration](https://github.com/sourcegraph/interviews/blob/master/engineering/team-collaboration.md). We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
    - 30m [Beyang Liu](../../../company/team/index.md#beyang-liu) (CTO)
-   - 30m [Quinn Slack](../../../company/team/index.md#quinn-slack) (CEO)
 1. Meet and greet with any people who you would be managing but didn't get a chance to meet in the interview process. These are informal conversations for you to get to know the team and them to meet you. You don't need to use the entire scheduled time if you don't need it.
 
 If we want to move forward after these sets of interviews, we will setup 30-minute calls to meet any [members of the Cloud team](../cloud/index.md#members) that weren't already an interviewer. These calls are informal and don't have a script.

--- a/handbook/engineering/hiring/software-engineer-campaigns-full-stack-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-campaigns-full-stack-frontend.md
@@ -58,7 +58,6 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - 1 hour **Code collaboration:** You [pair with an engineer](software-engineer-pairing-exercise.md) on a small task. Another engineer will observe, to reduce bias.
    - 30 minutes **VP Engineering**
    - 30 minutes **CTO**
-   - 30 minutes **CEO**
 1. We check your references.
 1. We make you a job offer.
 

--- a/handbook/engineering/hiring/software-engineer-code-insights-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-code-insights-frontend.md
@@ -98,7 +98,6 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
           -  Can backfill with any engineering manager.
    - 30 minutes [VP Engineering](../../../company/team/index.md#nick-snyder-he-him)
    - 30 minutes [CTO](../../../company/team/index.md#beyang-liu)
-   - [30 minutes CEO](../../ceo/index.md#interviews-with-me)
 1. We check your references.
 1. We make you a job offer.
 

--- a/handbook/engineering/hiring/software-engineer-code-intelligence.md
+++ b/handbook/engineering/hiring/software-engineer-code-intelligence.md
@@ -38,7 +38,7 @@ Learn more about what it is like to work at Sourcegraph by reading [our handbook
    - **Architecture:** We give you an open problem statement and you walk us through how you would solve the problem.
    - **Technical experience:** We ask you about your past work and accomplishments.
    - **Team collaboration:** We ask you about how you work and communicate in a team setting, and how you handle tricky situations.
-   - **CEO/CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
+   - **CTO:** We ask you about what motivates you to do your best work, and we tell you more about the vision for the company.
 1. We check your references.
 1. We make you a job offer.
 

--- a/handbook/sales/roles/account_executive.md
+++ b/handbook/sales/roles/account_executive.md
@@ -50,7 +50,7 @@ You apply [here](https://jobs.lever.co/sourcegraph/35aff80b-be4f-4887-a465-3e91e
    - Interview 1: an existing AE on the team (1 hour)
    - Interview 2: a member of our Customer Engineering team (30 minutes)
    - Interview 3: a deeper dive with our VP of Sales (1 hour)
-   - Interview 4 (CEO/CTO): We ask you about what motivates you to do your best work, and we tell you more about the vision for the company (30 minutes)
+   - Interview 4: We ask you about what motivates you to do your best work, and we tell you more about the vision for the company (30 minutes)
 
 4. We check your references.
 5. We make you a job offer.


### PR DESCRIPTION
I removed myself from the interview process for some (but not all) roles. The reason for this is that I simply don't have the time to interview everyone anymore. To decide which roles to remove myself from, I chose the roles where I would work less directly with the person and where we have successfully hired and onboarded more people in that role already (which indicates to me that my input is less needed).