### PR TITLE
Fixes news page styling on mobile

### DIFF
--- a/website/src/components/NewsList.tsx
+++ b/website/src/components/NewsList.tsx
@@ -8,7 +8,7 @@ class News extends React.Component {
                 {NewsData.map((newsYear: { year: React.ReactNode }, index: any) => (
                     <div className="row">
                         <div className="col-lg-2">
-                            <h3 id="{'news' + newsYear.year}" className="news__year">{newsYear.year}</h3>
+                            <h3 id={'news' + newsYear.year} className="news__year">{newsYear.year}</h3>
                         </div>
                         <div className="col-lg-10 container-fluid">
                             {newsYear.articles.map((a, i) => (

--- a/website/src/components/NewsList.tsx
+++ b/website/src/components/NewsList.tsx
@@ -4,11 +4,11 @@ import NewsData from '../data/news-listing'
 class News extends React.Component {
     public render(): JSX.Element {
         return (
-            <div>
+            <div className="container">
                 {NewsData.map((newsYear: { year: React.ReactNode }, index: any) => (
                     <div className="row">
                         <div className="col-lg-2">
-                            <h3 id="news2020">{newsYear.year}</h3>
+                            <h3 id="{'news' + newsYear.year}" className="news__year">{newsYear.year}</h3>
                         </div>
                         <div className="col-lg-10 container-fluid">
                             {newsYear.articles.map((a, i) => (

--- a/website/src/css/pages/_news.scss
+++ b/website/src/css/pages/_news.scss
@@ -5,11 +5,24 @@
     &__image {
         width: 100%;
         max-width: 150px;
-	margin-bottom: 1rem;
+        margin-bottom: 1rem;
     }
-   &__date {
-	font-size: 0.9em;
-	margin-left: .5em;
-	opacity: .7;
+    &__date {
+        font-size: 0.9em;
+        margin-left: 0.5em;
+        opacity: 0.7;
+    }
+
+    /* Mobile Portrait */
+    @media only screen and (max-device-width: 667px) and (orientation: portrait) {
+        &__year {
+            text-align: center;
+            font-size: 2rem;
+        }
+
+        &__image {
+            max-width: 100px;
+            margin-bottom: 0;
+        }
     }
 }


### PR DESCRIPTION
Fixes the styling of the news page on mobile.

## BEFORE
![about sourcegraph com_news_(iPhone 6_7_8)](https://user-images.githubusercontent.com/492942/105845658-cf981e80-5fe3-11eb-8b5c-094c900989d2.png)

## AFTER
![localhost_8000_news(iPhone 6_7_8)](https://user-images.githubusercontent.com/492942/105845732-ea6a9300-5fe3-11eb-9287-54373f6ad984.png)
