### PR TITLE
Update distribution goals

### DIFF
--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -20,8 +20,10 @@ Our existing deployment pipelines to our Sourcegraph instances (such as Sourcegr
 
 ## Roadmap
 
-- A high-level roadmap is tracked in [Productboard](https://sourcegraph.productboard.com/roadmap/2612216-fy2022-r-o-distribution).
-- A detailed roadmap is tracked in [ZenHub](https://app.zenhub.com/workspaces/distribution-603e9cc5fbe582000ef238fd/roadmap).
+- A high-level roadmap is tracked in our [roadmap view](https://sourcegraph.productboard.com/roadmap/2612216-fy2022-r-o-distribution)
+- Milestones and their status can be seen in our [current features board](https://sourcegraph.productboard.com/feature-board/2612407-fy2022-roadmap-distribution).
+- A implementation roadmap is tracked in [ZenHub](https://app.zenhub.com/workspaces/distribution-603e9cc5fbe582000ef238fd/roadmap).
+- Future features and goals are tracked in features [planning view](https://sourcegraph.productboard.com/feature-board/2526845-distribution)
 
 ## Past goals
 

--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -6,7 +6,7 @@ Goals are continuously updated and reviewed. If you find these goals do not refl
 
 Progress toward our active goals is described in our [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Atracking+label%3Ateam%2Fdistribution).
 
-### [Collect metrics and feedback about Sourcegraph deployments](https://github.com/orgs/sourcegraph/projects/143)
+### [Understand Sourcegraph site-admin requirements](https://github.com/orgs/sourcegraph/projects/143)
 
 Sourcegraph collects a number of data points through pings that are used to understand how customers use Sourcegraph and drive how we improve the product. We currently do not have any metrics, pings or manual data points collected from site-admins, which makes it impossible for the Distribution team to make educated guesses on features that site-admins require and how projects should be prioritized.
 
@@ -19,7 +19,7 @@ Sourcegraph collects a number of data points through pings that are used to unde
   1. ~~There are processes and tools that allows CEs, CSEs and site-admins provide feedback.~~
   1. We have collected data from 10 site-admins.
 
-### [Improve internal deployment pipeline UX](https://github.com/orgs/sourcegraph/projects/96)
+### [Fast and reliable deployments to Sourcegraph Cloud](https://github.com/orgs/sourcegraph/projects/96)
 
 Our existing deployment pipelines to our Sourcegraph instances (such as Sourcegraph Cloud) has several usability problems - for example, it is hard for engineers to identify when a commit on `sourcegraph/sourcegraph` was deployed to an environment or which deployment is currently running in a particular environment. We want to improve the deployment experience, making sure we can deploy with confidence and can easily understand in which stage of the pipeline a change currently is.
 

--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -14,9 +14,9 @@ Sourcegraph collects a number of data points through pings that are used to unde
 - **Outcomes**:
   - We can survey site-admins actively or passively.
 - **Milestones**:
-  ~~1. We have defined an initial set of data points we wish to collect.
+  1. ~~We have defined an initial set of data points we wish to collect.
   1. We have a tool in place to store and query site-admin data.
-  1. There are processes and tools that allows CEs, CSEs and site-admins provide feedback.
+  1. ~~There are processes and tools that allows CEs, CSEs and site-admins provide feedback.~~
   1. We have collected data from 10 site-admins.
 
 ### [Improve internal deployment pipeline UX](https://github.com/orgs/sourcegraph/projects/96)
@@ -28,8 +28,8 @@ Our existing deployment pipelines to our Sourcegraph instances (such as Sourcegr
   - Our deployment pipeline earns a positive score from Sourcegraph engineering team.
   - Fix the top 5 problems as highlighted by Sourcegraph engineers.
 - **Milestones**:
-  ~~1. Survey all Sourcegraph engineers to score our current deployment pipeline.
-  1. Commits are deployed in a deterministic way to k8s.sgdev.org & sourcegraph.com.
+  1. ~~Survey all Sourcegraph engineers to score our current deployment pipeline.~~
+  1. Commits are deployed in a deterministic way to k8s.sgdev.org & sourcegraph.com. **In Progress**
   1. Engineers can easily identify on which stage of our full CI/CD pipeline is a given commit.
   1. Engineers can determine what release is currently running on a given environment.
   1. Engineers can be notified when their commits have been deployed.

--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -4,7 +4,7 @@ Goals are continuously updated and reviewed. If you find these goals do not refl
 
 ## Goals
 
-Progress toward our goals is described in our [roadmap](#roadmap) and the linked Producboards.
+Progress toward our goals is described in our [roadmap](#roadmap) and the linked Productboards.
 
 ### Understand Sourcegraph site-admin requirements
 

--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -4,133 +4,24 @@ Goals are continuously updated and reviewed. If you find these goals do not refl
 
 ## Goals
 
-Progress toward our active goals is described in our [tracking issue](https://github.com/sourcegraph/sourcegraph/issues?q=is%3Aopen+is%3Aissue+label%3Atracking+label%3Ateam%2Fdistribution).
+Progress toward our goals is described in our [roadmap](#roadmap) and the linked Producboards.
 
-### [Understand Sourcegraph site-admin requirements](https://github.com/orgs/sourcegraph/projects/143)
+### Understand Sourcegraph site-admin requirements
+
+**[Productboard](https://sourcegraph.productboard.com/feature-board/2612407-fy2022-roadmap-distribution/features/7253378/detail/expanded)**
 
 Sourcegraph collects a number of data points through pings that are used to understand how customers use Sourcegraph and drive how we improve the product. We currently do not have any metrics, pings or manual data points collected from site-admins, which makes it impossible for the Distribution team to make educated guesses on features that site-admins require and how projects should be prioritized.
 
-- **Status**: In Progress. _Estimate FY22-Q1_
-- **Outcomes**:
-  - We can survey site-admins actively or passively.
-- **Milestones**:
-  1. ~~We have defined an initial set of data points we wish to collect.~~
-  1. We have a tool in place to store and query site-admin data. **In Progress**
-  1. ~~There are processes and tools that allows CEs, CSEs and site-admins provide feedback.~~
-  1. We have collected data from 10 site-admins.
+### Fast and reliable deployments to Sourcegraph Cloud
 
-### [Fast and reliable deployments to Sourcegraph Cloud](https://github.com/orgs/sourcegraph/projects/96)
+**[Productboard](https://sourcegraph.productboard.com/feature-board/2612407-fy2022-roadmap-distribution/features/7274917/detail/expanded)**
 
 Our existing deployment pipelines to our Sourcegraph instances (such as Sourcegraph Cloud) has several usability problems - for example, it is hard for engineers to identify when a commit on `sourcegraph/sourcegraph` was deployed to an environment or which deployment is currently running in a particular environment. We want to improve the deployment experience, making sure we can deploy with confidence and can easily understand in which stage of the pipeline a change currently is.
 
-- **Status**: In Progress. _Estimated: FY22-Q1_
-- **Outcomes**:
-  - Our deployment pipeline earns a positive score from Sourcegraph engineering team.
-  - Fix the top 5 problems as highlighted by Sourcegraph engineers.
-- **Milestones**:
-  1. ~~Survey all Sourcegraph engineers to score our current deployment pipeline.~~
-  1. Commits are deployed in a deterministic way to k8s.sgdev.org & sourcegraph.com. **In Progress**
-  1. Engineers can easily identify on which stage of our full CI/CD pipeline is a given commit.
-  1. Engineers can determine what release is currently running on a given environment.
-  1. Engineers can be notified when their commits have been deployed.
-  1. Engineers can trigger a deployment of a desired version.
-  1. Engineers can trigger a rollback to a previous version.
-  1. Survey all Sourcegraph engineers again to score the new deployment experience.
-  1. TBD: We can trigger rollbacks and deployments via a `/` command in Slack.
-  1. TBD: Branches can trigger a parallel `sourcegraph-frontend` deployments.
-
-### Deprecate single-docker for production usage
-
-In [RFC 263](https://docs.google.com/document/d/1GPypas4ZUZIw346EcNDM1up2OOQFyPpEzA3-0glPEMY/edit#) we discussed and agreed to deprecate `single-docker` for production usage. The RFC has been approved and we have to take the next steps in removing this deployment type.
-
-- **Status**: Not started. _Estimated: FY22-Q1_
-- **Outcomes**:
-  - No new production deployments are crated using `single-docker` after completion.
-- **Milestones**:
-  1. Create migration docs for customer and Sourcegraph to assist customers.
-  1. Set deprecation notice and announce deprecation in X versions.
-  1. `single-docker` is deprecated for production usage.
-  1. Stretch: Remove the `single-docker` deployment option.
-
-## Future goals
-
-These are ideas for future goals that the team might work on. Just because something is on this list, does not mean it will be worked on next.
-
-### Provide an alternative docker registry
-
-DockerHub announced that they will be rate-limiting image pulls for anonymous and free clients. While we don't anticipate this affecting our customers, we want to have some solution in place in the case some of them are affected.
-
-- **Status**: Not started. TBD
-- **Outcomes**:
-  - We have a mirrored docker repository containing all our old+new builds
-  - Have documentation on how to change the repository that can be used by CE to assist customers
-- **Milestones**: TBD
-
-### Provide a Sourcegraph in a box deployment option
-
-Sourcegraph is currently deployed via three, self serve methods. The only one-step deployment method (the sourcegraph docker image) is being sunsetted. As a result, we need to provide a turn-key full deployment option of Sourcegraph. Thus allowing end users to explore a full featured deployment, without having to understand the complexity of cloud infrastructure.
-
-- **Status**: TBD.
-- **Outcomes**:
-  - Customers can deploy a Sourcegraph docker-compose deployment to 1 cloud provider.
-  - Customers can deploy a Sourcegraph Kubernetes cluster to 1 cloud provider.
-- **Milestones**:
-  - There is a pipeline in place to deploy and version Sourcegraph docker-compose images.
-  - We can deploy a docker-compose in a box version of Sourcegraph to 1 cloud provider.
-  - Docker-compose in a box can be upgraded in place.
-  - We have Infrastructure as Code to deploy a Kuberentes cluster with Sourcegraph from scratch to 1 cloud provider.
-  - Stretch: We can leverage Cloud services of the cloud provider for the required services.
-
-### Improve the debugging and troubleshooting process
-
-As we deploy Sourcegraph to multiple different environments, we need to provide a consistent and straightforward process to debug issues. We are currently lacking tools to collect debugging information (configuration, type, size, diff from upstream, etc) consistently and a process to capture the output of debugging sessions to feed back into our priorities and documentation.
-We will initially focus on reducing the time it takes to collect troubleshooting information.
-
-- **Status**: Not started. Unknown amount of work.
-- **Outcomes**:
-  - We can categorize and capture the amount of effort spent on different incident types.
-  - We can provide a straightforward set of tools to collect initial debugging and deployment information.
-  - TBD
-- **Milestones**: TBD
-
-### Site admins use reliable methods like Docker Compose or Kubernetes for production deployments
-
-Many customers of Sourcegraph today are still running a single-container `sourcegraph/server` deployment in production. In 2019 we began advising all new deployments that this deployment option is _not_ for production use because it has no proper resource isolation and as such when it falls over it is impossible to debug, leading to painstakingly urgent migrations to better deployment types and frustrated/angry customers. We would like to get to a world where all production instances of Sourcegraph use reliable deployment methods like Docker Compose or Kubernetes.
-
-- **Status**: [RFC 263 REVIEW: Single-container deployments are for demos only](https://docs.google.com/document/d/1GPypas4ZUZIw346EcNDM1up2OOQFyPpEzA3-0glPEMY/edit)
-- **Outcomes**:
-  - Customer deployments become more reliable in performance, stability, uptime, etc.
-  - No customers are using the unreliable `sourcegraph/server` for their production deployment.
-  - Customers upgrade to Docker Compose or Kubernetes deployments without any major trouble.
-- **Milestones**:
-  - ~~RFC creation.~~
-  - RFC approval.
-  - ...TBD...
-
-### Support upgrading across multiple Sourcegraph versions
-
-Upgrading from 3.13 -> 3.17 requires you perform 4 individual upgrades today (3.14 -> 3.15 -> 3.16 -> 3.17) which is extremely painful and time consuming for site admins, especially so given how time consuming our upgrade process is in general. We would like to make upgrades across multiple Sourcegraph versions easier.
-
-- **Status**: Not started. Unknown amount of work.
-- **Outcomes**:
-  - Customers can upgrade across multiple versions of Sourcegraph, allowing them to get up-to-date more quickly and easily.
-- **Milestones**:
-
-### Releases can be done automatically
-
-Releases today require manual intervention to finalize release pull requests and address issues that might come up.
-We would like releases to happen seamlessly, and whenever required.
-
-- **Status**: Not started. Unknown amount of work.
-- **Outcomes**:
-  - Release tracking issues are no longer required.
-  - Releases require minimal manual intervention (at most 2-3 actions).
-- **Milestones**:
-  - [Releases can be done automatically (e.g. CLI command, `/` command in Slack, etc.)](https://github.com/orgs/sourcegraph/projects/131)
-
 ## Roadmap
 
-Coming soon.
+- A high-level roadmap is tracked in [Productboard](https://sourcegraph.productboard.com/roadmap/2612216-fy2022-r-o-distribution).
+- A detailed roadmap is tracked in [ZenHub](https://app.zenhub.com/workspaces/distribution-603e9cc5fbe582000ef238fd/roadmap).
 
 ## Past goals
 

--- a/handbook/engineering/distribution/goals.md
+++ b/handbook/engineering/distribution/goals.md
@@ -14,8 +14,8 @@ Sourcegraph collects a number of data points through pings that are used to unde
 - **Outcomes**:
   - We can survey site-admins actively or passively.
 - **Milestones**:
-  1. ~~We have defined an initial set of data points we wish to collect.
-  1. We have a tool in place to store and query site-admin data.
+  1. ~~We have defined an initial set of data points we wish to collect.~~
+  1. We have a tool in place to store and query site-admin data. **In Progress**
   1. ~~There are processes and tools that allows CEs, CSEs and site-admins provide feedback.~~
   1. We have collected data from 10 site-admins.
 


### PR DESCRIPTION
I have made several updates to our Distribution goals and goals format.

- Updated goals to reflect current active goals
- Moved milestones and their status to Productboard as sub-features, reflecting their current status
- Updated Productboard adding all goals as features, their descriptions, desired outcomes, and status
- Removed all information except the problem statement from this page to avoid duplication and because its status updates in Productboard or similar systems can cascade automatically to other views without us having to manually keep the handbook up to date.
- Linked our current detailed tracking system on this page
- Linked detailed views from the features or sub-features (depending on granularity required) so we can cross-reference them
- Left ZenHub (Trial) as the current detailed roadmap and feature links, but the new format could just as easily use GitHub Project (our current way of tracking) in the links and the workflow for consumers will remain the same.

High-level roadmap view:
![image](https://user-images.githubusercontent.com/9908105/111629489-a2047000-87f1-11eb-8326-40f901843302.png)

Example view from Productboard detailed view:
![image](https://user-images.githubusercontent.com/9908105/111629271-679ad300-87f1-11eb-9b5a-07a76b0c791f.png)

Example view from ZenHub for the team's detailed planning:
![image](https://user-images.githubusercontent.com/9908105/111629328-76818580-87f1-11eb-8048-80fca932ca8d.png)

An alternative view from GitHub projects for "epics" or projects if we end up not using ZenHub:
![image](https://user-images.githubusercontent.com/9908105/111629394-88fbbf00-87f1-11eb-9abf-0d6345ff3c78.png)

--- 

A note on GitHub Projects / ZenHub

We are currently using primarily GitHub projects:
- For iteration tracking. eg. https://github.com/orgs/sourcegraph/projects/151
- For project tracking. eg. https://github.com/orgs/sourcegraph/projects/143
- For backlog planning. eg. https://github.com/orgs/sourcegraph/projects/68

Since GH Issue can be added to multiple Projects, we basically add an issue to the Project it belongs and the iteration we are working on it. If the issue is not done by the end of the iteration, we simply close the project, which leaves the issues in their current columns for review (what was done/not/why) and simply add it to the new iteration. Closed projects are automatically collapsed, so they dont cause noise.

eg.
![image](https://user-images.githubusercontent.com/9908105/111645965-86a16100-8801-11eb-92d7-025998fbfac5.png)

This task was part of a closed iteration (check the closed dropdown button) and its currently part of the current iteration, and part of the "Fast and reliable deployments" project.

This gives us a lot more flexibility to use GH projects, but its still lacking any reporting functionality or the ability to do roadmaps, etc.
