### PR TITLE
Clarifying current vs. future state

### DIFF
--- a/handbook/ce/license_keys.md
+++ b/handbook/ce/license_keys.md
@@ -25,18 +25,13 @@ First, the company's Sourcegraph administrator must create a Sourcegraph.com use
   - `true-up` to allow the company to go over the user limit on the license.
   - `mau` to indicate that the company is on a monthly usage-based billing model.
   - `trial` to show an indicate in Sourcegraph that the company is on a trial.
-  - `plan:team-<version>` to indicate that the company is on team tier, on the given version, e.g. `plan:team-0` (please consult with Sales for the version).
-  - `plan:enterprise-<version>` to indicate that the company is on enterprise tier, on the given version, e.g. `plan:enterprise-0` (please consult with Sales for the version).
-  - Within the enterprise tier, every feature needs to be included explicitly with a tag, including:
-     - `acls`: Whether ACLs may be used, such as GitHub, GitLab or Bitbucket Server repository permissions and integration with GitHub, GitLab or Bitbucket Server for user authentication.
-     - `private-extension-registry`: Whether publishing extensions to this Sourcegraph instance has been purchased. If not, then extensions must be published to Sourcegraph.com. All instances may use extensions published to Sourcegraph.com.
-     - `remote-extensions-allow-disallow`: Whether explicitly specify a list of allowed remote extensions and prevent any other remote extensions from being used has been purchased. It does not apply to locally published extensions.
-     - `branding`: Whether custom branding of this Sourcegraph instance has been purchased.
-     - `campaigns`: Whether campaigns on this Sourcegraph instance has been purchased.
-     - `monitoring`: Whether monitoring on this Sourcegraph instance has been purchased.
-     - `backup-and-restore`: Whether builtin backup and restore on this Sourcegraph instance has been purchased.
-  - If no `plan:*` tag is supplied, the license will be treated as legacy enterprise tier which has unlimited access to all features.
-  - And the company's name (with dashes instead of spaces), to make it easy to search for a given license key in the future.
+  - `enterprise` for Enterprise licenses (formerly Enterprise Full), without campaigns
+  - `campaigns` to add Campaigns to an Enterprise license
+  - `team` for the Team plan
+  - `starter` for the Enterprise Starter plan, which functions as Team without user limits (a historical plan—only used for existing customers on this plan, not for new customers or trials)
+  - `internal` for licenses used for internal sites (dotcom, k8s, etc.)
+  - `dev` for internal developer licenses
+  - The company's name (with dashes instead of spaces), to make it easy to search for a given license key in the future.
 - Set the licensed number of users (note that if you added the `true-up` tag above, the company will be able to exceed this count, but administrators will see a warning) and the number of days that the license should be valid, and click **Generate license**.
 - Finally, click on the **View as user** link, and share the resulting URL with the company.
 
@@ -44,6 +39,22 @@ A typical email to send to a company is:
 
 >Hi,
 >I just created a new license key for you that you can find at ___! Just click **Reveal license key**, copy the key, and then save it to your Sourcegraph's site configuration in the `licenseKey` field.
+
+## Future state
+
+Right now, we only use `enterprise`, `team`, and `campaigns` to indicate plan and features. In the future we will use more granular plans:
+
+  - `plan:team-<version>` to indicate that the company is on team tier, on the given version, e.g. `plan:team-0` (Sales will own knowing the version).
+  - `plan:enterprise-<version>` to indicate that the company is on enterprise tier, on the given version, e.g. `plan:enterprise-0` (Sales will own knowing the version).
+  - Within the enterprise tier, every feature will need to be included explicitly with a tag, including:
+     - `acls`: Whether external code host auth services may be used, such as GitHub, GitLab or Bitbucket Server repository permissions and integration with GitHub, GitLab or Bitbucket Server for user authentication.
+     - `private-extension-registry`: Whether publishing extensions to this Sourcegraph instance has been purchased. If not, then extensions must be published to Sourcegraph.com. All instances may use extensions published to Sourcegraph.com.
+     - `remote-extensions-allow-disallow`: Whether explicitly specify a list of allowed remote extensions and prevent any other remote extensions from being used has been purchased. It does not apply to locally published extensions.
+     - `branding`: Whether custom branding of this Sourcegraph instance has been purchased.
+     - `campaigns`: Whether campaigns on this Sourcegraph instance has been purchased.
+     - `monitoring`: Whether monitoring on this Sourcegraph instance has been purchased.
+     - `backup-and-restore`: Whether builtin backup and restore on this Sourcegraph instance has been purchased.
+  - For now, if no `plan:*` tag is supplied, the license will be treated as legacy enterprise tier which has unlimited access to all features.
 
 ## How to delete a license key
 


### PR DESCRIPTION
Per https://sourcegraph.slack.com/archives/CHPC7UX16/p1613994761006200?thread_ts=1613061743.251900&cid=CHPC7UX16

I'm clarifying this because it's caused confusion for me twice—once when asking an AE for an enterprise version for a key (confusing them) and once because a customer is on an old Starter license and what that meant was really unclear. Are we okay keeping it split like this until we launch the future state?