### PR TITLE
Fix goal top level linking

### DIFF
--- a/handbook/engineering/campaigns/goals.md
+++ b/handbook/engineering/campaigns/goals.md
@@ -1,4 +1,4 @@
-# Campaigns goals
+# Goals
 
 The campaigns team is building the best solution available for creating and managing large scale changes. To do so we will focus on the following objectives:
 


### PR DESCRIPTION
I actually broke that earlier, trying to make this page more search friendly with a "Campaigns Goals" title.
For the record, the Goals section needs to have a "Goals" title so as to be pulled into https://about.sourcegraph.com/company/goals
Thanks @chrispine for noticing.