### PR TITLE
Revert "Add open graph tags to handbook"

### DIFF
--- a/_resources/templates/document.html
+++ b/_resources/templates/document.html
@@ -4,17 +4,7 @@
 
 {{define "head"}}
 	{{if (or (not .Content) .ContentVersion)}}<meta name="robots" content="noindex">{{end}}
-        {{with .Content}}
-		<link rel="canonical" href="https://about.sourcegraph.com/{{.Path}}">
-		<meta name="twitter:title" content="{{.Doc.Title}} - Sourcegraph" />
-		<meta name="twitter:site" content="@srcgraph" />
-		<meta name="twitter:image" content={{asset "sourcegraph-mark.png"}} />
-		<meta name="twitter:card" content="summary" />
-		<meta property="og:type" content="website" />
-		<meta property="og:title" content="{{.Doc.Title}} - Sourcegraph" />
-		<meta property="og:image" content={{asset "sourcegraph-mark.png"}} />
-		<meta property=”og:url” content=”https://about.sourcegraph.com” />
-	{{end}}
+        {{with .Content}}<link rel="canonical" href="https://about.sourcegraph.com/{{.Path}}">{{end}}
 {{end}}
 
 {{define "content"}}


### PR DESCRIPTION
Reverts sourcegraph/about#2389

Need additional tags - Twitter sees 11 metatags on handbook page, whereas the home page returns 17 metatags.