### PR TITLE
ce: route alerts and panels based on owner

### DIFF
--- a/handbook/ce/routing_questions.md
+++ b/handbook/ce/routing_questions.md
@@ -26,9 +26,11 @@ If asking the Distribution team in their Slack channel, ping the [on-call dev](.
 
 ## Monitoring, management, and performance optimization
 
-**Keywords**: `scaling`, `resources`, `performance`/`perf`, `monitoring`, `Grafana`, `Prometheus`
+**Keywords**: `scaling`, `resources`, `performance`/`perf`, `monitoring`, `Grafana`, `Prometheus`, `alert`, `dashboard`
 
-Any questions about monitoring and performance should be routed to the [Distribution team](../engineering/distribution/index.md).
+Questions about specific alerts and graph panels should be routed to the team that owns the alert or panel, as indicated by relevant entry in [Alert solutions](https://docs.sourcegraph.com/admin/observability/alert_solutions) or the [Dashboards reference](https://docs.sourcegraph.com/admin/observability/dashboards) respectively.
+
+Any other questions about monitoring and performance should be routed to the [Distribution team](../engineering/distribution/index.md).
 
 If asking the Distribution team in their Slack channel, ping the [on-call dev]../engineering/distribution/index.md#support-rotation).
 


### PR DESCRIPTION
All _Observables_ (alerts and panels) have been attached to an owner for a while (since https://github.com/sourcegraph/sourcegraph/issues/12010), this information is now consistently available across both alert solutions and the dashboards reference. Questions about specific alerts and panels should now to directly go the owning team first

![image](https://user-images.githubusercontent.com/23356519/106017058-0745ba00-60fb-11eb-9cbd-4baa6097bef8.png)
