### PR TITLE
Fix Goals link from company goals

### DIFF
--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -2,7 +2,7 @@
 
 Goals are continuously updated and reviewed. If you find these goals do not reflect our current priorities or are out of date, please update them as soon as possible or add it as a topic to our [weekly sync](recurring_processes.md#weekly-distribution-team-sync).
 
-## Active goals
+## Goals
 
 Progress toward our active goals is described in our [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Atracking+label%3Ateam%2Fdistribution).
 


### PR DESCRIPTION
The [company goals page](https://about.sourcegraph.com/company/goals) expects a Goals heading to parse the team goals.