### PR TITLE
Add note about hiring to code insights org chart

### DIFF
--- a/handbook/engineering/code-insights/index.md
+++ b/handbook/engineering/code-insights/index.md
@@ -32,7 +32,4 @@ The code insights team also keeps a [backlog GitHub project board](https://githu
 ## Members
 - [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/product_manager.md))
 - [Felix Becker](../../../company/team/index.md#felix-becker) ([Engineering Manager](../roles.md#engineering-manager))
-
-## We're hiring for this team!
-
-We are building the code insights team by hiring [frontend engineers](../hiring/software-engineer-code-insights-frontend.md) and [backend engineers](../hiring/software-engineer-backend.md). New team members will initially contribute work towards code insights under the umbrella of the [web team](../web/index.md) and split off into their own independent team once we have enough team members.
+-  We're hiring [frontend engineers](../hiring/software-engineer-code-insights-frontend.md) and [backend engineers](../hiring/software-engineer-backend.md) for this team!


### PR DESCRIPTION
So it's clear on the org page as well (which pulls from this page). 

@felixfbecker I discussed with @jeanduplessis this week and we think it makes sense that as soon as we make our first full-time hire, we become a separate team (separate retro/standup etc) so I removed the sentence about the web team parenting us. 