### PR TITLE
handbook: first pass at defining the word "licence"

### DIFF
--- a/handbook/community/faq.md
+++ b/handbook/community/faq.md
@@ -14,7 +14,7 @@ All files in the `enterprise/` and `src/enterprise/` directories are subject to 
 
 ## Is all of Sourcegraph open source?
 
-All files in this repository except those in the `enterprise/` and `src/enterprise/` directories are open source, and build a product known as Sourcegraph OSS. Sourcegraph OSS omits certain trademarks, logos, and [paid enterprise features](https://about.sourcegraph.com/pricing/) from the official Sourcegraph build to make it open source.
+All files in this repository except those in the `enterprise/` and `client/web/src/enterprise/` directories are open source, and build a product known as Sourcegraph OSS. Sourcegraph OSS omits certain trademarks, logos, and [paid enterprise features](https://about.sourcegraph.com/pricing/) from the official Sourcegraph build to make it open source.
 
 The official, free Sourcegraph build is called Sourcegraph Core and includes these additions (the source code of which is available in the `/enterprise` and `/src/enterprise` directories and is covered by the [Sourcegraph Enterprise license](https://github.com/sourcegraph/sourcegraph/blob/master/LICENSE)). The reason why we include these features in the official build is to provide a smooth upgrade path to Sourcegraph Enterprise (you can just supply a license key to activate the features, with no migration necessary).
 

--- a/handbook/community/faq.md
+++ b/handbook/community/faq.md
@@ -14,7 +14,7 @@ All files in the `enterprise/` and `src/enterprise/` directories are subject to 
 
 ## Is all of Sourcegraph open source?
 
-All files in this repository except those in the `enterprise/` and `client/web/src/enterprise/` directories are open source, and build a product known as Sourcegraph OSS. Sourcegraph OSS omits certain trademarks, logos, and [paid enterprise features](https://about.sourcegraph.com/pricing/) from the official Sourcegraph build to make it open source.
+All files in this repository except those in the `enterprise/` and `client/web/src/enterprise/` directories are open source, and build a product known as Sourcegraph OSS. Sourcegraph OSS omits certain trademarks, logos, and [paid enterprise features](https://about.sourcegraph.com/pricing/) from the official Sourcegraph build to [make it open source](../product/licensing.md).
 
 The official, free Sourcegraph build is called Sourcegraph Core and includes these additions (the source code of which is available in the `/enterprise` and `/src/enterprise` directories and is covered by the [Sourcegraph Enterprise license](https://github.com/sourcegraph/sourcegraph/blob/master/LICENSE)). The reason why we include these features in the official build is to provide a smooth upgrade path to Sourcegraph Enterprise (you can just supply a license key to activate the features, with no migration necessary).
 

--- a/handbook/product/index.md
+++ b/handbook/product/index.md
@@ -33,6 +33,7 @@ Product at Sourcegraph consists of [product management](product_management/index
 - [Working with BizOps](../ops/bizops/index.md#how-to-work-with-us)
 - [User research](./user_research/index.md)
 - [Recommended reading](./onboarding/recommended_reading.md)
+- [Product licensing](licensing.md)
 
 ### Metrics
 

--- a/handbook/product/licensing.md
+++ b/handbook/product/licensing.md
@@ -1,0 +1,28 @@
+# Licensing
+
+Licensing at Sourcegraph can be confusing: the word "license" (or "licence", for the non-Americans in the crowd) is used in two overlapping contexts within Sourcegraph:
+
+1. The software license under which our users obtain and potentially modify our source code, and
+2. The [team or enterprise plan](https://about.sourcegraph.com/pricing) that a customer uses to gain access to enterprise-only features such as [batch changes](https://docs.sourcegraph.com/batch_changes), which is controlled via a [license key](../ce/license_keys.md).
+
+## Software licensing
+
+The core of Sourcegraph is [licensed under the Apache License, version 2.0](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.apache).
+
+As described [in the open source FAQ](../../community/faq.md#is-all-of-sourcegraph-open-source), users can use just that functionality without agreeing to any enterprise licensing terms by building their own server image. If they do so, no code from our enterprise licensed features nor any trademarks or logos will be included in their Sourcegraph deployment. This means that there will be no references to functionality such as batch changes.
+
+Most users, however, will use our prebuilt images, which include code licensed under our [enterprise license](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise). Users who use these images — with or without a paid plan — are agreeing to be bound by the terms of the enterprise license in addition to the terms of the Apache License.
+
+## Plans
+
+To gain full access to enterprise features, paying customers are provided with a [license key](../ce/license_keys.md), usually by a customer engineer. When a prebuilt image is configured with a license key, the functionality covered under the customer's plan or subscription is enabled.
+
+> NOTE: Although it includes the word "license", a license key is _completely_ unrelated to the [software license](#software-licensing) described above.
+
+## Summary
+
+You can think of this as a set of three options from the user's perspective:
+
+1. Run a fully open source deployment of Sourcegraph. No enterprise code is included in this deployment, no enterprise features (or even landing pages for those features) are enabled, and no option is provided to do so.
+2. Run Sourcegraph Core. This corresponds to [the _Free_ option on the pricing page](https://about.sourcegraph.com/pricing/). A Sourcegraph Core deployment includes enterprise code, but without a license key, any functionality provided therein is extremely limited. (For example, batch changes can only be made with up to five changesets.)
+3. Run Sourcegraph with a paid plan. This corresponds to [the _Team_ or _Enterprise_ options on the pricing page](https://about.sourcegraph.com/pricing/). These deployments include enterprise code, with paid features available based on the customer's plan, controlled by their license key.

--- a/handbook/product/licensing.md
+++ b/handbook/product/licensing.md
@@ -9,7 +9,7 @@ Licensing at Sourcegraph can be confusing: the word "license" (or "licence", for
 
 The core of Sourcegraph is [licensed under the Apache License, version 2.0](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.apache).
 
-As described [in the open source FAQ](../../community/faq.md#is-all-of-sourcegraph-open-source), users can use just that functionality without agreeing to any enterprise licensing terms by building their own server image. If they do so, no code from our enterprise licensed features nor any trademarks or logos will be included in their Sourcegraph deployment. This means that there will be no references to functionality such as batch changes.
+As described [in the open source FAQ](../community/faq.md#is-all-of-sourcegraph-open-source), users can use just that functionality without agreeing to any enterprise licensing terms by building their own server image. If they do so, no code from our enterprise licensed features nor any trademarks or logos will be included in their Sourcegraph deployment. This means that there will be no references to functionality such as batch changes.
 
 Most users, however, will use our prebuilt images, which include code licensed under our [enterprise license](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise). Users who use these images — with or without a paid plan — are agreeing to be bound by the terms of the enterprise license in addition to the terms of the Apache License.
 

--- a/handbook/product/licensing.md
+++ b/handbook/product/licensing.md
@@ -11,7 +11,7 @@ The core of Sourcegraph is [licensed under the Apache License, version 2.0](http
 
 As described [in the open source FAQ](../community/faq.md#is-all-of-sourcegraph-open-source), users can use just that functionality without agreeing to any enterprise licensing terms by building their own server image. If they do so, no code from our enterprise licensed features nor any trademarks or logos will be included in their Sourcegraph deployment. This means that there will be no references to functionality such as batch changes.
 
-Most users, however, will use our prebuilt images, which include code licensed under our [enterprise license](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise). Users who use these images — with or without a paid plan — are agreeing to be bound by the terms of the enterprise license in addition to the terms of the Apache License.
+Most users, however, will use our prebuilt images, which include code licensed under our [enterprise license](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.enterprise), and require agreeing to our [terms of service](https://about.sourcegraph.com/terms/) and [privacy policy](https://about.sourcegraph.com/privacy). Users who use these images — with or without a paid plan — are agreeing to be bound by the terms of the enterprise license in addition to the terms of the Apache License.
 
 ## Plans
 
@@ -26,3 +26,5 @@ You can think of this as a set of three options from the user's perspective:
 1. Run a fully open source deployment of Sourcegraph. No enterprise code is included in this deployment, no enterprise features (or even landing pages for those features) are enabled, and no option is provided to do so.
 2. Run Sourcegraph Core. This corresponds to [the _Free_ option on the pricing page](https://about.sourcegraph.com/pricing/). A Sourcegraph Core deployment includes enterprise code, but without a license key, any functionality provided therein is extremely limited. (For example, batch changes can only be made with up to five changesets.)
 3. Run Sourcegraph with a paid plan. This corresponds to [the _Team_ or _Enterprise_ options on the pricing page](https://about.sourcegraph.com/pricing/). These deployments include enterprise code, with paid features available based on the customer's plan, controlled by their license key.
+
+For more information, you may also want to refer to our [explanation of Sourcegraph Enterprise vs Sourcegraph OSS](../ce/enterprise-vs-oss.md).


### PR DESCRIPTION
This came out of a discussion in the ~Badger~ Batcher sync today: we use the word "licence" in multiple contexts, and it's confusing how they interact in practice when discussing feature availability and licensing.

Some of this is ground I'm pretty comfortable with (FOSS licensing), but some of this treads on ground that I'm less comfortable with (anything that makes it sound like I'm a lawyer), so I'm going to take a slow, methodical approach to getting this merged, rather than mashing the merge button as soon as someone approves it.

First up, I'm opening this in draft so @malomarrec can review it and make sure it (a) makes vague sense, (b) aligns with what we discussed this morning, and (c) should actually live in the product section of the handbook. After that, I'll start bothering other people who I won't tag just yet to ensure that we're not telling authoritative sounding lies here.

:badger: 