### PR TITLE
add link to CMM role from marketing roles page

### DIFF
--- a/handbook/marketing/roles/index.md
+++ b/handbook/marketing/roles/index.md
@@ -1,4 +1,5 @@
 # Marketing roles
 - [Director of Community](./director_of_community.md)
+- [Customer Marketing Manager](customer_marketing_manager.md)
 
 See our [careers page](../../../company/careers.md) for open positions and more info.


### PR DESCRIPTION
Adds a link to the new Customer Marketing Manager role from https://about.sourcegraph.com/handbook/marketing/roles.