### PR TITLE
Clarifying Productboard Slack integration behavior

### DIFF
--- a/handbook/product/user_feedback.md
+++ b/handbook/product/user_feedback.md
@@ -79,7 +79,7 @@ We aggregate all of this feedback in [productboard](https://sourcegraph.productb
 
 All of the above sources of feedback (with the exception of HubSpot forms) require the team help forward that data into productboard using an available integration:
 
-- **Slack integration:** Hover on a message containing feedback, select the more actions menu (three vertical dots), and then choose 'Push to productboard'.
+- **Slack integration:** Hover on a message containing feedback, select the more actions menu (three vertical dots), and then choose 'Push to productboard'. This will post a message to the thread/channel that's visible, so keep that in mind if customers are in the channel.
 - **[browser extension](https://chrome.google.com/webstore/detail/productboard-make-product/mlpbdkpkicfkhgagnoamdcimmhdkakni?hl=en):** Use the browser extension for quick entry from a web page, or to just simply enter information when you think of it.
 - **[forwarding email address](mailto:inbox-hkpsum5melnwcauyjvztbtsq@inbound.productboard.com):** You can forward email threads, or write notes as emails to push information to productboard.
 


### PR DESCRIPTION
Productboard posts a visible note if you create something from Slack, which surprised me in a customer thread today. Noting the behavior here.