### PR TITLE
updated blog posts for the rename from Campaigns to Batch Changes

### DIFF
--- a/blogposts/2020/code-search-turned-code-checker.md
+++ b/blogposts/2020/code-search-turned-code-checker.md
@@ -322,7 +322,7 @@ with your thoughts. We're still working on performance and usability enhancement
 so that you can search your code and not just popular projects, so stay tuned!
 In the meantime, you can find an all-in-one config for replacing the patterns on your local machine
 at [comby-tools/go-patterns](https://github.com/comby-tools/go-patterns). If you want to make large scale,
-org-wide changes, talk to us about [campaigns](https://docs.sourcegraph.com/campaigns).
+org-wide changes, talk to us about [Batch Changes](https://docs.sourcegraph.com/campaigns).
 And if you find code checking valuable and want to learn more about our work at Sourcegraph, reach us at
 <feedback@sourcegraph.com>. Happy searching!
 

--- a/blogposts/2020/evolution-of-the-precise-code-intel-backend.md
+++ b/blogposts/2020/evolution-of-the-precise-code-intel-backend.md
@@ -148,7 +148,7 @@ To address these issues, we moved the queue data from Redis into PostgreSQL. Thi
 
 For a while, the lsif-server was accessible only through an undocumented proxy in the Sourcegraph frontend service. This proxy accepted uploads and served code navigation queries. The only consumers of this API were first-party Sourcegraph extensions like [sourcegraph/go](https://sourcegraph.com/extensions/sourcegraph/go) and [sourcegraph/typescript](https://sourcegraph.com/extensions/sourcegraph/typescript).
 
-Adding a GraphQL API enabled the LSIF backend to be used by other parts of Sourcegraph, such as the nascent [Campaigns](https://docs.sourcegraph.com/campaigns) feature and the currently in-progress [Code Insights](https://about.sourcegraph.com/blog/sourcegraph-3.17#product-preview-code-insights), and also to third-party Sourcegraph extension authors and third-party API consumers. As the functionality of the LSIF backend continues to grow (we've recently added support for [diagnostics](https://github.com/sourcegraph/sourcegraph/pull/11233)), so do the possibilities for users of this API.
+Adding a GraphQL API enabled the LSIF backend to be used by other parts of Sourcegraph, such as the nascent [Batch Changes](https://docs.sourcegraph.com/campaigns) feature and the currently in-progress [Code Insights](https://about.sourcegraph.com/blog/sourcegraph-3.17#product-preview-code-insights), and also to third-party Sourcegraph extension authors and third-party API consumers. As the functionality of the LSIF backend continues to grow (we've recently added support for [diagnostics](https://github.com/sourcegraph/sourcegraph/pull/11233)), so do the possibilities for users of this API.
 
 ![architecture diagram](https://sourcegraphstatic.com/lsif-arch-5.png)
 

--- a/blogposts/2020/find-and-replace.md
+++ b/blogposts/2020/find-and-replace.md
@@ -69,7 +69,7 @@ table.brain td img {
       <img src="https://storage.googleapis.com/about.sourcegraph.com/blog/a-programmers-guide-to-find-and-replace/brain3.jpg">
     </td>
     <td>
-    You get annoyed wth <code class="language-text">grep</code> and <code class="language-text">sed</code> and find 
+    You get annoyed wth <code class="language-text">grep</code> and <code class="language-text">sed</code> and find
     tools like ripgrep (<code class="language-text">rg</code>) and <code class="language-text">codemod</code>.
     Maybe you dive down the rabbit hole of parsers. Powerful—but it's a slog reading AST specs and writing tree traversers.
     </td>
@@ -517,6 +517,8 @@ released publicly.
 
 
 ### Campaigns
+
+_**Note:** Campaigns have evolved since this post was written, and we now call them batch changes. See [our docs](https://docs.sourcegraph.com/campaigns) for the latest._
 
 After hearing the same thing over and over again from different development teams, we decided to try
 to build a general solution for this hairy problem of large-scale code transformation. Starting in


### PR DESCRIPTION
This updates our blog posts for the campaigns/batch-changes rename.

**Notes:**

- We are intentionally _not_ updating changelogs and press releases.
- For the "find and replace Odyssey" post, since the content was out of date anyway, I just added a note to see the docs for the latest.
- I will come back and update the docs URLs when the docs have been updated.