### PR TITLE
Slight tweaks so we can start adding more support-related stuff here

### DIFF
--- a/handbook/ce/customer-support-onboarding.md
+++ b/handbook/ce/customer-support-onboarding.md
@@ -1,0 +1,3 @@
+#Customer Support Onboarding
+
+Welcome to Sourcegraph, to the Customer Engineering department, and the Customer Support team! This document will guide you through customer support-specific onboarding. It builds on our company onboarding and focuses on everything you need to be successfull in this particular role.

--- a/handbook/ce/customer-support-onboarding.md
+++ b/handbook/ce/customer-support-onboarding.md
@@ -1,3 +1,5 @@
-# Customer Support Onboarding
+# Customer Support Onboarding (WIP)
+
+Currently a work-in-progress; expected to have a working version 1 by 2021-02-19
 
 Welcome to Sourcegraph, to the Customer Engineering department, and the Customer Support team! This document will guide you through customer support-specific onboarding. It builds on our company onboarding and focuses on everything you need to be successfull in this particular role.

--- a/handbook/ce/customer-support-onboarding.md
+++ b/handbook/ce/customer-support-onboarding.md
@@ -2,4 +2,4 @@
 
 Currently a work-in-progress; expected to have a working version 1 by 2021-02-19
 
-Welcome to Sourcegraph, to the Customer Engineering department, and the Customer Support team! This document will guide you through customer support-specific onboarding. It builds on our company onboarding and focuses on everything you need to be successfull in this particular role.
+Welcome to Sourcegraph, to the Customer Engineering department, and the Customer Support team! This document will guide you through customer support-specific onboarding. It builds on our company onboarding and focuses on everything you need to be successful in this particular role.

--- a/handbook/ce/customer-support-onboarding.md
+++ b/handbook/ce/customer-support-onboarding.md
@@ -1,3 +1,3 @@
-#Customer Support Onboarding
+# Customer Support Onboarding
 
 Welcome to Sourcegraph, to the Customer Engineering department, and the Customer Support team! This document will guide you through customer support-specific onboarding. It builds on our company onboarding and focuses on everything you need to be successfull in this particular role.

--- a/handbook/ce/index.md
+++ b/handbook/ce/index.md
@@ -13,7 +13,7 @@ We work with many other teams at Sourcegraph, including:
 ---
 
 * [Customer Engineering Onboarding](onboarding.md)
-* [Customer Support Onboarding] (customer-support-onboarding.md)
+* [Customer Support Onboarding](customer-support-onboarding.md)
 * [Team members](#members)
 * [Customer notes](customer-notes.md)
 * [Training session and demo flows](training.md)

--- a/handbook/ce/index.md
+++ b/handbook/ce/index.md
@@ -12,7 +12,8 @@ We work with many other teams at Sourcegraph, including:
 
 ---
 
-* [Onboarding](onboarding.md)
+* [Customer Engineering Onboarding](onboarding.md)
+* [Customer Support Onboarding] (customer-support-onboarding.md)
 * [Team members](#members)
 * [Customer notes](customer-notes.md)
 * [Training session and demo flows](training.md)

--- a/handbook/index.md
+++ b/handbook/index.md
@@ -50,7 +50,7 @@ The handbook is a living document and we expect every teammate to propose improv
 ### [Customer Engineering](ce/index.md)
 
 - [Customer Engineering](ce/index.md)
-- [Customer Technical Support](ce/support.md)
+- [Customer Support](ce/support.md)
 - Customer Training (TODO)
 
 ### [Marketing](marketing/index.md)


### PR DESCRIPTION
- Changed support name on main page to Customer Support
- Changed "onboarding" on CE page to "Customer Engineering Onboarding" so it's clearer for new CSE hires later
- Added page for support onboarding

@emchap since this is my first time adding a new page and making changes this way, can you do a quick review and just make sure I haven't broken anything? Thank you!