### PR TITLE
Remove "SWE - backend - Search" from open positions

### DIFF
--- a/company/careers.md
+++ b/company/careers.md
@@ -16,7 +16,6 @@ Generally, we are not hiring for interns and new grads. The decision to hire int
 - [Engineering Manager - Core Application](https://jobs.lever.co/sourcegraph/95ad534f-8724-45dc-9b50-291c5926a7dc)
 - [Software Engineer - Code Insights - Frontend](https://jobs.lever.co/sourcegraph/73fda68b-c821-4627-af07-41a0850072fb)
 - [Software Engineer - Code Insights - Backend](https://jobs.lever.co/sourcegraph/5a25e568-575a-4209-b887-05f914ff0650)
-- [Software Engineer - Backend](https://jobs.lever.co/sourcegraph/a0dba744-ed1d-4172-8a4a-0feb52609322)
 - [Software Engineer - Distribution](https://jobs.lever.co/sourcegraph/ddef3b91-ce19-4b22-8db4-65e159d7ff2b)
 - [Software Engineer - Security](https://jobs.lever.co/sourcegraph/c36db3e1-0ece-465d-ad7c-1eb6de9a4b22)
 - [Software Engineer - Campaigns - Full Stack / Frontend](https://jobs.lever.co/sourcegraph/886e4343-6efc-4ab1-b204-f9115cfdeae3)

--- a/handbook/engineering/search/index.md
+++ b/handbook/engineering/search/index.md
@@ -60,15 +60,15 @@ Iterations start **every other Monday**.
         - [Keegan Carruthers-Smith](../../../company/team/index.md#keegan-carruthers-smith)
         - [Stefan Hengl](../../../company/team/index.md#stefan-hengl-he-him)
         - R.H., starting March 8
-        - FQ3 [backend engineer](https://jobs.lever.co/sourcegraph/a0dba744-ed1d-4172-8a4a-0feb52609322)
+        - FQ3 backend engineer
 - [Search product](index.md) {#search-product-eng}
     - [Loïc Guychard](../../../company/team/index.md#loïc-guychard) ([Engineering Manager](../roles.md#engineering-manager))
         - [Rijnard van Tonder](../../../company/team/index.md#rijnard-van-tonder)
         - [Juliana Peña](../../../company/team/index.md#juliana-peña-she-her)
         - [Rok Novosel](../../../company/team/index.md#rok-novosel-he-him)
         - [Camden Cheek](../../../company/team/index.md#camden-cheek-hehim)
-        - FQ2 [backend hire](https://jobs.lever.co/sourcegraph/a0dba744-ed1d-4172-8a4a-0feb52609322)
-        - FQ2 frontend hire
+        - FQ2 backend engineer
+        - FQ2 frontend engineer
 
 ## On-call
 

--- a/handbook/people-ops/hiring/index.md
+++ b/handbook/people-ops/hiring/index.md
@@ -56,7 +56,6 @@ We cross-post our open positions to the following locations:
   1. [Director of Engineering - Platform and Infrastructure](https://jobs.lever.co/sourcegraph/8fcbaade-e511-4d93-bd9b-9cc7ec3438af)
   1. [Engineering Manager - Cloud Application and Core Services](https://jobs.lever.co/sourcegraph/95ad534f-8724-45dc-9b50-291c5926a7dc)
   1. [Software Engineer - Cloud - Frontend](https://jobs.lever.co/sourcegraph/b2f9a8b0-cc06-4629-81a0-0f2fa64271c7)
-  1. [Software Engineer - Backend](https://jobs.lever.co/sourcegraph/a0dba744-ed1d-4172-8a4a-0feb52609322)
   1. [Software Engineer - Distribution](https://jobs.lever.co/sourcegraph/ddef3b91-ce19-4b22-8db4-65e159d7ff2b)
   1. [Software Engineer - Security](https://jobs.lever.co/sourcegraph/c36db3e1-0ece-465d-ad7c-1eb6de9a4b22)
   1. [Director of Community](https://jobs.lever.co/sourcegraph/480e8d71-03af-4659-ac90-b8e32ad4ef34)


### PR DESCRIPTION
We've recently closed on a backend hire for the search team. We'll now switch our focus to hiring a frontend engineer.