### PR TITLE
Clarify usage eng-projects folder

### DIFF
--- a/handbook/engineering/environments.md
+++ b/handbook/engineering/environments.md
@@ -22,6 +22,8 @@ These projects contain per-project permissions.
 
 Contains projects used by individual engineers. Engineers are expected to remove all their resources once they are done testing. All projects must be prefixed with `$name-` (the name of the owner).
 
+Generally, these projects should be short-lived and shutdown by the engineer when it is no longer needed (this will delete all resources in the project). Longer lived projects should be put in another folder and distribution should be contacted for review. 
+
 #### Sourcegraph Cloud
 
 Sourcegraph Cloud projects.


### PR DESCRIPTION
As more engineers use the eng project folder for scratch work, we should provide further guidance.