### PR TITLE
revive "Routing customer questions" page

### DIFF
--- a/handbook/ce/onboarding.md
+++ b/handbook/ce/onboarding.md
@@ -127,6 +127,6 @@ NOTE: Request access/licenses to these tools in [#it-tech-ops](https://sourcegra
     - Prospects: #trial-companyname / new format is: #trial-companyname-sourcegraph
     - Customers: #support-companyname / new format is: #support-companyname-sourcegraph
 - How do I route technical questions to the appropriate team?
-  - [Routing Customer Questions](https://about.sourcegraph.com/handbook/ce/routing_questions)
+  - [Routing Customer Questions](routing_questions.md)
 - Where can I track user feedback?
   - [User Feedback](https://about.sourcegraph.com/handbook/product/user_feedback)

--- a/handbook/ce/routing_questions.md
+++ b/handbook/ce/routing_questions.md
@@ -1,0 +1,83 @@
+# How to route questions from customers
+
+This document is provided as a glossary for new CE team members to know how to route questions from customers. It is a rough feature ownership mapping by team.
+
+In many cases, questions can span multiple teams. For example, a question about how to scale up indexed search to serve a large set of repositories could cover the Distribution, Cloud, and Search teams. In such cases, default to asking the [Distribution team](../engineering/distribution/index.md) for more precise guidance first.
+
+Additions to this document are welcome.
+
+## Subscriptions and licenses
+
+**Keywords**: `subscription`, `license`, `key`, `renew`, `expire`, `contract`
+
+For any questions about contract renewal, the CE and [Sales](../sales/index.md) teams are responsible.
+
+For any questions about license key extension, the CE team is responsible. See the [license key management documentation](../sales/license_keys.md) for guidance.
+
+## Deployment
+
+**Keywords**: `deploy`, `Docker`, `container`, `image`, `Kubernetes`/`k8s`, `cluster`, `AWS`, `Google Cloud`/`GCP`
+
+Any questions about deployment should be routed to the [Distribution team](../engineering/distribution/index.md).
+
+## Monitoring, management, and performance optimization
+
+**Keywords**: `scaling`, `resources`, `performance`/`perf`, `monitoring`, `Grafana`, `Prometheus`
+
+Any questions about monitoring and performance should be routed to the [Distribution team](../engineering/distribution/index.md).
+
+## Code host connections
+
+**Keywords**: `code host`, `cloning`, `syncing`, `token`, `GitHub`, `GitLab`, `Bitbucket`, `Phabricator`, `Gerrit`, `repository`, `project`, `Perforce`, `src-expose`
+
+Any questions about code host connections and repository syncing should be routed to the [Cloud team](../engineering/cloud/index.md).
+
+Note that this section applies to backend connections with code hosts, such as repository cloning and syncing. Questions about [frontend/UI integrations with code hosts](#browser-extensions-and-code-host-native-integrations) (e.g., getting code intelligence inside of a code host) should be rounted to the [Web team](../engineering/web/index.md).
+
+## Repository permissions
+
+**Keywords**: `permissions`, `ACLs`, `access`
+
+Any questions about repository permissions should be routed to the [Cloud team](../engineering/cloud/index.md).
+
+## Code intelligence
+
+**Keywords**: `code intelligence`, `precise`, `navigation`, `LSIF`, `language server`/`LSP`, `go to definition`, `hover`, `find references`, any programming language names (e.g. `Go`, `Java`, `Python`, `COBOL`, etc.)
+
+Any questions about code intelligence and navigation should be routed to the [Code Intelligence team](../engineering/code-intelligence/index.md).
+
+## Search
+
+**Keywords**: `search`, `indexed search`, `indexing`, `diff search`, `symbols`, `keyword`, `filter`, `scope`, `version context`, `repogroup`, `saved search`
+
+Any questions about search should be routed to the [Search team](../engineering/search/index.md).
+
+## Browser extension and code host native integrations
+
+**Keywords**: `browser extension`, `native integration`, `chrome`, `firefox`, `safari`, `Phabricator`, `Bitbucket`, `GitHub`, `GitLab`
+
+Any questions about the browser extension or code host native integrations should be routed to the [Web team](../engineering/web/index.md).
+
+## Sourcegraph extensions
+
+**Keywords**: `extensions`, `plugins`, `blame`, `git-extras`, `Codecov`
+
+Any questions about Sourcegraph extensions should be routed to the [Web team](../engineering/web/index.md).
+
+## Sourcegraph extensions
+
+**Keywords**: `extensions`, `plugins`, `blame`, `git-extras`, `Codecov`
+
+Any questions about Sourcegraph extensions should be routed to the [Web team](../engineering/web/index.md).
+
+## Campaigns
+
+**Keywords**: `campaigns`, `large scale code changes`, `refactoring`
+
+Any questions about campaigns should be routed to the [Campaigns team](../engineering/campaigns/index.md).
+
+## Usage statistics
+
+**Keywords**: `usage`, `users`, `DAU`, `WAU`, `MAU`
+
+Any questions about usage statistics should be routed to the [Business Operations team](../bizops/index.md).


### PR DESCRIPTION
As is, this page is outdated and links to teams and other pages that do not exist. If you want to revive it, you will need to update the contents of the `routing_questions.md` page.

If you don't want to revive it, you can just close this PR and then delete the outdated link to the page from the handbook.

@amenne