### PR TITLE
Updated "Other Tools" table styling so text is visible

### DIFF
--- a/workflow/index.md
+++ b/workflow/index.md
@@ -57,11 +57,11 @@ See product comparisons and integrations with:
     .gray {
         background-color: #222;
     }
-    .tooltip .tooltiptext {
+    .tooltip-container .tooltiptext {
         display: none;
         position: absolute;
     }
-    .tooltip:hover .tooltiptext {
+    .tooltip-container:hover .tooltiptext {
         display: inline-block;
         visibility: visible;
         width: 250px;
@@ -93,7 +93,7 @@ See product comparisons and integrations with:
 </tr>
 
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Basic text and file search
         <span class="tooltiptext">
             Offers some search capabilities over code, often very limited and not tailored to core code search use cases.
@@ -107,7 +107,7 @@ See product comparisons and integrations with:
 </tr>
 
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Symbol search
         <span class="tooltiptext">The ability to search specifically for function, class, and variable names, while filtering out noise from matches in non-code files, comments, and string constants.</span>
     </td>
@@ -119,7 +119,7 @@ See product comparisons and integrations with:
 </tr>
 
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Regular expressions
         <span class="tooltiptext">Regular expressions ("regex") are a powerful pattern-matching syntax used for many types of patterns found in code, such as similarly named functions, anti-patterns that should be avoided, and fuzzy matching.</span>
     </td>
@@ -130,7 +130,7 @@ See product comparisons and integrations with:
     <td class="green"></td>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Multi-repository regex search
         <span class="tooltiptext">Regular expression search is especially useful when you can look for patterns and anti-patterns across all repositories in your organization.</span>
     </td>
@@ -141,7 +141,7 @@ See product comparisons and integrations with:
     <td class="green"></td>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         <a href="https://comby.dev/" target="_blank">Comby syntax</a>
         <span class="tooltiptext">
             A powerful pattern-matching syntax that goes beyond regular expressions and makes it easy to match common patterns in code (like balanced parens) that are hard to describe in regex.
@@ -162,7 +162,7 @@ See product comparisons and integrations with:
     <td class="gray"></td>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Universal search
         <span class="tooltiptext">
             Most engineering organizations have multiple repositories and code hosts. Universal search lets you search across all repositories, wherever they may be hosted, while obeying whatever permissions are defined.
@@ -188,7 +188,7 @@ See product comparisons and integrations with:
     <td class="green"></td>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Symbol outline
         <span class="tooltiptext">
             View an outline of functions, classes, and variables defined in a code file.
@@ -201,7 +201,7 @@ See product comparisons and integrations with:
     <td class="green"></td>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Basic code intelligence
         <span class="tooltiptext">Jump-to-definition within the same file, in some languages</span>
     </td>
@@ -212,7 +212,7 @@ See product comparisons and integrations with:
     <td class="gray"></td>
 </tr>
 <tr>
-    <td class="tooltip">Universal code intelligence
+    <td class="tooltip-container">Universal code intelligence
         <span class="tooltiptext">Jump-to-definition across files and repositories, most languages</span>
     </td>
     <td class="green"></td>
@@ -236,7 +236,7 @@ See product comparisons and integrations with:
     <th colspan="20"></th>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Integrates with major code hosts and code review
         <span class="tooltiptext">
             Whatever code host or code review tool is used, makes code searchable, navigable, and accessible.
@@ -249,7 +249,7 @@ See product comparisons and integrations with:
     <td class="gray"></td>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Extensions
         <span class="tooltiptext">
             Third-party and internal developer tools integrating directly into search and code browsing UI.
@@ -270,7 +270,7 @@ See product comparisons and integrations with:
     <td class="gray"></td>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         Code-as-data GraphQL API
         <span class="tooltiptext">
             GraphQL API supports structured information about source code that is used to power smart internal developer tools
@@ -283,7 +283,7 @@ See product comparisons and integrations with:
     <td class="gray"></td>
 </tr>
 <tr>
-    <td class="tooltip">
+    <td class="tooltip-container">
         On-prem deployment
         <span class="tooltiptext">
             Can be deployed on-premises in a deployment environment you control and which obeys the security policies you set.


### PR DESCRIPTION
Text was hidden due to a conflicting style named "tooltip" defined in bootstrap.min.css.  I don't see boostrap included when I run the handbook site locally.  So, it seems unlikely that this .tooltip style was intended to come from bootstrap.