### PR TITLE
Change web team PM listings to reflect Joel's scope

### DIFF
--- a/handbook/engineering/web/index.md
+++ b/handbook/engineering/web/index.md
@@ -14,9 +14,9 @@ This is a large ownership area, so the team creates a focused plan each iteratio
 ## Members
 
 <!-- Due to the markdown renderer that we use, the indentation here is sensitive. If you want to change the indentation, check that it renders correctly locally with `make serve` -->
-- [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/index.md#product-manager)*)
 - [Alicja Suska](../../../company/team/index.md#alicja-suska-she-her) ([Product Designer](../../product/roles/index.md#product-designer))
 - [Frontend platform](index.md) {#frontend-platform-eng}
+   - We're hiring a [Product Manager](../../product/roles/index.md#product-manager) ([apply here](https://jobs.lever.co/sourcegraph/254299f5-f91b-43e2-aa1a-3732963dd296)) for this role. Alicja and Jean are involved in the meantime. 
    - FQ1 [Engineering Manager](../roles.md#engineering-manager), Jean acting manager until then.
          - [Tom Ross](../../../company/team/index.md#tom-ross-he-him)
          - [Felipe Janer](../../../company/team/index.md#felipe-janer-he-him)
@@ -24,14 +24,13 @@ This is a large ownership area, so the team creates a focused plan each iteratio
          - FQ3 frontend engineer
          - FQ4 frontend engineer
 - [Extensibility](index.md) {#extensibility-eng}
+   - [Joel Kwartler](../../../company/team/index.md#joel-kwartler-he-him) ([Product Manager](../../product/roles/index.md#product-manager)) is the acting PM for this team until we can hire a dedicated PM for it ([apply here](https://jobs.lever.co/sourcegraph/254299f5-f91b-43e2-aa1a-3732963dd296)). Once that happens, Joel will focus entirely on code insights. 
    - FQ3 [Engineering Manager](../roles.md#engineering-manager), Jean acting manager until then.
          - [Marek Zaluski](../../../company/team/index.md#marek-zaluski)
          - [TJ Kandala](../../../company/team/index.md#tharuntej-kandala-he-him)
          - M.S. 2021-02-15
          - FQ2 frontend engineer
          - FQ4 frontend engineer
-
-_* Joel is the acting PM for this team until we are able to hire a dedicated PM for it. Once that happens, he will focus entirely on code insights._  
 
 ## Contact
 


### PR DESCRIPTION
Merge on any approvals; just wanted to confirm this org listing format makes sense here (splitting to two PM slots from 1 prior).  The product team doesn't have an explicit "Q1, Q2" for PM hires (I think they're all a priority-ordered ASAP since we're already behind) so there wasn't a direct parallel there. 