### PR TITLE
releases: releases happen in a single day

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -1,11 +1,12 @@
 <!--
-DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking:patch-issue <version>` in the main repository to create a patch release issue, instead.
+DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking:issues` in the `sourcegraph/sourcegraph` repository.
 
 Arguments:
 - $MAJOR
 - $MINOR
 - $PATCH
 - $RELEASE_DATE
+- $ONE_WORKING_DAY_AFTER_RELEASE
 -->
 
 # $MAJOR.$MINOR.$PATCH patch release

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -1,86 +1,92 @@
 <!--
-DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn run release tracking:patch-issue <version>` from the
-`dev/release` directory in the main repository to create a patch release issue, instead.
+DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking:patch-issue <version>` in the main repository to create a patch release issue, instead.
 
 Arguments:
 - $MAJOR
 - $MINOR
 - $PATCH
+- $RELEASE_DATE
 -->
 
-# $MAJOR.$MINOR.$PATCH Patch Release
+# $MAJOR.$MINOR.$PATCH patch release
 
-**Attention developers:** to get your commits in `main` included in this patch release, please file a [patch request](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.$PATCH%3A+) for review. Only check off items if the commit have been cherry-picked into the `$MAJOR.$MINOR` branch by the release captain.
+This release is scheduled for **$RELEASE_DATE**.
 
-- [ ] TODO: Add [patch request issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apatch-release-request) and their associated commits on `main` here
+> **Attention developers:** to get your commits in `main` included in this patch release, please file a [patch request](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.$PATCH%3A+) for review.
+>
+> Only check off items if relevant commits across the following repositories have been cherry-picked into the relevant `$MAJOR.$MINOR` branch by the release captain:
+>
+> - `sourcegraph/sourcegraph`
+> - `sourcegraph/deploy-sourcegraph`
+> - `sourcegraph/deploy-sourcegraph-docker`
 
----
-
-**Note:** All `yarn run release ...` commands should be run from folder `dev/release`.
-
-**Note:** All `yarn run test ...` commands should be run from folder `web`.
+- [ ] TODO: Add [patch request issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apatch-release-request) and their associated commits here
 
 ## Setup
+
+<!-- Keep in sync with release_issue_template's "Setup" section -->
 
 - [ ] Ensure release configuration in [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) on `main` is up to date with the parameters for the current release.
 - [ ] Ensure you have the latest version of the release tooling and configuration by checking out and updating `sourcegraph@main`.
 
 ## Prepare release
 
-Ensure all patch changes are included:
+Ensure that all [patch request issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apatch-release-request) are accounted for, and have all relevant commits across relevant repositories listed above in the checklist.
 
