### PR TITLE
Add product design principles, clarify developing handbook locally

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Gatsby requires Node.js, and we recommend using [yarn](https://yarnpkg.com/en/) 
 
 ## Developing locally
 
-[Click here to develop the handbook locally](#Handbook)
+Developing the static site locally is separate from developing the handbook. [Read the Handbook section](#Handbook) to learn how to develop the handbook locally.
 
 In a terminal, change into the `website` directory, and run:
 

--- a/handbook/product/design_principles.md
+++ b/handbook/product/design_principles.md
@@ -1,0 +1,40 @@
+# Sourcegraph’s design principles
+
+**Draft**: 2021-03-05
+
+Sourcegraph’s product design principles are how we express our shared vision and values while designing for our product.
+
+We use our principles to:
+
+- To help our team make **consistent decisions**.
+- To **provide constraints** that lead to better outcomes.
+- To **resolve ambiguity** when faced with options that provide value among different dimensions.
+- To build a **shared vision** across our design and product team.
+
+Our principles were [co-created](https://docs.google.com/document/d/1zRbtZR68ZITYypSAJJ63Ir_fFPxJfTtidJmsrxUXW7o/edit#) with members of the design, product, and frontend application teams, and will benefit:
+
+- Designers.
+- Product managers.
+- Engineers.
+- Marketing.
+- And other stakeholders involved in the design process.
+
+## Our principles  
+
+- **A personal tool within a larger workflow**  
+  Sourcegraph is a powerful yet personal tool that exists within a larger workflow. Design for familiar patterns with thoughtful defaults, while embracing personalization and adaptability.
+
+- **Made for everyone**  
+  Our purpose is to make it so everyone can code. This demands we make Sourcegraph accessible and useful for all developers through universal, inclusive design.
+
+- **Gracefully manage complexity**  
+  Sourcegraph supports complex product requirements, but also empowers users to manage this complexity for their individual needs.
+
+- **Code as content**  
+  More time is spent reading than writing code. Elevate the craft of code as content.
+
+- **Trust is earned** 
+  Sourcegraph is the source of truth, but this trust is earned. Accuracy, transparency, recency, and honesty together work to uphold this source of truth.
+
+- **Create momentum**  
+  Help developers create and maintain flow. To do this, Sourcegraph must be fast in every way. We design purposefully to help users iterate and build momentum.

--- a/handbook/product/index.md
+++ b/handbook/product/index.md
@@ -25,6 +25,8 @@ Product at Sourcegraph consists of [product management](product_management/index
 
 ## Resources
 
+- [Sourcegraph's product design principles](./design_principles.md)
+
 ### References
 
 - [Onboarding to the product team](./onboarding/index.md)


### PR DESCRIPTION
This PR adds the draft form of Sourcegraph's product design principles from [RFC 342](https://docs.google.com/document/d/1zRbtZR68ZITYypSAJJ63Ir_fFPxJfTtidJmsrxUXW7o/edit#).

It also adds a bit of clarification to the README.md for developing the handbook locally, because it gets me every time.