### PR TITLE
Add Alex Fogg to team pages

### DIFF
--- a/company/team/index.md
+++ b/company/team/index.md
@@ -728,3 +728,10 @@ Outside of work, he enjoys golfing, cheering on his favorite LA sports teams and
 - GitHub: [northyg](https://github.com/northyg)
 - [giselle@sourcegraph.com](mailto:giselle@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/giselle-northy/), [Pronounce my name 🔊](https://www.pronouncenames.com/search?name=Giselle)
 - Giselle is a long time nerd who has dabbled in coding and PC games for many years. She started her tech career after several twists and turns, followed by a short stint in Sales & Marketing. At work her passions include automating the boring, creating an amazing customer experience, leveling up coding skills, and learning something new every day! Outside of work, she enjoys spending time with family, her fur children Odin the dog, cats Ben & Jerry, exercise, gardening and nature walks.
+
+## Alex Fogg (he/him)
+- Customer Engineer
+- Philadelphia, PA, USA 🇺🇸
+- GitHub: [alexfogg](https://github.com/alexfogg)
+- [afogg@sourcegraph.com](mailto:afogg@sourcegraph.com), [LinkedIn](https://www.linkedin.com/in/alexfogg/)
+- Alex spent the bulk his career working as a software engineer and team lead in NYC at startups and media companies. His love of people, process, communication, and customers led him to the customer engineering role. Alex loves traveling and staying active via hiking/biking/running. He spends his weeknights watching YouTube cooking videos and loves to try out new recipes.

--- a/handbook/ce/index.md
+++ b/handbook/ce/index.md
@@ -58,7 +58,7 @@ CSEs are the go-to technical team for our CEs, helping customers both pre- and p
 - Customer Engineers (US East)
   - [Christine Lovett](../../company/team/index.md#christine-lovett-she-her)
   - [Mike McLaughlin](../../company/team/index.md#mike-mclaughlin-he-him)
-  - A. (starting 2021-02-22)
+  - [Alex Fogg](../../company/team/index.md#alex-fogg-he-him)
   - T. (Director of Customer Engineering, US East; starting 2021-03-01)
 - Customer Support
   - [Virginia Ulrich](../../company/team/index.md#virginia-ulrich-she-her) (Head of Customer Support)


### PR DESCRIPTION
- Add Alex Fogg to the main team page.
- Add Alex Fogg to the CE team page.