### PR TITLE
Update example names to use gender-neutral names

### DIFF
--- a/handbook/communication/content_guidelines/style_and_mechanics.md
+++ b/handbook/communication/content_guidelines/style_and_mechanics.md
@@ -989,10 +989,10 @@ Don’t use examples to compensate for poor documentation. Avoid “cutesy” ex
 
 For consistency, all examples should use the following names (as appropriate).
 
-- **People:** Alice, Bob, Carol, David, Elizabeth (alphabetical first names)
-- **Usernames:** `alice`, `bob`
+- **People:** Logan, Morgan, Jordan, Riley (gender-neutral first names)
+- **Usernames:** `logan`, `morgan`, `jordan`, `riley`
 - **Hostnames:** example.com and subdomains of example.com (avoid using real names such as `mycompany.com`)
-- **Email addresses:** alice@example.com, bob@example.com
+- **Email addresses:** logan@example.com, morgan@example.com
 - **URLs:** https://sourcegraph.example.com (assume HTTPS)
 - **Organizations:** ABC Organization (`abc-org`)
 


### PR DESCRIPTION
This is ultimately a proposal that I'd like to get feedback on from others, as it affects how we write documentation and probably means there's a followup action to find/replace in current docs.

Previously, we used alphabetical first names like Alice and Bob. While this is good for alphabetical ordering and preventing slips in using the wrong name later in docs, it feels unnecessarily gendered. Whenever I use names in product design work, such as for mockups, I always use names like Logan, Morgan, Jordan, and Riley, which (although anglocentric) are effectively gender neutral.

I'd suggest using these names by default, and also adding a few more that represent further diversity.