### PR TITLE
Add link to design workflow from eng onboarding

### DIFF
--- a/handbook/engineering/onboarding/software-engineer-onboarding.md
+++ b/handbook/engineering/onboarding/software-engineer-onboarding.md
@@ -40,6 +40,7 @@ There will be plenty for you to read and learn about when you're not working on 
 - Read through the rest of the engineering handbook to learn more about how we operate.
 - Read how we choose and continually update our [goals](../../../company/goals/index.md).
 - Read how we plan and keep each other up to date with [tracking issues](../tracking_issues.md).
+- Read how we collaborate with design to [request or implement design work](../../product/design/index.md#working-with-design-requesting-design-work). 
 - Watch this [high-level overview of the Sourcegraph repository on Github](https://drive.google.com/file/d/1Godo2cFIIEBfKg23SOygta1cbSccpICE/view?usp=sharing)
 - Frontend engineers should watch [Figma for Sourcegraphers part 1](https://drive.google.com/file/d/1zzUKDJN5XUwvKF8LfKZqQb7gK9NpK1Wx/view?usp=sharing) to learn about how design and engineering work together. [Part 2, working with the Wildcard design system](https://drive.google.com/file/d/1kfT3PVvTag_e0RXLAt6nndf6fS2n1Slv/view?usp=sharing) shows how to work with our design system and may be interesting for anyone who wants to submit designs.
 


### PR DESCRIPTION
@AlicjaSuska and I were chatting and thought we should add this to eng onboarding so all engineers are aware of how they can request or track design work. 

I think it applies to more than just frontend engineers since we encourage all of our engineers to take active roles in surfacing design issues, and because someone may be working on the backend that's dependent on a frontend design or is requested to comment on a design and they need to know what "stage" the design is in. I think that this section is a good place to link from if we agree that we want to include this at the onboarding level. 