-- [ ] Ensure that all [patch request issues](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aissue+is%3Aopen+sort%3Aupdated-desc+label%3Apatch-release-request) are accounted for, and that the commits listed above has been cherry-picked to [`$MAJOR.$MINOR` release branch](https://github.com/sourcegraph/sourcegraph/tree/$MAJOR.$MINOR), and ensure CI passes on the release branch.
-    ```
-    git checkout $MAJOR.$MINOR
-    git pull
-    git cherry-pick <commit0> <commit1> ... # all relevant commits from the main branch
-    git push $MAJOR.$MINOR
-    ```
-- [ ] Cherry-pick relevant [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph) configuration changes from `master` to the [`$MAJOR.$MINOR` release branch](https://github.com/sourcegraph/deploy-sourcegraph/tree/$MAJOR.$MINOR), and ensure CI passes on the release branch.
-    ```
-    git checkout $MAJOR.$MINOR
-    git pull
-    git cherry-pick <commit0> <commit1> ... # all relevant commits from the master branch
-    git push $MAJOR.$MINOR
-    ```
-- [ ] Cherry-pick relevant [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker) configuration changes from `master` to the [`$MAJOR.$MINOR` release branch](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$MAJOR.$MINOR), and ensure CI passes on the release branch.
-    ```
-    git checkout $MAJOR.$MINOR
-    git pull
-    git cherry-pick <commit0> <commit1> ... # all relevant commits from the master branch
-    git push $MAJOR.$MINOR
-    ```
+For each of the following repositories, cherry-pick (see snippet below) and check off commits listed above.
 
-Create and test release candidates:
+- [ ] `sourcegraph/sourcegraph` ([`$MAJOR.$MINOR` release branch](https://github.com/sourcegraph/sourcegraph/tree/$MAJOR.$MINOR))
+- [ ] `sourcegraph/deploy-sourcegraph` ([`$MAJOR.$MINOR` release branch](https://github.com/sourcegraph/deploy-sourcegraph/tree/$MAJOR.$MINOR))
+- [ ] `sourcegraph/deploy-sourcegraph-docker` ([`$MAJOR.$MINOR` release branch](https://github.com/sourcegraph/deploy-sourcegraph-docker/tree/$MAJOR.$MINOR))
+
+```sh
+git checkout $MAJOR.$MINOR
+git pull
+git cherry-pick <commit0> <commit1> ... # all relevant commits from the default branch
+git push $MAJOR.$MINOR
+```
+
+- [ ] Ensure CI passes on all release branches listed above.
+
+Create and test the first release candidate:
 
 - [ ] Push a release candidate tag:
-    ```
-    yarn run release release:create-candidate 1
+    ```sh
+    N=1 yarn release release:create-candidate $N
     ```
 - [ ] Ensure the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite passes.
+- [ ] File any failures and regressions in the pipelines as `release-blocker` issues and assign the appropriate teams.
 
 ## Stage release
 
+<!-- Keep in sync with release_issue_template's "Stage release" section -->
+
+- [ ] Verify the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) on `main` and `$MAJOR.$MINOR` are accurate.
 - [ ] Tag the final release:
     ```sh
-    yarn run release release:create-candidate final
+    yarn release release:create-candidate final
     ```
-- [ ] Ensure the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite passes.
+- [ ] Ensure the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite passes, and for the release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags).
 - [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns)):
   ```sh
-  yarn run release release:stage
+  yarn release release:stage
   ```
 
-## Release
+## Finalize release
 
-<!-- Keep in sync with release_issue_template's "Release" section -->
+<!-- Keep in sync with release_issue_template's "Finalize elease" section, except no blog post -->
 
 - [ ] From the [release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns), merge the release-publishing PRs created previously.
+  - For [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph), also:
+    - [ ] Tag the `v$MAJOR.$MINOR.0` release at the most recent commit on the `v$MAJOR.$MINOR` branch.
+        ```sh
+        VERSION='v$MAJOR.$MINOR.0' bash -c 'git tag -a "$VERSION" -m "$VERSION" && git push origin "$VERSION"'
+        ```
   - For [sourcegraph](https://github.com/sourcegraph/sourcegraph), also:
     - [ ] Cherry pick the release-publishing PR from `sourcegraph/sourcegraph@main` into the release branch.
 - [ ] Finalize and announce that the release is live:
   ```sh
-  yarn run release release:close
+  yarn release release:close
   ```
 
 ## Post-release

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -1,10 +1,12 @@
 <!--
-DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking-issue:create` in the main repository to create a release tracking issue, instead.
+DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking:issues` in the `sourcegraph/sourcegraph` repository.
 
 Arguments:
 - $MAJOR
 - $MINOR
+- $PATCH
 - $RELEASE_DATE
+- $ONE_WORKING_DAY_AFTER_RELEASE
 -->
 
 # $MAJOR.$MINOR release
@@ -96,11 +98,8 @@ Notify the next [release captain](https://about.sourcegraph.com/handbook/enginee
 - [ ] Ensure you have the latest version of the release tooling and configuration by checking out and updating `sourcegraph@main`.
 - [ ] Create release calendar events, tracking issue, and announcement for next release:
   ```sh
-  # Add calendar events and reminders for key dates in the release cycle
-  yarn run release tracking:release-timeline
-
-  # Create the release tracking issue (i.e., this issue)
-  yarn run release tracking:release-issue
+  yarn run release tracking:issues
+  yarn run release tracking:timeline
   ```
 - [ ] Close this issue.
 

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -1,87 +1,75 @@
 <!--
-DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn run release tracking-issue:create` from the
-`dev/release` directory in the main repository to create a release tracking issue, instead.
+DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking-issue:create` in the main repository to create a release tracking issue, instead.
 
 Arguments:
 - $MAJOR
 - $MINOR
 - $RELEASE_DATE
-- $FIVE_WORKING_DAYS_BEFORE_RELEASE
-- $FOUR_WORKING_DAYS_BEFORE_RELEASE
-- $ONE_WORKING_DAY_BEFORE_RELEASE
 -->
 
-# $MAJOR.$MINOR Release
+# $MAJOR.$MINOR release
 
-This release is scheduled for $RELEASE_DATE.
+This release is scheduled for **$RELEASE_DATE**.
 
 ---
-
-**Note:** All `yarn run release ...` commands should be run from folder `dev/release`.
-
-**Note:** All `yarn run test ...` commands should be run from folder `web`.
 
 ## Setup
 
 - [ ] Ensure release configuration in [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) on `main` is up to date with the parameters for the current release.
 - [ ] Ensure you have the latest version of the release tooling and configuration by checking out and updating `sourcegraph@main`.
 
-## $FIVE_WORKING_DAYS_BEFORE_RELEASE (5 work days before release): Prep for branch cut
+## Prepare release
 
 - [ ] Post a release status update to Slack - review all release-blocking issues, and ensure someone is resolving each.
   ```sh
-  yarn run release release:status
-  ``` 
+  yarn release release:status
+  ```
 
-## $FOUR_WORKING_DAYS_BEFORE_RELEASE (4 work days before release): Branch cut
+Do the [branch cut](https://about.sourcegraph.com/handbook/engineering/releases#release-branches) for the release:
 
 - [ ] Update the changelog and merge the generated pull request:
   ```sh
-  yarn run release changelog:cut
+  yarn release changelog:cut
   ```
-- [ ] Create the `$MAJOR.$MINOR` branch off the CHANGELOG commit in the previous step: `git branch $MAJOR.$MINOR && git push origin $MAJOR.$MINOR`.
+- [ ] Create the `$MAJOR.$MINOR` branch off the CHANGELOG commit in the previous step:
+  ```sh
+  git branch $MAJOR.$MINOR && git push origin $MAJOR.$MINOR
+  ```
 
-Upon branch cut, create and test the first release candidate:
+Upon branch cut, create and test release candidates:
 
 - [ ] Tag the first release candidate:
   ```sh
-  yarn run release release:create-candidate 1
+  N=1 yarn release release:create-candidate $N
   ```
 - [ ] Wait for the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite to complete.
 - [ ] File any failures and regressions in the pipelines as `release-blocker` issues and assign the appropriate teams.
 
-Revert or disable features that may cause delays. As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch. Continue to create new release candidates daily or as necessary, until no more `release-blocker` issues remain:
+Revert or disable features that may cause delays. As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch. Continue to create new release candidates as necessary, until no more `release-blocker` issues remain.
 
-- [ ] Cut the Nth release candidate:
+- [ ] Post a release status update to Slack:
   ```sh
-  N=<release-candidate-number> yarn run release release:create-candidate $N
-  ```
-- [ ] Re-run the automated test suite against the new release candidate, file any regressions as
-  `release-blocker` issues.
-  - [ ] If necessary, manually test features or workflows affected by the cherry-pick.
-- [ ] Post a release status update by running the command below. Ensure someone is resolving each release-blocking issue. If there are no more release-blocking issues, proceed to tag the final release in the next section.
-  ```
-  yarn run release release:status
+  yarn release release:status
   ``` 
 
-## Tag final release
+## Stage release
+
+<!-- Keep in sync with patch_release_issue's "Stage release" section -->
 
 Once there are no more release-blocking issues (as reported by the `release:status` command) proceed with creating the final release:
 
-- [ ] Verify the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) on
-  `main` is accurate (no items should have been added since branch cut, but some items may need to
-  be removed).
+- [ ] Verify the [CHANGELOG](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md) on `main` and `$MAJOR.$MINOR` are accurate.
 - [ ] Tag the final release:
   ```sh
-  yarn run release release:create-candidate final
+  yarn release release:create-candidate final
   ```
-- [ ] Wait for the release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags).
+- [ ] Ensure the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite passes, and for the release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags).
 - [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns)):
   ```sh
-  yarn run release release:stage
+  yarn release release:stage
   ```
 
-## $RELEASE_DATE: Release
+## Finalize release
 
 - [ ] From the [release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns), merge the release-publishing PRs created previously.
   - For [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph), also:
@@ -91,18 +79,19 @@ Once there are no more release-blocking issues (as reported by the `release:stat
         ```
   - For [sourcegraph](https://github.com/sourcegraph/sourcegraph), also:
     - [ ] Cherry pick the release-publishing PR from `sourcegraph/sourcegraph@main` into the release branch.
-- [ ] Ask the product team to merge the blog post ([example](https://github.com/sourcegraph/about/pull/83)). Add the pull request to the release campaign:
+- [ ] Ask the product team (`#product`) to merge the blog post. Add the pull request to the release campaign:
   ```sh
-  yarn run release release:add-to-campaign sourcegraph/about <pr-number>
+  yarn release release:add-to-campaign sourcegraph/about <pr-number>
   ```
 - [ ] Finalize and announce that the release is live:
   ```sh
-  yarn run release release:close
+  yarn release release:close
   ```
 
 ### Post-release
 
-- [ ] Notify the next release captain that they are on duty for the next release. They should complete the steps in this section.
+Notify the next [release captain](https://about.sourcegraph.com/handbook/engineering/releases#release-captain) that they are on duty for the next release. They should complete the steps in this section.
+
 - [ ] Open a PR to update [`dev/release/release-config.jsonc`](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/dev/release/release-config.jsonc) with the parameters for the current release.
 - [ ] Ensure you have the latest version of the release tooling and configuration by checking out and updating `sourcegraph@main`.
 - [ ] Create release calendar events, tracking issue, and announcement for next release:
@@ -115,4 +104,4 @@ Once there are no more release-blocking issues (as reported by the `release:stat
   ```
 - [ ] Close this issue.
 
-**Note:** If a patch release are requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1%3A+) be filled out and approved first.
+**Note:** If a patch release is requested after the release, ask that a [patch request issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=team%2Fdistribution&template=request_patch_release.md&title=$MAJOR.$MINOR.1%3A+) be filled out and approved first.

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -90,7 +90,7 @@ Once there are no more release-blocking issues (as reported by the `release:stat
   yarn release release:close
   ```
 
-### Post-release
+## Post-release
 
 Notify the next [release captain](https://about.sourcegraph.com/handbook/engineering/releases#release-captain) that they are on duty for the next release. They should complete the steps in this section.
 

--- a/handbook/engineering/releases/upgrade_managed_issue_template.md
+++ b/handbook/engineering/releases/upgrade_managed_issue_template.md
@@ -1,11 +1,11 @@
 <!--
-DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking-issue:create` from the
-`dev/release` directory in the main repository to create a release tracking issue, instead.
+DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking:issues` in the `sourcegraph/sourcegraph` repository.
 
 Arguments:
 - $MAJOR
 - $MINOR
 - $PATCH
+- $RELEASE_DATE
 - $ONE_WORKING_DAY_AFTER_RELEASE
 -->
 

--- a/handbook/engineering/releases/upgrade_managed_issue_template.md
+++ b/handbook/engineering/releases/upgrade_managed_issue_template.md
@@ -1,17 +1,29 @@
 <!--
-DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn run release tracking-issue:create` from the
+DO NOTE COPY THIS ISSUE TEMPLATE MANUALLY. Use `yarn release tracking-issue:create` from the
 `dev/release` directory in the main repository to create a release tracking issue, instead.
 
 Arguments:
 - $MAJOR
 - $MINOR
+- $PATCH
 - $ONE_WORKING_DAY_AFTER_RELEASE
 -->
 
-# $MAJOR.$MINOR
+# $MAJOR.$MINOR.$MINOR managed instances upgrade
 
-## $ONE_WORKING_DAY_AFTER_RELEASE Upgrade managed instances
+These [managaged instances](https://about.sourcegraph.com/handbook/engineering/distribution/managed) upgrades are scheduled for **$ONE_WORKING_DAY_AFTER_RELEASE**.
 
-- [ ] Upgrade [demo.sourcegraph.com](https://demo.sourcegraph.com)
+To perfomr these upgrades, follow the [managed instances upgrade process](https://about.sourcegraph.com/handbook/engineering/distribution/managed/upgrade_process).
+
+---
+
+## Upgrade internal managed instances
+
 - [ ] Upgrade [devmanaged.sourcegraph.com](https://demo.sourcegraph.com)
+- [ ] Upgrade [demo.sourcegraph.com](https://demo.sourcegraph.com)
+
+## Upgrade customer managed instances
+
+<!-- DO NOT MENTION CUSTOMER NAMES on this list - use a Hubspot link instead. -->
+
 - [ ] Upgrade instance for [https://app.hubspot.com/contacts/2762526/company/1712860829](https://app.hubspot.com/contacts/2762526/company/1712860829/)


### PR DESCRIPTION
closes https://github.com/sourcegraph/sourcegraph/issues/17364 . There are also changes to accommodate command changes in https://github.com/sourcegraph/sourcegraph/pull/17401

also updates issue templates for uniformity