### PR TITLE
Add security tooling page - private for now

### DIFF
--- a/handbook/engineering/security/index.md
+++ b/handbook/engineering/security/index.md
@@ -29,6 +29,7 @@ See [security goals and priorities](goals.md)
 - Increase our security posture by running traditional security tools such as vulnerability scanners, SAST, and DAST tools.
   - https://github.com/sourcegraph/sourcegraph/security/code-scanning
   - [Infrastructure information](./infrastructure/index.md)
+  - [Security tooling](./tooling/index.md)
 - Create a culture of security at Sourcegraph that empowers all of our engineers to write secure code.
 
 ## How we work

--- a/handbook/engineering/security/tooling/index.md
+++ b/handbook/engineering/security/tooling/index.md
@@ -1,0 +1,3 @@
+# Security tooling
+
+Tools used by the security team. Sensitive information stored in [Google Drive](https://docs.google.com/document/d/10oocqojeIM0uZpcOl6L76afDYj3-MLsFxRK2jhOg93E/).


### PR DESCRIPTION
Add security tooling page to link to my WIP document about security tooling. Hopefully we'll be more comfortable disclosing this information publicly later, but for now, we're not comfortable enough telling hackers where we're watching.