### PR TITLE
Read sourcegraphSourceUrl cookie value into HubSpot forms

### DIFF
--- a/website/src/components/HubSpot.tsx
+++ b/website/src/components/HubSpot.tsx
@@ -1,6 +1,7 @@
 import cookies from 'js-cookie'
 
 export const SOURCEGRAPH_ANONYMOUS_ID_KEY = 'sourcegraphAnonymousUid'
+export const SOURCEGRAPH_SOURCE_URL_KEY = 'sourcegraphSourceUrl'
 export interface HubSpotForm {
     portalId: string
     formId: string
@@ -15,6 +16,7 @@ export function createHubSpotForm({ portalId, formId, targetId, onFormSubmit, on
     const hubspot = document.getElementById(targetId)
     hubspot!.appendChild(script)
     const anonymousId = cookies.get(SOURCEGRAPH_ANONYMOUS_ID_KEY)
+    const firstSourceURL = cookies.get(SOURCEGRAPH_SOURCE_URL_KEY)
     script.addEventListener('load', () => {
         ;(window as any).hbspt.forms.create({
             portalId,
@@ -30,6 +32,12 @@ export function createHubSpotForm({ portalId, formId, targetId, onFormSubmit, on
                     if (anonymousIdInput && anonymousIdInput.value === '') {
                         // Populate the hidden anonymous_user_id form field with the value from the sourcegraphAnonymousUid cookie.
                         anonymousIdInput.value = anonymousId || ''
+                    }
+
+                    const firstSourceURLInput = form.querySelector<HTMLInputElement>('input[name="first_source_url"]')
+                    if (firstSourceURLInput && firstSourceURLInput.value === '') {
+                        // Populate the hidden first_source_url form field with the value from the sourcegraphSourceUrl cookie.
+                        firstSourceURLInput.value = firstSourceURL || ''
                     }
                 }
                 if (onFormReady) {


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/17972. 

Reads the value from the `sourcegraphSourceUrl` cookie and sends it with HubSpot form submissions. Allows us to associate a user with the first ever Sourcegraph URL they visited.