### PR TITLE
Add a communication step to switching teams process

### DIFF
--- a/handbook/communication/announcements.md
+++ b/handbook/communication/announcements.md
@@ -29,3 +29,7 @@ These posts should cover:
 These posts should NOT cover the reason for the departure, in the interest of respecting the teammate's privacy.
 
 If the teammate chooses, and still has access to Slack, they are free to share any context they may desire.
+
+## Switching Teams
+
+When a teammate [switches teams](../people-ops/switching-teams.md), the teammate's new manager should post a brief note in the #general channel announcing the switch and what the teammate's new responsibilities and role will be.

--- a/handbook/people-ops/switching-teams.md
+++ b/handbook/people-ops/switching-teams.md
@@ -26,6 +26,7 @@ This process is not fixed. If you believe pursuing any steps in a different orde
   - If the new team manager doesn't support the move, you can reach out to the People Ops team to discuss options.
 - If both team managers support the change in principle, you will go through a [short internal interview process](#requirements-for-the-new-manager) for the role.
 - If the internal interview concludes with positive results, the team switch can be planned.
+- Once the transition plan is approved and the impacted teams informed of the switch, the manager receiving the transfer should post an update in the `#general` channel to ensure broad awareness of the change.
 
 ## Requirements for the new manager
 

--- a/handbook/people-ops/switching-teams.md
+++ b/handbook/people-ops/switching-teams.md
@@ -26,7 +26,7 @@ This process is not fixed. If you believe pursuing any steps in a different orde
   - If the new team manager doesn't support the move, you can reach out to the People Ops team to discuss options.
 - If both team managers support the change in principle, you will go through a [short internal interview process](#requirements-for-the-new-manager) for the role.
 - If the internal interview concludes with positive results, the team switch can be planned.
-- Once the transition plan is approved and the impacted teams informed of the switch, the manager receiving the transfer should post an update in the `#general` channel to ensure broad awareness of the change.
+- Once the transition plan is approved and the impacted teams informed of the switch, the teammate's new manager should [post an announcement](../communication/announcements.md).
 
 ## Requirements for the new manager
 


### PR DESCRIPTION
To ensure switching teams doesn't happen without the necessary communication which could lead to uncertainty and confusion.