### PR TITLE
HubSpot: check that email is unknown before populating firstSourceURL

### DIFF
--- a/website/src/components/HubSpot.tsx
+++ b/website/src/components/HubSpot.tsx
@@ -35,7 +35,13 @@ export function createHubSpotForm({ portalId, formId, targetId, onFormSubmit, on
                     }
 
                     const firstSourceURLInput = form.querySelector<HTMLInputElement>('input[name="first_source_url"]')
-                    if (firstSourceURLInput && firstSourceURLInput.value === '') {
+                    const emailInput = form.querySelector<HTMLInputElement>('input[name="email"]')
+                    if (
+                        firstSourceURLInput &&
+                        firstSourceURLInput.value === '' &&
+                        emailInput &&
+                        emailInput.value === ''
+                    ) {
                         // Populate the hidden first_source_url form field with the value from the sourcegraphSourceUrl cookie.
                         firstSourceURLInput.value = firstSourceURL || ''
                     }


### PR DESCRIPTION
HubSpot will pre-populate forms with emails when they are known. If the email is known, we already have a HubSpot contact record, so we don't want to populate first source URL, since they visited the site before we implemented this logic. If we were to populate it for these already-existing contacts, we may cause inaccurate source data.