### PR TITLE
updated CE and Marketing pages for the rename: Campaigns -> Batch Changes

### DIFF
--- a/handbook/ce/customer-support-onboarding.md
+++ b/handbook/ce/customer-support-onboarding.md
@@ -60,12 +60,12 @@ Welcome back! Let’s get started....
 		* feedback: Where the NPS (net promoter score) bot posts responses from customers, we post feedback manually we get from other interactions (like support cases) -- sometimes a NPS response indicates a customer is having a support issue
 	* All the super important company channels to stay informed of what is happening: #general, #handbook, #hiring, #progress, #rfcs, #any-question, #thanks, #buddies, #analytics
 	* Whichever of the social channels strike your fancy, for example: #books, #cooking, #kids-of-sourcegraph, #pets-of-sourcegraph, #random, #side-project, #ted-talks, #today-i-learned, #trash-tv (this is definitely not an exhaustive list)
-	* All the product/engineering channels (it can be hard to stay up on all of them all the time, but that is what our daily captain’s log ritual is meant to help with): #dev-ops (probably most important since this seems to the channel where we post about 🔥 emergency issues), #dev-announce, #dev-chat, #dev-rel, #security-chat, #backend-platform, #campaigns-chat (soon changing name to reflect team name change to "batch changes"), #code-insights-chat, #code-intel, #core-application, #design, #developer-experience, #distributioneers, #eng-pulse, #extensibility-chat, #frontend-platform-chat, #product, #web-chat
+	* All the product/engineering channels (it can be hard to stay up on all of them all the time, but that is what our daily captain’s log ritual is meant to help with): #dev-ops (probably most important since this seems to the channel where we post about 🔥 emergency issues), #dev-announce, #dev-chat, #dev-rel, #security-chat, #backend-platform, #batch-changes-chat, #code-insights-chat, #code-intel, #core-application, #design, #developer-experience, #distributioneers, #eng-pulse, #extensibility-chat, #frontend-platform-chat, #product, #web-chat
 	* All the other team channels so we can see what is going on with all of our teammates across the company and pitch in when we think we might add value: #it-tech-ops, #marketing, #people-ops, #sales, #sales-chat, #sales-ops, #sales-resources
 	* All the channels that could have support issues reported in them: ALL the #support- and #trial- channels … there are a lot of them, #twitter (we will have a workflow set-up for marketing to alert us if we need to engage, but it’s still good to be aware as time allows) -- these will be linked to Zendesk, so we don’t monitor these as much as be sure we have quick access when we need to engage in a thread
 	* Feel free to browse all the channels and join anything else that looks relevant or interesting to you and share with the rest of the team in #customer-support-chat
 * Join the following developer communities to help make sure folks talking about Sourcegraph are getting their questions answered:
