### PR TITLE
Remove inline link in 3.24 blog description

### DIFF
--- a/blogposts/2021/release-3.24.md
+++ b/blogposts/2021/release-3.24.md
@@ -18,8 +18,8 @@ changelogItems:
   - description: "The `serviceType` field is now deprecated and will be removed completely in a future release. The `serviceKind` field of the `ExternalServiceKind` type has been added to `Repository.externalURLs` GraphQL API."
     url: https://github.com/sourcegraph/sourcegraph/issues/14979
     category: API
-  - description: "The minimum Kubernetes version required to use the [Kubernetes deployment option](https://docs.sourcegraph.com/admin/install/kubernetes) is now v1.15 (released June 2019)."
-    url: "https://kubernetes.io/blog/2019/06/19/kubernetes-1-15-release-announcement/"
+  - description: "The minimum Kubernetes version required to use the Kubernetes deployment option is now v1.15 (released June 2019)."
+    url: "https://docs.sourcegraph.com/admin/install/kubernetes"
     category: Admin
   - description: "The endpoint for \"Open in Sourcegraph\" functionality in editor extensions now uses code host connection information to resolve the repository, which makes it more correct and respect the `repositoryPathPattern` setting."
     url: https://github.com/sourcegraph/sourcegraph/pull/16846


### PR DESCRIPTION
Having an inline link (which I copied from our changelog entry and forgot to check over; my bad) breaks our render and leaves an empty section. 

This should fix that. 

(I think this specific issue might be worth calling out in whatever handbook documentation we make on release blog posts after product+marketing has had their release blog discussion. If that discussion is not going to happen before the next release, please let me know and I'll add some note to what we have instead around release blogposts now. Specifically, to catch this locally you must run `yarn serve` instead of `yarn run`.)  