### PR TITLE
fix bullet points and reorder RFC content

### DIFF
--- a/handbook/communication/rfcs/index.md
+++ b/handbook/communication/rfcs/index.md
@@ -30,6 +30,61 @@ When you are referring to an RFC with a group of people who might not be familia
 
 _"We finished standardizing the RFC process ([RFC 27](https://docs.google.com/document/d/1ym5c8G5JcrFf5s0QXJqQKBcZRziVAZZsxWdcUJ7Ukfw/edit))"_ is better than saying/writing _"RFC 27 is done"__.
 
+## RFC structure
+
+Effective RFCs contain several *metadata* sections followed by several *main* sections. These are defined below.
+
+The precise format is not as important as the content itself. Ultimately RFCs are a tool to communicate and gather feedback, so optimize for that over blindly following the given format.
+
+<i>There is a [Google Docs Template](https://docs.google.com/document/d/1vUp1A-j5xxnPn_rv3x3rWo8tbXJhIA5NggHLU6UofUc/edit) that can be used when creating new RFCs.</i>
+
+#### Metadata sections
+
+- **Title:** The title includes the [RFC number](#rfcs-are-sequentially-numbered). This is the title of the Google document, but it is also inlined for visibility and to ensure it will not disappear if exported to a different format.
+- **Editor:** The person responsible for iterating on the content of the RFC. Generally, this is the author of the Google Doc but it is possible for ownership to be transferred.
+- **Status:** A description of the current state or outcome of the RFC. Illustrative examples:
+  - "Still drafting this. I expect to share this with the web team September 6."
+  - "Collecting feedback. I will update the RFC on September 8 based on the feedback collected.
+  - "Updating RFC based on collected feedback. I expect to reshare the updated doc September 9.
+  - "We aren't going to pursue this RFC for the following reasons..."
+  - "The web team is going to implement this RFC in 3.8."
+  - "This RFC has been implemented."
+- **Requested reviewers:** The list of people that the RFC author is requesting a review from and a requested deadline for those reviews (e.g. "Requested reviewers: Alice and Bob can you please review by 10am PST on 2020-10-21"). The author is responsible for ensuring that the reviewers aware of the review request (e.g. by sending them a Slack message or tagging them in a comment on the Google Doc). If an RFC reader thinks someone is missing from this list, they should make a Google Docs suggestion to add that person to this list.
+- **Approvals:** A list of people who approve of this RFC. Anyone can express approval for an RFC, even if they are not in the "Requested reviewers" list; however, a RFC is not APPROVED until the RFC author receives approval from the people on the "Requested reviewers" list.
+- **Team(s):** The team(s) that would be involved in implementing the RFC. You can still request review from people not on a listed team. Writing the team allows us to search RFCs by team using Google Docs's exact match string search. 
+ - Everyone must use the same (case-insensitive) team name so a Google Docs search can find all of and only a team's RFCs. We use the team names listed on our [org chart](../../../company/team/org_chart.md).
+ - Example: "Team: Web"
+ - Multi-team example: "Team: Web, Team: Customer Engineering". 
+ - It's important to write "Team: " in front of each team when there are multiple teams so that a search for an exact match (using quotes) on "Team: [Team Name]" always returns. 
+- **GitHub issues:** (optional) Links to any GitHub issues that capture work being done to implement this RFC. A good way to notify reviewers is to comment on their name and then assign them in the comment. This will send them an email and allow them to resolve the comment after their review.
+
+#### Main sections
+- **Background:** A sufficient, but minimal, amount of context necessary to frame the rest of the RFC. The content should be indisputable facts, not opinions or arguments. The facts should support the chosen definition of the problem and the constraints in the next section.
+- **Problem:** A description of the problem that this RFC is trying to address, the constraints that this RFC trying to satisfy, and why this problem is worth solving now.
+- **Proposed solution (optional):** A description of HOW to solve the problem. It is ok to omit this section if you just want to define a problem. This can be useful if you want help thinking of solutions or want to handoff ownership of this problem to someone else.
+- **Definition of success:** How do we know if this project was successful? Are there any metrics we need to start tracking? Link to the delivery plan for customer oriented features.
+
+
+## RFCs are public
+
+[We value openness](https://about.sourcegraph.com/company#open-company). Transparency helps us communicate with and gather feedback from our customers, and it holds everyone accountable to a higher quality bar.
+
+The default sharing state of documents in our [Google Drive's RFCs](https://drive.google.com/drive/folders/1zP3FxdDlcSQGC1qvM9lHZRaHH4I9Jwwa) folder will allow everyone to publicly read/comment, and all Sourcegraph teammates to edit.
+
+<img src="link-sharing.png" width="300" alt="Google link sharing settings">
+
+Sometimes there is information relevant to an RFC, but that information can't be made public.
+
+- RFCs should never reference customer names directly, even if they are listed on our homepage. Instead, you can use a Hubspot link or an arbitrary code name (e.g. "ACME", "Customer X") for each customer that you need to reference in the document. Code names do not need to be consistent across documents. The first usage of each code name should be linked to the actual company's profile in Hubspot.
+    - To make this easy, add a search engine to your browser so that you can quickly type `h ACME` or `h sourcegraph` to find the company in HubSpot. Use this URL [https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s](https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s)
+    ![Hubspot search](hubspot-search.png)
+    - Don't share the link to the search results (it has the company name in the search)! Instead, share the direct link to the company; it should look like this: [https://app.hubspot.com/contacts/2762526/company/557690851/](https://app.hubspot.com/contacts/2762526/company/557690851/)
+    ![Hubspot results](hubspot-results.png)
+- If there is strategic information that shouldn't be public, you can post it in Slack and link to it from the public RFC.
+- If most of the content is non-public, then it is OK to make the RFC only accessible to the Sourcegraph team. Add "PRIVATE" after the [status](#status) in the title, move it to the [private RFCs folder in GDrive](https://drive.google.com/drive/folders/1KCq4tMLnVlC0a1rwGuU5OSCw6mdDxLuv), and explain why it's private in the doc.
+
+Only Sourcegraph teammates are able to see the revision history of RFCs (because edit access is required for that). This means if sensitive information is found in the document all you need to do is remove that information. Comments that accidentally contain sensitive info can be deleted.
+
 ## RFCs are Google Docs
 
 It is valuable to standardize on a single system for publishing RFCs.
@@ -67,59 +122,6 @@ Rejected alternatives:
     - Suggestions are cumbersome to make/read.
     - Even with recent improvements to collapse old threads, the PR activity page becomes cumbersome after a lot of discussion has happened on a document.
   - It is higher friction to author and/or contribute to multiple RFCs due to either (1) the necessary git workflow or (2) the clunky editing experience in GitHub's UI.
-
-## RFC structure
-
-Effective RFCs contain the following information:
-
-- Title that includes the RFC number.
-  - The title is inlined in the Google Doc so that it is more visible and will not disappear if exported to a different format.
-- Metadata about the state of the RFC. Including but not limited to:
-  - **Editor:** The person responsible for iterating on the content of the RFC.
-    - Generally, this is the author of the Google Doc but it is possible for ownership to be transferred.
-  - **Status:** A description of the current state or outcome of the RFC. Illustrative examples:
-    - "Still drafting this. I expect to share this with the web team September 6."
-    - "Collecting feedback. I will update the RFC on September 8 based on the feedback collected.
-    - "Updating RFC based on collected feedback. I expect to reshare the updated doc September 9.
-    - "We aren't going to pursue this RFC for the following reasons..."
-    - "The web team is going to implement this RFC in 3.8."
-    - "This RFC has been implemented."
-  - **Requested reviewers:** The list of people that the RFC author is requesting a review from and a requested deadline for those reviews (e.g. "Requested reviewers: Alice and Bob can you please review by 10am PST on 2020-10-21"). The author is responsible for ensuring that the reviewers aware of the review request (e.g. by sending them a Slack message or tagging them in a comment on the Google Doc). If an RFC reader thinks someone is missing from this list, they should make a Google Docs suggestion to add that person to this list.
-  - **Approvals:** A list of people who approve of this RFC. Anyone can express approval for an RFC, even if they are not in the "Requested reviewers" list; however, a RFC is not APPROVED until the RFC author receives approval from the people on the "Requested reviewers" list.
-  - **Team(s):** The team(s) that would be involved in implementing the RFC. You can still request review from people not on a listed team. Writing the team allows us to search RFCs by team using Google Docs's exact match string search. 
-     - Everyone must use the same (case-insensitive) team name so a Google Docs search can find all of and only a team's RFCs. We use the team names listed on our [org chart](../../../company/team/org_chart.md).
-     - Example: "Team: Web"
-     - Multi-team example: "Team: Web, Team: Customer Engineering". It's important to write "Team: " in front of each team when there are multiple teams so that a search for an exact match (using quotes) on "Team: [Team Name]" always returns. 
-  - (optional) Links to any GitHub issues that capture work being done to implement this RFC.
-  - A good way to notify reviewers is to comment on their name and then assign them in the comment. This will send them an email and allow them to resolve the comment after their review.
-- **Background:** A sufficient, but minimal, amount of context necessary to frame the rest of the RFC. The content should be indisputable facts, not opinions or arguments. The facts should support the chosen definition of the problem and the constraints in the next section.
-- **Problem:** A description of the problem that this RFC is trying to address, the constraints that this RFC trying to satisfy, and why this problem is worth solving now.
-- **Proposed solution (optional):** A description of HOW to solve the problem. It is ok to omit this section if you just want to define a problem. This can be useful if you want help thinking of solutions or want to handoff ownership of this problem to someone else.
-- **Definition of success:** How do we know if this project was successful? Are there any metrics we need to start tracking? Link to the delivery plan for customer oriented features.
-
-The precise format is not as important as the content itself. Ultimately RFCs are a tool to communicate and gather feedback, so optimize for that.
-
-_For convenience, there is a [Google Docs Template](https://docs.google.com/document/d/1vUp1A-j5xxnPn_rv3x3rWo8tbXJhIA5NggHLU6UofUc/edit) that can be used when creating new RFCs._
-
-## RFCs are public
-
-[We value openness](https://about.sourcegraph.com/company#open-company). Transparency helps us communicate with and gather feedback from our customers, and it holds everyone accountable to a higher quality bar.
-
-The default sharing state of documents in our [Google Drive's RFCs](https://drive.google.com/drive/folders/1zP3FxdDlcSQGC1qvM9lHZRaHH4I9Jwwa) folder will allow everyone to publicly read/comment, and all Sourcegraph teammates to edit.
-
-<img src="link-sharing.png" width="300" alt="Google link sharing settings">
-
-Sometimes there is information relevant to an RFC, but that information can't be made public.
-
-- RFCs should never reference customer names directly, even if they are listed on our homepage. Instead, you can use a Hubspot link or an arbitrary code name (e.g. "ACME", "Customer X") for each customer that you need to reference in the document. Code names do not need to be consistent across documents. The first usage of each code name should be linked to the actual company's profile in Hubspot.
-    - To make this easy, add a search engine to your browser so that you can quickly type `h ACME` or `h sourcegraph` to find the company in HubSpot. Use this URL [https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s](https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s)
-    ![Hubspot search](hubspot-search.png)
-    - Don't share the link to the search results (it has the company name in the search)! Instead, share the direct link to the company; it should look like this: [https://app.hubspot.com/contacts/2762526/company/557690851/](https://app.hubspot.com/contacts/2762526/company/557690851/)
-    ![Hubspot results](hubspot-results.png)
-- If there is strategic information that shouldn't be public, you can post it in Slack and link to it from the public RFC.
-- If most of the content is non-public, then it is OK to make the RFC only accessible to the Sourcegraph team. Add "PRIVATE" after the [status](#status) in the title, move it to the [private RFCs folder in GDrive](https://drive.google.com/drive/folders/1KCq4tMLnVlC0a1rwGuU5OSCw6mdDxLuv), and explain why it's private in the doc.
-
-Only Sourcegraph teammates are able to see the revision history of RFCs (because edit access is required for that). This means if sensitive information is found in the document all you need to do is remove that information. Comments that accidentally contain sensitive info can be deleted.
 
 ## External contributors
 


### PR DESCRIPTION
* prompted by https://github.com/sourcegraph/about/issues/1389
* add two subheadings so that each item can have its own main bullet
* move background/history about why Google Docs was chosen to the end of the file to bring the meat of the content (the RFC structure) further up.