### PR TITLE
hiring: Change general frontend role to be Cloud specific

### DIFF
--- a/company/careers.md
+++ b/company/careers.md
@@ -10,7 +10,7 @@ We're hiring! Check out our open positions:
 
 - [Director of Engineering - Platform and Infrastructure](https://jobs.lever.co/sourcegraph/8fcbaade-e511-4d93-bd9b-9cc7ec3438af)
 - [Engineering Manager - Cloud Application and Core Services](../handbook/engineering/hiring/engineering-manager-cloud.md)
-- [Software Engineer - Frontend](../handbook/engineering/hiring/software-engineer-frontend.md)
+- [Software Engineer - Cloud - Frontend](../handbook/engineering/hiring/software-engineer-cloud-frontend.md)
 - [Software Engineer - Code Insights - Frontend](../handbook/engineering/hiring/software-engineer-code-insights-frontend.md)
 - [Software Engineer - Backend](../handbook/engineering/hiring/software-engineer-backend.md)
 - [Software Engineer - Distribution](../handbook/engineering/hiring/software-engineer-distribution.md)
@@ -44,7 +44,6 @@ We're hiring! Check out our open positions:
 - [Business Operations Analyst](../handbook/ops/roles/business_operations_analyst.md)
 - [Tech Ops Manager](../handbook/ops/roles/tech_operations_manager.md)
 - [VP Talent](../handbook/talent/vp_talent.md)
-
 
 ## Apply
 

--- a/handbook/engineering/hiring/CODENOTIFY
+++ b/handbook/engineering/hiring/CODENOTIFY
@@ -7,6 +7,7 @@ software-engineer-backend.md            @tsenart
 software-engineer-code-intelligence.md  @nicksnyder
 software-engineer-coding-exercise.md    @tsenart @lguychard
 software-engineer-distribution.md       @pecigonzalo
-software-engineer-frontend.md           @lguychard
+software-engineer-frontend.md           @jeanduplessis
+software-engineer-cloud-frontend.md     @tsenart
 software-engineer-full-stack.md         @tsenart
 software-engineer-security.md           @chayim

--- a/handbook/engineering/hiring/software-engineer-cloud-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-cloud-frontend.md
@@ -1,0 +1,98 @@
+# Software Engineer - Cloud - Frontend
+
+The [Cloud team](../cloud/index.md) is looking for an experienced frontend engineer who knows how to build intuitive user experiences to make the power of [Universal Code Search](https://about.sourcegraph.com/product) accessible to everyone on [sourcegraph.com](https://sourcegraph.com/). You will have a lot of ownership to solve tough technical and UX problems that will drive massive adoption of our product by developers all around the world.
+
+## About you
+
+- You have practice at creating high quality software balanced with a pragmatic understanding of how to make appropriate tradeoffs (e.g. cut scope) to ship quickly and iterate when necessary.
+- You communicate clearly and empathetically, especially in writing and documentation.
+- You share our [values](../../../company/values.md), and work in accordance with those values.
+
+## Your responsibilities
+
+- Work closely with a dedicated designer and PM to implement high-quality UIs using React, SCSS and TypeScript.
+- Actively participate in the planning of the features we're going to build, e.g. by writing and reviewing RFCs.
+- Build UIs you will love to use yourself as a developer.
+- Ensure UI/UX consistency in our app.
+- Identify potential for abstraction and build components that can be reused, even by other teams.
+- Improve the code patterns in our frontend.
+- Hold up accessibility standards.
+
+## Qualifications
+
+- Experience in writing [SPAs](https://en.wikipedia.org/wiki/Single-page_application) using React or similar component-based frontend frameworks.
+- Familiarity with TypeScript or a different typed programming language.
+- Skilled at writing clean, reusable CSS and semantic HTML to implement visual designs.
+- Experience in using backend APIs from the frontend.
+- Skilled at building and testing (e.g. unit testing, automated end-to-end testing) UIs.
+
+## Nice-to-haves
+
+- Extensive experience with TypeScript.
+- Extensive experience with GraphQL.
+- Experience building browser extensions (e.g. Chrome, Firefox, Safari).
+- Large and/or numerous contributions to open source projects.
+- Published blog posts and/or tech talks about your work.
+- Experience working on small high-performing product teams, preferably tech startups.
+- Experience working with a global or otherwise multicultural team.
+- Developer platform/tool industry experience.
+
+## Learn more about us
+
+To create a product that serves the needs of all developers, we are building a diverse [all-remote team](../../../company/remote/index.md) that is [distributed across the world](../../../company/team/index.md). Sourcegraph is an equal opportunity workplace; we welcome people from all backgrounds and communities.
+
+We provide [competitive compensation](../../people-ops/compensation.md) and [practical benefits](../../people-ops/benefits-and-perks.md) to keep you happy and healthy so that you can do your best work.
+
+Learn more about what it is like to work at Sourcegraph by reading [our handbook](../../index.md).
+
+## Interview process
+
+1. You [apply here](https://jobs.lever.co/sourcegraph/b2f9a8b0-cc06-4629-81a0-0f2fa64271c7/apply).
+1. The **Hiring Manager** reviews all the information you provided on your application to determine if you meet our qualifications for this role (if there is another open role we think you would be better qualified for, we will let you know).
+1. A **Recruiter** sets up a 30 minute call to learn more about what you are looking for, tell you about Sourcegraph, and answer any questions that you have.
+1. We set up a 45 minutes interview with the **Hiring Manager**, who will tell you more about the available role in the team. They will ask you about your past work experience, accomplishments and assess your suitability for the role and alignment with [Sourcegraph's values](../../../company/values.md).
+1. You complete a 3 hour [coding excercise](software-engineer-coding-exercise.md#frontend-coding-exercise) that we designed to test your technical ability and the responsibilities of the role as [listed above](#your-responsibilities).
+   - _Note: while we do not disqualify candidates who do not have React and TypeScript experience from taking the excercise, you will be required to use these for the exercise._
+1. An **Engineer** and a **Designer** will review and grade your submission.
+1. We schedule a **1 hour follow-up call** to discuss your submission and ask any questions we might have to clarify our understanding of your technical capability and suitability for the role.
+   - You will interview with one teammate from each of the following 2 lists
+     - **Engineer**:
+       - [Felix Becker](../../../company/team/index.md#felix-becker)
+       - [Erik Seliger](../../../company/team/index.md#erik-seliger)
+     - **Designer**:
+       - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
+       - [Alicja Suska](../../../company/team/index.md#alicja-suska-she-her)
+       - [Quinn Keast](../../../company/team/index.md#quinn-keast-he-him)
+1. We schedule the following additional interviews, in no particular order, across multiple days:
+   - 1 hour **Technical experience:** We ask you about your past work and accomplishments in depth, how you worked with others, decisions you made, and what you'd do differently today.
+     - You will interview with two teammates from the following list
+       - [Felix Becker](../../../company/team/index.md#felix-becker)
+       - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
+       - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
+       - [Erik Seliger](../../../company/team/index.md#erik-seliger)
+   - 1 hour **Team collaboration:** We ask you about how you work and communicate in a team setting, how you handle tricky situations, decisions you made, and what you'd do differently today.
+     - You will interview with one teammate from each of the following 2 lists
+       - **Engineer**:
+         - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
+         - [Loïc Guychard](../../../company/team/index.md#lo%c3%afc-guychard)
+         - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
+       - **Non-engineer**:
+         - [Rob Rhyne](../../../company/team/index.md#rob-rhyne)
+         - [Alicja Suska](../../../company/team/index.md#alicja-suska-she-her)
+         - [Quinn Keast](../../../company/team/index.md#quinn-keast-he-him)
+         - [María Craig](../../../company/team/index.md#mar%c3%ada-craig-she-her)
+         - [Eric Brody-Moore](../../../company/team/index.md#eric-brody-moore)
+         - [Jonah Dueck](../../../company/team/index.md#jonah-dueck-he-him)
+         - [Josh Saunders](../../../company/team/index.md#josh-saunders)
+         - [Nick McMillen](../../../company/team/index.md#nick-mcmillen-he-him)
+         - [Christine Lovett](../../../company/team/index.md#christine-lovett-she-her)
+   - 30 minutes [VP Engineering](../../../company/team/index.md#nick-snyder-he-him)
+   - 30 minutes [CTO](../../../company/team/index.md#beyang-liu)
+1. We check your references.
+1. We make you a job offer.
+
+We want to ensure Sourcegraph is an environment that suits your working style and empowers you to do your best work, so we are eager to answer any questions that you have about us at any point in the interview process.
+
+**[Click here to apply](https://jobs.lever.co/sourcegraph/b2f9a8b0-cc06-4629-81a0-0f2fa64271c7/apply)**
+
+Go back to the [careers page](../../../company/careers.md) for all open positions or read more about our [hiring processes](../../people-ops/hiring/index.md).

--- a/handbook/engineering/hiring/software-engineer-cloud-frontend.md
+++ b/handbook/engineering/hiring/software-engineer-cloud-frontend.md
@@ -1,6 +1,6 @@
 # Software Engineer - Cloud - Frontend
 
-The [Cloud team](../cloud/index.md) is looking for an experienced frontend engineer who knows how to build intuitive user experiences to make the power of [Universal Code Search](https://about.sourcegraph.com/product) accessible to everyone on [sourcegraph.com](https://sourcegraph.com/). You will have a lot of ownership to solve tough technical and UX problems that will drive massive adoption of our product by developers all around the world.
+The [Cloud team](../cloud/index.md) is looking for a senior frontend engineer who knows how to build intuitive user experiences to make the power of [Universal Code Search](https://about.sourcegraph.com/product) accessible to everyone on [sourcegraph.com](https://sourcegraph.com/). You will have a lot of ownership to solve tough technical and UX problems that will drive massive adoption of our product by developers all around the world.
 
 ## About you
 

--- a/handbook/people-ops/hiring/index.md
+++ b/handbook/people-ops/hiring/index.md
@@ -13,24 +13,24 @@
    - All interviewers submit written feedback independently before being able to see feedback from other interviewers. Feedback may not be edited after submission.
    - We maintain a consistent hiring [decision process](#decision-making-process) for all candidates.
 1. Hiring managers own the hiring process for their team.
-    - Hiring managers are encouraged to experiment to learn how to improve their hiring process.
-    - The handbook is kept up-to-date with our learnings and current norms.
-    
+   - Hiring managers are encouraged to experiment to learn how to improve their hiring process.
+   - The handbook is kept up-to-date with our learnings and current norms.
+
 ## How recruiting interfaces with hiring managers
 
-For any members of a hiring team, please see [this page](how_recruiting_interfaces_with_hiring_managers.md) for a breakdown of each step in the hiring process. 
+For any members of a hiring team, please see [this page](how_recruiting_interfaces_with_hiring_managers.md) for a breakdown of each step in the hiring process.
 
 The page will outline responsibilities by role (Hiring Manager, Scheduling Coordinator, and People Ops) for each team.
-    
+
 ## Recruiting tools
 
 We currently use Lever as our applicant tracking system. [guide coming soon]
 
-We utilize LinkedIn as our sourcing platform. 
+We utilize LinkedIn as our sourcing platform.
 
-Hiring managers will be a assigned a hiring manager seat on the platform. For details on hiring manager seat capabilities, [click here](https://about.sourcegraph.com/handbook/people-ops/hiring/linkedin). 
+Hiring managers will be a assigned a hiring manager seat on the platform. For details on hiring manager seat capabilities, [click here](https://about.sourcegraph.com/handbook/people-ops/hiring/linkedin).
 
-We will work with recruiters and hiring managers to gain access to the tools they need to be successfull. 
+We will work with recruiters and hiring managers to gain access to the tools they need to be successfull.
 
 ## Open positions
 
@@ -44,7 +44,7 @@ We cross-post our open positions to the following locations:
 - [Tech Ladies](https://www.hiretechladies.com/). With our current plan we can post up to 10 roles at a time (and can rotate out roles as they are filled). Nick owns this list and payments are made with Nick's Brex. Tech Ladies checks our open positions every month to see if there are updates, but we can request an update anytime by emailing jobpostings@hiretechladies.com. Here are the 10 roles that we post:
   1. [Director of Engineering - Platform and Infrastructure](https://jobs.lever.co/sourcegraph/8fcbaade-e511-4d93-bd9b-9cc7ec3438af)
   1. [Engineering Manager - Cloud Application and Core Services](../../engineering/hiring/engineering-manager-cloud.md)
-  1. [Software Engineer - Frontend](../../engineering/hiring/software-engineer-frontend.md)
+  1. [Software Engineer - Cloud - Frontend](../../engineering/hiring/software-engineer-cloud-frontend.md)
   1. [Software Engineer - Backend](../../engineering/hiring/software-engineer-backend.md)
   1. [Software Engineer - Distribution](../../engineering/hiring/software-engineer-distribution.md)
   1. [Software Engineer - Security](../../engineering/hiring/software-engineer-security.md)
@@ -70,20 +70,20 @@ See the [job descriptions guidelines](./job_description_guidelines.md) when crea
 We review each candidate at each stage of our hiring pipeline (e.g. application, phone screen, interviews, references) to determine if we want to move the candidate to the next stage. Here are some things that we consider:
 
 - Applications
-    - Does this candidate meet all qualifications for the role they are applying for?
-    - Does this candidate's resume and application effectively communicate their skills, accomplishments, and a genuine interest in Sourcegraph?
-    - How do this candidate's skills, accomplishments, and interest in Sourcegraph compare to other candidates or our current team?
-    - What makes this candidate's application stand out and excite us about moving forward with interviews?
+  - Does this candidate meet all qualifications for the role they are applying for?
+  - Does this candidate's resume and application effectively communicate their skills, accomplishments, and a genuine interest in Sourcegraph?
+  - How do this candidate's skills, accomplishments, and interest in Sourcegraph compare to other candidates or our current team?
+  - What makes this candidate's application stand out and excite us about moving forward with interviews?
 - Interviews
-    - Does this candidate have the skills and experience that we are looking for?
-    - How do this candidate's skills, accomplishments, and interest in Sourcegraph compare to other candidates or our current team?
-    - What makes us excited about hiring this candidate?
+  - Does this candidate have the skills and experience that we are looking for?
+  - How do this candidate's skills, accomplishments, and interest in Sourcegraph compare to other candidates or our current team?
+  - What makes us excited about hiring this candidate?
 
 ## Making a referral
 
 Current employees can refer a candidate [here](https://hire.lever.co/referrals/new)
 
-Having your referral complete the application provides helpful context when considering their profile, but is not required. 
+Having your referral complete the application provides helpful context when considering their profile, but is not required.
 
 Benefits of having a referral complete the application:
 


### PR DESCRIPTION
We decided to move towards team specific roles, so this closes that gap.

@felixfbecker, @jeanduplessis: I left the interview process intact, since I think the interviewers listed can do the best job at assessing a frontend candidate, but if we want to move to an offer stage, I'd want the candidate to meet a few teammates of the Cloud team. Does this make sense?

@withdavidli: We need to open a role in Lever and link to it in the job page. Can you help with this?