-	* Gopher Slack community. Gophers Slack is a thriving, real-time messaging community. If you are looking to get immediate answers to questions or join in the conversation about Go with other Gophers, this is the place to be. Post in #customer-support-chat so a member of the team can add you. You will need to join with your personal email address so our presence feels helpful and not sales-y. 
+	* Gopher Slack community. Gophers Slack is a thriving, real-time messaging community. If you are looking to get immediate answers to questions or join in the conversation about Go with other Gophers, this is the place to be. Post in #customer-support-chat so a member of the team can add you. You will need to join with your personal email address so our presence feels helpful and not sales-y.
 * Read [Our ABC’s Always Be Coding](https://about.sourcegraph.com/blog/our-abcs-always-be-coding-childrens-book/). It’s just cute and so why not!? It’s also a great source of inspiration when trying to simplify complex ideas.
 
 
@@ -97,7 +97,7 @@ Welcome back! Let’s get started....
 Big pause here. These next tasks need a ton of improvement -- as mentioned in the last bullet! They are all supposed to help you learn the product and get more comfortable doing the job. Work with what is here and take abundant notes for how this can be improved.
 
 * Browse some of the available materials to help you learn more about the product:
-	* [Campaigns Overview Deck](https://docs.google.com/presentation/d/1CN3KQf1Hfdb4RO6FgBgKuiHK4ERcOAHPgVnOcBu-MPU/edit#slide=id.g7d2aea8729_0_0) -- also note that as of 2021-03-01, Campaigns has been renamed to Batch Changes
+	* [Batch Changes Overview Deck](https://docs.google.com/presentation/d/1CN3KQf1Hfdb4RO6FgBgKuiHK4ERcOAHPgVnOcBu-MPU/edit#slide=id.g7d2aea8729_0_0)
 	* [Structural Search Overview](https://zoom.us/rec/share/CJtwQ7uEp3v1pvPqdUD7GDuaYm_2g6w3zSP7GNA3aGQHZDjQ72awYXvHEnwsoio6.Bt-0DuuAZjs7UXMc?startTime=1606237440000)
 	* Code Intelligence [video](https://drive.google.com/file/d/1TyCj62LLmhvamXK-CC6D8-7uGk1jmsKj/view) and [slides](https://docs.google.com/presentation/d/181oMTXRmcTqTCfOe5P__fLKwlzV1uk9wvwG6ocFgz20/edit?usp=sharing)
 	* [“Deployment types - A crash course in Sourcegraph”](https://docs.google.com/presentation/d/1u4mbXjubQqV-6WFbuS7Q1b_X6BVh-_GWzzFQMcrAzLw/edit#slide=id.p)
@@ -106,10 +106,10 @@ Big pause here. These next tasks need a ton of improvement -- as mentioned in th
 * Read about [search queries](https://docs.sourcegraph.com/code-search) and perform your first searches.
 * Work through the questions from the [Sales Onboarding Quiz](https://about.sourcegraph.com/handbook/sales/onboarding/quiz) to make sure you understand key concepts. Feel free to skip any obvious answers and discuss any questions you have in our #customer-support-chat Slack channel.
 * Explore our official [documentation](https://docs.sourcegraph.com/getting-started). Get used to navigating it and trying to find what you need in it. We know we have a lot of opportunity for improvement -- more on that soon!
-* Explore the sections of the handbook for each engineering team. Get used to trying to find answers in the handbook as much as our documentation. 
-	* [Distribution](https://about.sourcegraph.com/handbook/engineering/distribution) 
+* Explore the sections of the handbook for each engineering team. Get used to trying to find answers in the handbook as much as our documentation.
+	* [Distribution](https://about.sourcegraph.com/handbook/engineering/distribution)
 	* [Web](https://about.sourcegraph.com/handbook/engineering/web)
-	* [Batch changes (formerly Campaigns)](https://about.sourcegraph.com/handbook/engineering/batch-changes)
+	* [Batch changes](https://about.sourcegraph.com/handbook/engineering/batch-changes)
 	* [Core application](https://about.sourcegraph.com/handbook/engineering/core-application)
 	* [Code insights](https://about.sourcegraph.com/handbook/engineering/code-insights)
 	* [Code intelligence](https://about.sourcegraph.com/handbook/engineering/code-intelligence)
@@ -119,7 +119,7 @@ Big pause here. These next tasks need a ton of improvement -- as mentioned in th
 * Explore issues customers have reported in the past in Jira and in our #support- Slack channels. Get a sense of how the back and forth goes, the issues, the resolutions … all aspects of our [workflow](https://about.sourcegraph.com/handbook/ce/support-workflow)
 
 * Write your first weekly reflection post (another of our [rituals](https://about.sourcegraph.com/handbook/ce/support-team-rituals)). You can see examples in our #customer-support-chat Slack channel.
- 
+
 
 ## By the end of your first month, the following will be true...
 * You have helped several customers
@@ -133,7 +133,7 @@ Big pause here. These next tasks need a ton of improvement -- as mentioned in th
 
 * Keep helping customers!
 * Schedule a chat with each member of the [Distribution team](https://about.sourcegraph.com/handbook/engineering/distribution). This is the engineering team that we cross paths with the most (they own customer deployment, monitoring, and upgrades).
-* Schedule a chat with each engineering team manager. You can find who they are by starting on the [org chart page](https://about.sourcegraph.com/company/team/org_chart), navigating to each engineering team page, and then looking at the members listed somewhere there. 
+* Schedule a chat with each engineering team manager. You can find who they are by starting on the [org chart page](https://about.sourcegraph.com/company/team/org_chart), navigating to each engineering team page, and then looking at the members listed somewhere there.
 * Sign-up for which playbook(s) you will help develop and have a plan for how to approach it. Note: more on this soon.
 * Select your focus blocks and update our [team schedule](https://about.sourcegraph.com/handbook/ce/support-schedule).
 

--- a/handbook/ce/engaging-other-teams.md
+++ b/handbook/ce/engaging-other-teams.md
@@ -8,7 +8,7 @@ When we need help, we seek it consistently, following the steps outlined here. W
 * Exhaust our collective expertise
 * Minimize the time added to the customer experience whilst they wait for help
 
-At no point are we meant to be gate keepers or go-betweens. Generally, when a CE needs help, they will come to us. They may also still go directly to engineering for other questions they have. And when we engage engineering, if the CE wants to be included, be sure to do so. This is especially relevant for customers still in the pre-sales process where everything is just a bit more sensitive. 
+At no point are we meant to be gate keepers or go-betweens. Generally, when a CE needs help, they will come to us. They may also still go directly to engineering for other questions they have. And when we engage engineering, if the CE wants to be included, be sure to do so. This is especially relevant for customers still in the pre-sales process where everything is just a bit more sensitive.
 
 ## Step 1: Gather all the details/context and set expectations with the customer
 
@@ -26,18 +26,18 @@ Never say "I need to ask engineering" or anything that can erode trust with the 
 
 If you don't need help and are filing a defect, you can skip this step.
 
-When you need help, post in our #customer-support-chat Slack channel first to see if anyone on our team is able to help you move forward. Always trust your assessment of the situation and move forward to engaging engineering based on the level of urgency/priority associated with the work. 
+When you need help, post in our #customer-support-chat Slack channel first to see if anyone on our team is able to help you move forward. Always trust your assessment of the situation and move forward to engaging engineering based on the level of urgency/priority associated with the work.
 
 ## Step 3: Identify which team can help you
 
-In many cases, questions can span multiple teams. For example, a question about how to scale up indexed search to serve a large set of repositories could cover the Distribution, Cloud, and Search teams. In such cases, start where you think is best and our teammates in engineering will help us figure out if we need to go to another engineering team. 
+In many cases, questions can span multiple teams. For example, a question about how to scale up indexed search to serve a large set of repositories could cover the Distribution, Cloud, and Search teams. In such cases, start where you think is best and our teammates in engineering will help us figure out if we need to go to another engineering team.
 
 
 ### Deployment
 
 **Keywords**: `deploy`, `Docker`, `container`, `image`, `Kubernetes`/`k8s`, `cluster`, `AWS`, `Google Cloud`/`GCP`
 
-Any questions about deployment should be routed to the [Distribution team](../engineering/distribution/index.md). 
+Any questions about deployment should be routed to the [Distribution team](../engineering/distribution/index.md).
 
 ### Monitoring, management, and performance optimization
 
@@ -45,7 +45,7 @@ Any questions about deployment should be routed to the [Distribution team](../en
 
 Questions about specific alerts and graph panels should be routed to the team that owns the alert or panel, as indicated by relevant entry in [Alert solutions](https://docs.sourcegraph.com/admin/observability/alert_solutions) or the [Dashboards reference](https://docs.sourcegraph.com/admin/observability/dashboards) respectively.
 
-Any other questions about monitoring and performance should be routed to the [Distribution team](../engineering/distribution/index.md). 
+Any other questions about monitoring and performance should be routed to the [Distribution team](../engineering/distribution/index.md).
 
 
 ### Code host connections
@@ -92,11 +92,11 @@ Any questions about the browser extension or code host native integrations shoul
 
 Any questions about Sourcegraph extensions should be routed to the [Extensibility team](../engineering/web/index.md).
 
-### Batch changes (formerly Campaigns)
+### Batch Changes
 
 **Keywords**: `campaigns`, `large scale code changes`, `refactoring`, `src-cli`, `automation`, `batch changes`
 
-Any questions about campaigns should be routed to the [Batch changes (formerly Campaigns team)](../engineering/batch-changes/index.md).
+Any questions about Batch Changes should be routed to the [Batch Changes team](../engineering/batch-changes/index.md).
 
 
 ## Step 4: File a Github issue
@@ -115,16 +115,16 @@ When in doubt, file in the private repo—issues can be moved over to the public
 File new customer issues in the [private customer issue tracker](https://github.com/sourcegraph/customer/issues/new):
 
 * Initiate the issue from Zendesk via the integration with Github so that the conversation with the customer is available to engineering directly in Github
-* Provide all information required for troubleshooting that you gathered in the previous steps. 
-* Label it with `customer/$name` and `rfh`. 
-* Assign the issue to the appropriate team you identified in the previous step. 
+* Provide all information required for troubleshooting that you gathered in the previous steps.
+* Label it with `customer/$name` and `rfh`.
+* Assign the issue to the appropriate team you identified in the previous step.
 
 If it turns our to be a general issue affecting multiple deployments, create an issue in the [public issue tracker](https://github.com/sourcegraph/sourcegraph/issues/new/choose). The issue must not include any private information. It is okay to link any relevant private, customer specific issues. If not already linked to the relevant Zendesk tickets, do so.
 
 ### Add the priority label
 Add a prioritization label to the issue, from `p0` to `p3` based on a combination of (1) the severity of the issue and (2) any relevant context that translates to level of urgency (for example, if a customer is in the sales process, issues have a higher degree of urgency):
 
-* `p0`: System outages (`about`, `/search` (for sourcegraph.com only), or `docs` is fully unreachable) are always p0. At your discretion, we may also designate an issue p0 that results in the company's Sourcegraph instance being unusable. 
+* `p0`: System outages (`about`, `/search` (for sourcegraph.com only), or `docs` is fully unreachable) are always p0. At your discretion, we may also designate an issue p0 that results in the company's Sourcegraph instance being unusable.
 * `p1`: All customer reported issues per our contractual p1 service level agreement definition [here](https://about.sourcegraph.com/handbook/ce/support#our-service-level-agreements-slas).
 * `p2`: All customer reported issues per our contractual p2 service level agreement definition [here](https://about.sourcegraph.com/handbook/ce/support#our-service-level-agreements-slas).
 * `p3`: All feature requests.
@@ -141,7 +141,7 @@ When posting in Distribution team's Slack channel, @ mention the [on-call dev](.
 
 ### Defects
 
-If the issue is a defect, we trust our teammates in product and engineering to schedule the fix based on all other priorities they have to consider. The context you provide on urgency in the ticket is useful to them for this. If the customer requires a timeline update, we can talk with the relevant engineering team to get a sense. We never want to make promises, but we can share what we know and make sure the customer doesn't feel left in the dark or like no one cares about their issue. 
+If the issue is a defect, we trust our teammates in product and engineering to schedule the fix based on all other priorities they have to consider. The context you provide on urgency in the ticket is useful to them for this. If the customer requires a timeline update, we can talk with the relevant engineering team to get a sense. We never want to make promises, but we can share what we know and make sure the customer doesn't feel left in the dark or like no one cares about their issue.
 
 ### Collaboration
 

--- a/handbook/ce/index.md
+++ b/handbook/ce/index.md
@@ -1,6 +1,6 @@
 # Customer Engineering
 
-On the Customer Engineering team, we help developers use Sourcegraph to solve their organization's Big Code problems. 
+On the Customer Engineering team, we help developers use Sourcegraph to solve their organization's Big Code problems.
 
 - [**Customer Engineers**](https://jobs.lever.co/sourcegraph/3ede0606-7a86-45d4-a627-e8cbae7a1a57) help our developer users and champions get more value from using Sourcegraph in more and better ways.
 - [**Customer Support Engineers**](https://about.sourcegraph.com/handbook/ce/support) solve technical problems from all organizations about deployment, configuration, integration, authentication, scaling, troubleshooting, and more. <!-- Example: A Customer Support Engineer might help a customer get perfect cross-repository code intelligence set up for all of their code so they have joyful and more effective code reviews. -->
@@ -11,7 +11,7 @@ We work with many other teams at Sourcegraph, including:
 - with the [Product team](../product/index.md) and [Engineering team](../engineering/index.md) on product feedback and requirements (by aggregating and relaying what users tell us, and by helping team members get in touch with or solicit feedback from the right users).
 
 ### What is the difference between a Customer Engineer and Customer Support Engineer?
-CSEs are the go-to technical team for our CEs, helping customers both pre- and post-sales, and allowing CEs to do more proactive work by taking on the reactive technical troubleshooting work when customers experience issues. We can think of CE and CSE as work best friends, working closely together every day. Where Sales is focused on the commercial relationship, CE is focused on product success/usage/adoption. If the CE is stuck, doesn’t know the answer, that is the exact right time to bring in a CSE and let support do the heads-down troubleshooting work. 
+CSEs are the go-to technical team for our CEs, helping customers both pre- and post-sales, and allowing CEs to do more proactive work by taking on the reactive technical troubleshooting work when customers experience issues. We can think of CE and CSE as work best friends, working closely together every day. Where Sales is focused on the commercial relationship, CE is focused on product success/usage/adoption. If the CE is stuck, doesn’t know the answer, that is the exact right time to bring in a CSE and let support do the heads-down troubleshooting work.
 
 ---
 
@@ -40,9 +40,9 @@ CSEs are the go-to technical team for our CEs, helping customers both pre- and p
 
 * Resources
   * [QBR Guide](https://docs.google.com/document/d/1gFRn2SkX19sU0GSMGndNkk-I9cFe7FlN3xlZ2UX3Frs/edit#u)
-  * [Guide to demoing the Campaigns feature](https://drive.google.com/drive/folders/18Sa_NpsVRvVV8MIvuXyoDEinpEf8fbGn) (video recording)
+  * [Guide to demoing the Batch Changes feature](https://drive.google.com/drive/folders/18Sa_NpsVRvVV8MIvuXyoDEinpEf8fbGn) (video recording)
     * [Slides](https://docs.google.com/presentation/d/1niZBMhHKWJT1-n_ExSbYIRD51vcubrWwQm-Tc5EZo8s/edit#slide=id.g7d2aea8729_0_0)
-    * [Campaign demo and training materials](https://docs.google.com/document/d/1xQxhdGaudydOn5nBGIG91F6Z4VR4NwBfuKFvgbmCjJo/edit?usp=drive_web&ouid=107037782400977645523)
+    * [Batch Changes demo and training materials](https://docs.google.com/document/d/1xQxhdGaudydOn5nBGIG91F6Z4VR4NwBfuKFvgbmCjJo/edit?usp=drive_web&ouid=107037782400977645523)
 
 
 ## Members

--- a/handbook/ce/license_keys.md
+++ b/handbook/ce/license_keys.md
@@ -25,8 +25,8 @@ First, the company's Sourcegraph administrator must create a Sourcegraph.com use
   - `true-up` to allow the company to go over the user limit on the license.
   - `mau` to indicate that the company is on a monthly usage-based billing model.
   - `trial` to show an indicate in Sourcegraph that the company is on a trial.
-  - `enterprise` for Enterprise licenses (formerly Enterprise Full), without campaigns
-  - `campaigns` to add Campaigns to an Enterprise license
+  - `enterprise` for Enterprise licenses (formerly Enterprise Full), without batch changes
+  - `batch-changes` to add Batch Changes to an Enterprise license
   - `team` for the Team plan
   - `starter` for the Enterprise Starter plan, which functions as Team without user limits (a historical plan—only used for existing customers on this plan, not for new customers or trials)
   - `internal` for licenses used for internal sites (dotcom, k8s, etc.)
@@ -42,7 +42,7 @@ A typical email to send to a company is:
 
 ## Future state
 
-Right now, we only use `enterprise`, `team`, and `campaigns` to indicate plan and features. In the future we will use more granular plans:
+Right now, we only use `enterprise`, `team`, and `batch-changes` to indicate plan and features. In the future we will use more granular plans:
 
   - `plan:team-<version>` to indicate that the company is on team tier, on the given version, e.g. `plan:team-0` (Sales will own knowing the version).
   - `plan:enterprise-<version>` to indicate that the company is on enterprise tier, on the given version, e.g. `plan:enterprise-0` (Sales will own knowing the version).
@@ -51,7 +51,7 @@ Right now, we only use `enterprise`, `team`, and `campaigns` to indicate plan an
      - `private-extension-registry`: Whether publishing extensions to this Sourcegraph instance has been purchased. If not, then extensions must be published to Sourcegraph.com. All instances may use extensions published to Sourcegraph.com.
      - `remote-extensions-allow-disallow`: Whether explicitly specify a list of allowed remote extensions and prevent any other remote extensions from being used has been purchased. It does not apply to locally published extensions.
      - `branding`: Whether custom branding of this Sourcegraph instance has been purchased.
-     - `campaigns`: Whether campaigns on this Sourcegraph instance has been purchased.
+     - `batch-changes`: Whether Batch Changes on this Sourcegraph instance has been purchased.
      - `monitoring`: Whether monitoring on this Sourcegraph instance has been purchased.
      - `backup-and-restore`: Whether builtin backup and restore on this Sourcegraph instance has been purchased.
   - For now, if no `plan:*` tag is supplied, the license will be treated as legacy enterprise tier which has unlimited access to all features.

--- a/handbook/ce/onboarding.md
+++ b/handbook/ce/onboarding.md
@@ -1,18 +1,18 @@
-# Customer Engineering Onboarding 
+# Customer Engineering Onboarding
 
 Welcome to Sourcegraph - we're very excited to have you on the Customer Engineering team! This document will guide you through customer engineering-specific onboarding.
-  
+
 ## CE Onboarding Checklist
 
 ### Week 1
 
-#### Goals: 
+#### Goals:
 - Clear knowledge of what the company’s, and Customer Engineering’s mission, vision, values and culture are.
 - Know the expected outcome of each CE onboarding milestone
 - Become familiar with CE tools and processes
-- Go through General Onboarding 
+- Go through General Onboarding
 
-#### Tasks: 
+#### Tasks:
 - Meet your onboarding buddy
 - Verify access to all CE [tools](#tools)
 - Add shared [CE calendar](https://calendar.google.com/calendar/u/0?cid=Y19yY3Y0ZTRqODI0OXZzNmJwbzd0bXFrZjVuZ0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t) to your calendar
@@ -21,58 +21,58 @@ Welcome to Sourcegraph - we're very excited to have you on the Customer Engineer
 - Open and merge first GitHub pull request by adding yourself to [team page](https://about.sourcegraph.com/company/team) in Handbook
 - Read our [CE handbook pages](index.md)
 - Read the [sales/CE data and Looker onboarding](../sales/onboarding/data_onboarding.md)
-  
+
 
 ### Week 2
 
-#### Goals: 
+#### Goals:
 - Develop high-level understanding of product
 - Become familiar with demo flow
-- Understand how we work with the Customer Support team 
-- Get to know your team! 
+- Understand how we work with the Customer Support team
+- Get to know your team!
 - Ask your onboarding buddy lots of questions!
 
-#### Tasks: 
+#### Tasks:
 - Attend next product tour
 - Start shadowing customer calls
 - Go through the product deep-dives and demo recordings under Resources
-- Review [CSE onboarding](https://about.sourcegraph.com/handbook/ce/customer-support-onboarding) and understand how we interact with our [Customer Support team](https://about.sourcegraph.com/handbook/ce/support) 
+- Review [CSE onboarding](https://about.sourcegraph.com/handbook/ce/customer-support-onboarding) and understand how we interact with our [Customer Support team](https://about.sourcegraph.com/handbook/ce/support)
 - Attend team meetings/events
-- Start practicing/get comfortable with product demo 
+- Start practicing/get comfortable with product demo
 
-### Month 1 
+### Month 1
 
 #### Goals:
 - Understand the day-to-day of what a CE does
-- Become knowledgeable with Sourcegraph documentation and technical architecture 
-- Become familiar with sales process and how CE integrates with that 
+- Become knowledgeable with Sourcegraph documentation and technical architecture
+- Become familiar with sales process and how CE integrates with that
 - Be able to deliver a proficient product demo
 
-#### Tasks: 
-- Begin diving into technical documentation and understanding SG architecture 
-- Review customer calls on [Chorus](https://chorus.ai/) 
-  - Try pausing the video when the customer asks a question, and attempt to answer on your own before continuing. 
+#### Tasks:
+- Begin diving into technical documentation and understanding SG architecture
+- Review customer calls on [Chorus](https://chorus.ai/)
+  - Try pausing the video when the customer asks a question, and attempt to answer on your own before continuing.
 - Shadow as many customer/prospect calls as possible
 - Participate in any relevant training sessions or workshops
-- Deliver demo cert presentation to team 
+- Deliver demo cert presentation to team
 
 ### Month 2
 
-#### Goals: 
+#### Goals:
 - Start taking ownership of accounts and customer-facing calls
 - Interact directly with customers with little to no assistance
 - Run bi-monthly [Product Tours](https://info.sourcegraph.com/product-tour)
 
-#### Tasks: 
+#### Tasks:
 - Develop relationships with the accounts assigned to you (Ask the AE for intros)
 - Start driving and owning customer calls and interactions
-- Deliver customer-facing demos 
+- Deliver customer-facing demos
 
 ### Month 3
 
-#### Goals: 
-- Proactively work on existing accounts to grow adoption and expansion 
-- Help new teammates onboard 
+#### Goals:
+- Proactively work on existing accounts to grow adoption and expansion
+- Help new teammates onboard
 
 ## Tools
 NOTE: Request access/licenses to these tools in [#it-tech-ops](https://sourcegraph.slack.com/archives/C01CSS3TC75).
@@ -82,7 +82,7 @@ NOTE: Request access/licenses to these tools in [#it-tech-ops](https://sourcegra
   - Request to be a member of the [Sourcegraph organization](https://sourcegraph.com/organizations/sourcegraph/).  This gives you access to some additional features.
   - Once you have access, familiarize yourself with the site-admin page.
   - NOTE: request this same access for [demo.sourcegraph.com](https://demo.sourcegraph.com) as well
-- [GitHub](https://github.com/) (Provide GitHub username and request access to Sourcegraph repo) 
+- [GitHub](https://github.com/) (Provide GitHub username and request access to Sourcegraph repo)
 - [Salesforce](https://sourcegraph2020.my.salesforce.com/?ec=302&startURL=%2Fvisualforce%2Fsession%3Furl%3Dhttps%253A%252F%252Fsourcegraph2020.lightning.force.com%252Flightning%252Fpage%252Fhome)
 - [HubSpot](https://app.hubspot.com/contacts/2762526/deals/board/view/all/)
   - Note: We have officially transitioned to Salesforce as our CRM, but HubSpot still has some historical context. Please get access to both.
@@ -98,11 +98,11 @@ NOTE: Request access/licenses to these tools in [#it-tech-ops](https://sourcegra
 #### Demo Recordings
   - [101 Demo](https://drive.google.com/file/d/1VUZ0rnZQpNgjtGDI0tMC-h-OtL0Czz8H/view?usp=sharing) (dan@)
   - [Product Info Session](https://youtu.be/iTBTri_q5MA) (jonah@)
-  - [CE-to-CE Demo walkthrough](https://drive.google.com/drive/folders/1rf2E2KLBztH1Qe2shq3p39afF5mLK7m1) 
-#### Product Deep-Dives  
-  - [Campaigns Overiew Deck](https://docs.google.com/presentation/d/1CN3KQf1Hfdb4RO6FgBgKuiHK4ERcOAHPgVnOcBu-MPU/edit#slide=id.g7d2aea8729_0_0)
+  - [CE-to-CE Demo walkthrough](https://drive.google.com/drive/folders/1rf2E2KLBztH1Qe2shq3p39afF5mLK7m1)
+#### Product Deep-Dives
+  - [Batch Changes Overiew Deck](https://docs.google.com/presentation/d/1CN3KQf1Hfdb4RO6FgBgKuiHK4ERcOAHPgVnOcBu-MPU/edit#slide=id.g7d2aea8729_0_0)
   - [Structural Search Overview](https://zoom.us/rec/share/CJtwQ7uEp3v1pvPqdUD7GDuaYm_2g6w3zSP7GNA3aGQHZDjQ72awYXvHEnwsoio6.Bt-0DuuAZjs7UXMc?startTime=1606237440000)
-  - [Code Intelligence](https://drive.google.com/file/d/1TyCj62LLmhvamXK-CC6D8-7uGk1jmsKj/view) [[slides](https://docs.google.com/presentation/d/181oMTXRmcTqTCfOe5P__fLKwlzV1uk9wvwG6ocFgz20/edit?usp=sharing)]  
+  - [Code Intelligence](https://drive.google.com/file/d/1TyCj62LLmhvamXK-CC6D8-7uGk1jmsKj/view) [[slides](https://docs.google.com/presentation/d/181oMTXRmcTqTCfOe5P__fLKwlzV1uk9wvwG6ocFgz20/edit?usp=sharing)]
 #### CE Resources
   - [Shared CE Calendar](https://calendar.google.com/calendar/u/0?cid=Y19yY3Y0ZTRqODI0OXZzNmJwbzd0bXFrZjVuZ0Bncm91cC5jYWxlbmRhci5nb29nbGUuY29t)
   - [Open opportunities with assigned CE in Salesforce](https://sourcegraph2020.lightning.force.com/lightning/r/Report/00O3t000006jUsfEAE/view)
@@ -112,14 +112,14 @@ NOTE: Request access/licenses to these tools in [#it-tech-ops](https://sourcegra
     -   Understand the 3 differrent Sourcegraph deployment methods
         - ["Deployment types - A crash course in Sourcegraph"](https://docs.google.com/presentation/d/1u4mbXjubQqV-6WFbuS7Q1b_X6BVh-_GWzzFQMcrAzLw/edit#slide=id.p)
   - [Architecture overview](https://docs.sourcegraph.com/dev/background-information/architecture) to understand how our application and system         works.
-      - Also review [How the Sourcegraph CLI executes a campaign spec](https://docs.sourcegraph.com/campaigns/explanations/how_src_executes_a_campaign_spec)
-  - [Observability and monitoring](https://docs.sourcegraph.com/admin/observability) docs and understand how to troubleshoot those tools 
+      - Also review [How the Sourcegraph CLI executes a batch spec](https://docs.sourcegraph.com/campaigns/explanations/how_src_executes_a_campaign_spec)
+  - [Observability and monitoring](https://docs.sourcegraph.com/admin/observability) docs and understand how to troubleshoot those tools
      - [Grafana and Prometheus](https://docs.sourcegraph.com/admin/observability/metrics)
      - [Tracing](https://docs.sourcegraph.com/admin/observability/tracing)
      - [Alerting](https://docs.sourcegraph.com/admin/observability/alerting)
 
- 
-  
+
+
 ## FAQ
 
 - How do we interface in customer engagements?

--- a/handbook/marketing/adding_screenshots_screen_recording.md
+++ b/handbook/marketing/adding_screenshots_screen_recording.md
@@ -15,7 +15,7 @@
 
 ## Don't add title slides to videos
 
-We almost never use title slides. Title slides are slides at the start of your video that have a Sourcegraph logo, a background, a title (like "Campaigns demo"), and maybe a nice visual effect.
+We almost never use title slides. Title slides are slides at the start of your video that have a Sourcegraph logo, a background, a title (like "Batch Changes demo"), and maybe a nice visual effect.
 
 Why do we not use title slides?
 

--- a/handbook/marketing/messaging.md
+++ b/handbook/marketing/messaging.md
@@ -3,31 +3,31 @@
 ## What problems does Sourcegraph solve?
 
 The way the world creates code has shifted. We’ve entered the era of Big Code.
- 
+
 Big Code is all about how code is growing in:
 
 * Volume – exponential increases in the amount of code
 * Variety – more complexity in the languages, tools, and processes for delivering software
 * Velocity – accelerated delivery cycles that mean code is changing faster and being shipped virtually every minute
 * Value – the reimagination of business models and practices through high-quality software
- 
+
 This digital transformation led to countless innovations that improve the lives of people all over the world. But it’s been hard on developers.
- 
-With increased complexity, developers still need to efficiently write and make changes to their enterprise’s code, while meeting tight deadlines and stringent quality and security requirements. 
- 
+
+With increased complexity, developers still need to efficiently write and make changes to their enterprise’s code, while meeting tight deadlines and stringent quality and security requirements.
+
 Sub-optimal developer productivity in the era of Big Code is a losing proposition for any company. Development delays mean late releases, poor quality, frustrated teams, unhappy customers, and uncompetitive products.
- 
-Google and Facebook were among the first to begin addressing this problem, investing hundreds of millions of dollars in their customized, proprietary code search infrastructure for internal use. 
+
+Google and Facebook were among the first to begin addressing this problem, investing hundreds of millions of dollars in their customized, proprietary code search infrastructure for internal use.
 
 But what about everybody else?
- 
+
 The answer is universal code search. Companies like Uber, Lyft, Yelp, Qualtrics, and others adopted search technology as the right solution to enhance developer productivity in the era of Big Code.
 
 ## Sourcegraph value proposition
 
 How does Sourcegraph help solve these problems?
 
-With rapidly growing codebases, proliferating number of repositories, multiple languages and file formats, and a wide variety of developer tools, Sourcegraph universal code search empowers developers to quickly explore and better understand all code faster. Code navigation and code exploration improves developer productivity, contextual code intelligence enables better code reviews and onboarding for new hires, and code change campaigns automate large-scale changes. Sourcegraph universal code search lets developers focus on solving problems, not struggle to find code, while managing rapidly changing and complex codebases.
+With rapidly growing codebases, proliferating number of repositories, multiple languages and file formats, and a wide variety of developer tools, Sourcegraph universal code search empowers developers to quickly explore and better understand all code faster. Code navigation and code exploration improves developer productivity, contextual code intelligence enables better code reviews and onboarding for new hires, and batch changes automate large-scale changes. Sourcegraph universal code search lets developers focus on solving problems, not struggle to find code, while managing rapidly changing and complex codebases.
 
 ### Short single sentence
 
@@ -45,37 +45,37 @@ With rapidly growing codebases, proliferating number of repositories, multiple l
 
 ### Medium message (~100 words)
 
-With rapidly growing codebases, proliferating number of repositories, multiple languages and file formats, and a wide variety of developer tools, Sourcegraph universal code search empowers developers to quickly explore and better understand all code faster. Code navigation and code exploration improves developer productivity, contextual code intelligence enables better code reviews and onboarding for new hires, and code change campaigns automate large-scale changes. Sourcegraph universal code search lets developers focus on solving problems, not struggle to find code, while managing rapidly changing and complex codebases.
+With rapidly growing codebases, proliferating number of repositories, multiple languages and file formats, and a wide variety of developer tools, Sourcegraph universal code search empowers developers to quickly explore and better understand all code faster. Code navigation and code exploration improves developer productivity, contextual code intelligence enables better code reviews and onboarding for new hires, and batch changes automate large-scale changes. Sourcegraph universal code search lets developers focus on solving problems, not struggle to find code, while managing rapidly changing and complex codebases.
 
 ### Long message (~450 words)
 
 Sourcegraph universal code search enables developers to traverse the complex universe of interdependent codebases – a plethora of different programming languages, code hosts, repositories, version control systems, services, and APIs – to find the code and information they need to do their jobs in today’s collaborative, multi-dimensional development environment.
- 
+
 Search is severely limited in traditional developer tools, such as editors and IDEs built for individual developers working on a sole repository, not for collaborating teams working with large codebases at scale. GitHub, in its effort to broaden as a software development platform, is improving its code search capabilities, but a single code host inherently can’t be a universal, cross-repository solution.
- 
+
 Universal code search is different: a single, highly scalable way to explore, navigate, and analyze all of an organization's massive stores of code, regardless of system, repository, or language. It is uniquely suited to address Big Code’s four V’s:
- 
+
 * Volume – code exploration, navigation, intelligence, and change management across the whole codebase.
 * Variety – the same functionality is available for every programming language, code host, etc.
-* Velocity – search all branches, diffs, and commits – code search across history, or get alerts about coming changes. 
+* Velocity – search all branches, diffs, and commits – code search across history, or get alerts about coming changes.
 * Value – improved developer productivity that drives more value for the entire enterprise.
- 
+
 Instead of constantly searching in disparate codebases, developers use universal code search to discover and re-use existing code across repositories. They can understand and debug code, figure out the right library or service for a certain task, and share code links to help teammates with best practices.
- 
+
 API owners can see and monitor who’s using their code and how, upgrade API consumers’ call sites across all repositories, and deprecate old APIs.
- 
+
 For DevOps and security teams, universal code search can pinpoint the source of an error or vulnerability, identify code changes responsible for the incident, evaluate the performance of specific lines of code in production, and apply patches and upgrades across all repositories.
- 
-In the era of Big Code, code search needs to be not only how developers discover and explore the entire enterprise codebase but also how they can quickly understand code in context. Universal code search enables better, more sophisticated code reviews and is the fundamental technology behind code change campaigns.
- 
-To be effective, search must be universal across several dimensions: 
+
+In the era of Big Code, code search needs to be not only how developers discover and explore the entire enterprise codebase but also how they can quickly understand code in context. Universal code search enables better, more sophisticated code reviews and is the fundamental technology behind Batch Changes.
+
+To be effective, search must be universal across several dimensions:
 
 * All repositories
 * All programming languages
 * All code changes (commits, branches, and forks)
 * All file formats
 * All other developer tools that generate metadata about code (such as for logging, tracing, and profiling)
- 
+
 Universal code search meets these requirements, and all users have to do is search via a browser, shell, or inside popular tools like GitHub, GitLab, Bitbucket Server, Phabricator, Perforce, and Subversion. Results are instant.
 
 By solving some of the most pressing challenges in today’s fast-moving, intricately connected software organizations, universal code search is the right technology for the era of Big Code.
@@ -84,15 +84,15 @@ By solving some of the most pressing challenges in today’s fast-moving, intric
 
 Sourcegraph is a company that creates software to help every organization build software with the quality and efficiency of today's elite technology companies.
 
-## Press release boilerplate	
+## Press release boilerplate
 
-Sourcegraph helps companies solve [Big Code problems](https://about.sourcegraph.com/press-release/big-code-survey-2020/) so developers can innovate faster. [Sourcegraph’s Universal Code Search](https://info.sourcegraph.com/universal-code-search-ebook-req) is the only solution that empowers developers to easily find and understand code and fix problems across the entire codebase. Companies using Sourcegraph benefit from accelerated software iteration, improved code quality, faster bug fixes and incident response times, more effective remote coding collaboration, safer legacy code deprecation, better coding insights and [more](https://info.sourcegraph.com/universal-code-search-ebook-req). Sourcegraph’s customers include many of the world’s leading companies, such as Amazon, PayPal, Uber, Lyft, Yelp, Atlassian, and Indeed. The all-remote company is backed by Sequoia Capital, Craft Ventures, Redpoint Ventures, and Goldcrest Capital. 
+Sourcegraph helps companies solve [Big Code problems](https://about.sourcegraph.com/press-release/big-code-survey-2020/) so developers can innovate faster. [Sourcegraph’s Universal Code Search](https://info.sourcegraph.com/universal-code-search-ebook-req) is the only solution that empowers developers to easily find and understand code and fix problems across the entire codebase. Companies using Sourcegraph benefit from accelerated software iteration, improved code quality, faster bug fixes and incident response times, more effective remote coding collaboration, safer legacy code deprecation, better coding insights and [more](https://info.sourcegraph.com/universal-code-search-ebook-req). Sourcegraph’s customers include many of the world’s leading companies, such as Amazon, PayPal, Uber, Lyft, Yelp, Atlassian, and Indeed. The all-remote company is backed by Sequoia Capital, Craft Ventures, Redpoint Ventures, and Goldcrest Capital.
 
 ## Definitions
 
 * Code search - Essential task for all developers to quickly find, understand, and change all of the code that they are responsible for. Includes the activities of code discovery, code intelligence, and code change management.
 * Code navigation - Guided traveling to find specific code via ad-hoc query (enables code discovery and exploration)
 * Code exploration - Find both known and unknown code, with code intelligence providing the contextual understanding
-* Code discovery - Navigate, explore, and understand the code you are looking for, even if you didn’t know it existed 
+* Code discovery - Navigate, explore, and understand the code you are looking for, even if you didn’t know it existed
 * Code intelligence - Display and share additional contextual information around code (allows code reviews with context)
-* Campaigns - Make large-scale code changes
+* Batch changes - Make large-scale code changes


### PR DESCRIPTION
This updates the CE and Marketing pages in our handbook to refer to Batch Changes instead of Campaigns.

_I am not confident that these changes are all correct, especially those relating to license keys._ So please double-check those.

(Finally, my editor trims trailing whitespace, so you might want to append `?w=1` to the url when viewing the diffs to ignore those trivial changes.)