### PR TITLE
Remove line about future handbook deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Learn how to [create and publish a blog post](https://about.sourcegraph.com/hand
 
 ## Handbook
 
-The [Sourcegraph handbook](https://about.sourcegraph.com/handbook) also lives in this repository. Soon it will be deployed together with the rest of the about.sourcegraph.com site.
+The [Sourcegraph handbook](https://about.sourcegraph.com/handbook) also lives in this repository. This is currently deployed in GCP.
 
 The handbook uses [docsite](https://github.com/sourcegraph/docsite).
 


### PR DESCRIPTION
This line confused me because it was committed a long time ago, so I assumed it was out of date and we already deploy our handbook along with about.sourcegraph.com (along with messages in Slack saying that people looked into Netlify during past downtime). Better to remove and change update it when we actually move it to Netlify.