### PR TITLE
Reorder the campaign sprint planning to look at product board and One Big Thing first

### DIFF
--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -79,9 +79,9 @@ Our two-week sprints start every other Wednesday. We follow this process:
 
 * We then have our planning meeting to determine our common goals for the iteration.
   * First we verify that any unfinished items in the old sprint will be finished by EOD.
-  * Next, we look at all of the items in the new sprint, to verify that these are our highest priority items that we definitely want to finish this sprint. (These tend to be smaller items, like bug fixes, or work carrying over from the previous sprint.) These should all be prioritized as P0s in the planning project. (If they are not P0s, then we remove the milestone and assing the correct priority.)
   * Then we look at our [roadmap in Productboard](https://sourcegraph.productboard.com/roadmap/2263724-campaigns-releases) to align on priorities and verify estimates. *The goal is to have a freshly prioritized roadmap.*
-  * We work as a team to assign One Big Thing to each engineer.
+  * We work as a team to assign One Big Thing to each engineer, creating tickets as needed and putting them in the current sprint and P0 column.
+  * We look at all of the items in our planning board (including the "Needs prioritization" tickets), ordering them by priority into P0, P1, P2. (These tend to be smaller items, like bug fixes, or work carrying over from the previous sprint.) P0 tickets get the current sprint as a milestone.
   * Finally, we verify that the sum of the estimates of our P0 column is does not exceed 2 days per engineer. In other words:
      * `issues.filter(p0).map(estimate).sum <= (num_engineers * 2).days`
 

--- a/handbook/engineering/campaigns/index.md
+++ b/handbook/engineering/campaigns/index.md
@@ -82,7 +82,7 @@ Our two-week sprints start every other Wednesday. We follow this process:
   * Then we look at our [roadmap in Productboard](https://sourcegraph.productboard.com/roadmap/2263724-campaigns-releases) to align on priorities and verify estimates. *The goal is to have a freshly prioritized roadmap.*
   * We work as a team to assign One Big Thing to each engineer, creating tickets as needed and putting them in the current sprint and P0 column.
   * We look at all of the items in our planning board (including the "Needs prioritization" tickets), ordering them by priority into P0, P1, P2. (These tend to be smaller items, like bug fixes, or work carrying over from the previous sprint.) P0 tickets get the current sprint as a milestone.
-  * Finally, we verify that the sum of the estimates of our P0 column is does not exceed 2 days per engineer. In other words:
+  * Finally, we verify that the sum of the estimates of our P0 column does not exceed 2 days per engineer. In other words:
      * `issues.filter(p0).map(estimate).sum <= (num_engineers * 2).days`
 
 * After sprint planning, the team has a retro to discuss how the previous sprint went, and what changes we might want to our working agreements.


### PR DESCRIPTION
In yesterday's planning session we spent the _majority_ of the time looking at all the tickets in our planning board, often discussing whether it's technically feasible, ready to implement, what an estimate would be, etc.

All the while we already knew roughly what the One Big Thing for each engineer could/should be, but that still needed discussion and input from product.

In the retrospective we then said that we should probably get an overview of what the big things we need or want to do are, before we dive into the nitty gritty of tickets.

This PR now reorders the planning algorithm to follow this structure:

1. Verify old sprint is done/move old stuff over
2. Get the bigger picture: what does product want, what do the engineers want to work on for their one big thing
3. Then look at the other things we need to work on that are in our planning board
4. Prioritize and verify that we're not overloaded, possible reorder