### PR TITLE
Add the web team's code reviews process

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -198,6 +198,13 @@ We do regular backlog triages together, where we go through [the issues in our b
 This helps us resurface older issues, create shared awareness for existing deficiencies among everyone on our team and ensures no-longer-applicable issues are closed.
 To manage the load for these triages, a triage may have a specific theme, like "debt" or "performance".
 
+### Code reviews
+
+The team follow's the [default code review guidelines](../code_reviews.md) with the following addition:
+
+1. If the author would like any of the requested reviewers to merge the PR after approval they add the label `merge-on-any-approve`
+1. If the author would like their PR to be merged once all of the requested reviewers have approved it they add the label `merge-on-all-approve`
+
 ## Team syncs
 
 The web team holds weekly syncs.


### PR DESCRIPTION
Adds 2 labels, and document the process, for PR authors to provide a signal when the author is happy for the reviewer(s) to merge their PR if they approve it.

<img width="999" alt="screen-capture--2021-02-01--1456@2x" src="https://user-images.githubusercontent.com/492942/106463239-d6210d00-649f-11eb-8058-2725370280c2.png">
