### PR TITLE
Migrate job board to Greenhouse

### DIFF
--- a/company/careers.md
+++ b/company/careers.md
@@ -1,80 +1,10 @@
-# Careers
+# Sourcegraph careers
 
-Join us on our mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. Read [Sourcegraph strategy](strategy.md) to learn more about what we're building, and why it matters.
+<style>
+#sourcegraph-careers {
+  display: none;
+}
+</style>
 
-## Open positions
-
-We're hiring! All our positions are remote. Our teammates are distributed [around the world.](https://about.sourcegraph.com/company/team)
-
-## Internships and new grad hiring
-
-Generally, we are not hiring for interns and new grads. The decision to hire interns and new grads are determined by individual hiring managers. People considered for intern and new grad roles have demonstrated skills and project work above their peer group. Examples of this work are building an open source project related to Sourcegraph, acting as a primary maintainer for a significant open source dependency, significant contribution to open source projects, or something of that caliber. 
-
-### Engineering
-
-- [Director of Engineering - Global code graph](https://jobs.lever.co/sourcegraph/92a29215-e44f-4f2e-b147-73a8cb756d09)
-- [Backend Engineer - Code Insights](https://jobs.lever.co/sourcegraph/5a25e568-575a-4209-b887-05f914ff0650)
-- [Site Reliability Engineer (SRE) / DevOps – Distribution](https://jobs.lever.co/sourcegraph/282b1709-0b4f-47b6-8188-722d8e59b512)
-- [Software Engineer - Distribution](https://jobs.lever.co/sourcegraph/ddef3b91-ce19-4b22-8db4-65e159d7ff2b)
-- Experienced security engineering manager (will be posted soon)
-- Engineering manager for our [Distribution team](../handbook/engineering/distribution/index.md) (will be posted soon)
-- Frontend engineer for our [Extensibility team](../handbook/engineering/web/extensibility/index.md) (will be posted soon)
-
-### Product
-
-- [Director of Product](https://jobs.lever.co/sourcegraph/3d9b0fae-707f-4e38-b8f6-1f5cfd47e9f0)
-- [Product Manager](https://jobs.lever.co/sourcegraph/254299f5-f91b-43e2-aa1a-3732963dd296)
-- [Product Designer](https://jobs.lever.co/sourcegraph/fa7d3807-ae4c-4a35-9401-56dad0958227)
-- Director of Technical Writing (to be posted very soon)
-
-### Sales
-
-- [Account Executive - US East](https://jobs.lever.co/sourcegraph/35aff80b-be4f-4887-a465-3e91e1ca3d2b)
-- [Account Executive - US West](https://jobs.lever.co/sourcegraph/21ff9156-32d9-40e6-b0d5-6d3a555ccd12)
-- [Account Executive - International](https://jobs.lever.co/sourcegraph/c56818d3-9613-4c57-a50d-fc5de3fee01a)
-
-### Customer Engineering
-
-- [Customer Engineer](https://jobs.lever.co/sourcegraph/3ede0606-7a86-45d4-a627-e8cbae7a1a57)
-- [Training Engineer](https://jobs.lever.co/sourcegraph/7aae60bb-228f-4e48-89f8-d16646aa4642)
-
-### Marketing
-
-- [Brand Strategist](https://jobs.lever.co/sourcegraph/9bcfdf33-3ff9-4c57-9c1e-5d6b23b440b5)
-- [Content Marketing Manager](https://jobs.lever.co/sourcegraph/7a4175fb-10c8-4849-8f73-3afc6abe9db8)
-- [Senior Demand Generation Program Manager](https://jobs.lever.co/sourcegraph/5c74fc3f-7b1a-40cb-b106-0bc6c34714ba)
-- [Product Marketing Manager, Emerging Products](https://jobs.lever.co/sourcegraph/d7813bec-5ebe-438c-a826-f12a78516c16)
-
-### Operations, finance, and legal
-
-- [Tech Ops Analyst](https://jobs.lever.co/sourcegraph/40e2f3cc-9cc1-4753-8ab1-c1269e531cf3)
-
-### Talent
-- [Technical Recruiter - Product](https://jobs.lever.co/sourcegraph/c1630817-8de1-41e5-b199-00e1664be861)
-- [Recruiter - GTM](https://jobs.lever.co/sourcegraph/15af1881-2a4d-4c1c-86c2-0e157e4af889)
-
-## Apply
-
-Apply by following the directions in the job description.
-
-If you're interested in Sourcegraph but aren't yet ready to apply, we are still happy to connect and answer any questions that you might have: [DM us on Twitter](https://twitter.com/srcgraph) or email hiring@sourcegraph.com.
-
-## Our team
-
-Our team consists of talented, collaborative, driven individuals who are attracted to the massive problem we are tackling. We work in an open environment that treats people in a first-class manner and provides them with ownership, responsibility, and autonomy. See the [Sourcegraph handbook](https://about.sourcegraph.com/handbook) for more about what it's like to work at Sourcegraph.
-
-## Our work
-
-Most of our work, including our main product, is [open source](https://github.com/sourcegraph)! You can check out our code to see the kinds of problems that we work on, file an issue if you run into any problems, or even submit a PR if you want to help make Sourcegraph better.
-
-## Our pledge
-
-We pledge to make participation in our company an open and welcoming experience for everyone, regardless of ability, age, body size, skin color, culture, education, ethnicity, gender identity and expression, immigration status, level of experience, mental and physical ability, nationality, personal appearance, political beliefs, race, relationship or family status, religion, sex, sexual identity and orientation, or socio-economic status.
-
-We care about the safety and comfort of everyone in our community, including colleagues, contributors, and users.
-
-See more about [diversity, equity, and inclusion](../handbook/communication/dei.md) at Sourcegraph.
-
-## Benefits
-
-[Benefits and perks](../handbook/people-ops/benefits-and-perks.md).
+<script src="https://boards.greenhouse.io/embed/job_board/js?for=sourcegraph91"></script>
+<div id="grnhse_app"></div>

--- a/company/greenhouse-careers.css
+++ b/company/greenhouse-careers.css
@@ -56,6 +56,7 @@ h3 {
 
 #app_body {
   padding-left: 0px !important;
+  max-width: inherit;
 }
 
 #app_body #header {

--- a/company/greenhouse-careers.css
+++ b/company/greenhouse-careers.css
@@ -1,0 +1,64 @@
+/* This file must be uploaded to Greenhouse to affect the job board and job posting styles. The upload option is located in the job board's Developer Settings page. */
+
+body {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Helvetica,Arial,sans-serif,"Apple Color Emoji","Segoe UI Emoji","Segoe UI Symbol";
+  font-size: 16px;
+  color: #24292e;
+}
+
+.accessible #content {
+  line-height: 1.5 !important;
+}
+
+a {
+  font-weight: normal !important;
+}
+
+h1, h2{
+  border-bottom: 1px solid #eaecef;;
+}
+
+h1, h2, h3 {
+  padding-bottom: 0.3em;
+  margin-bottom: 16px !important;
+  font-weight: 600;
+  line-height: 1.25;
+  box-sizing: border-box;
+}
+
+h1 {
+  font-size: 32px;
+  padding-top: 0px !important;
+  margin-top: 0px !important;
+}
+
+h2 {
+  font-size: 24px;
+
+  margin-top: 24px;
+}
+
+h3 {
+  font-size: 20px;
+}
+
+#main {
+  padding-left: 0px;
+  padding-right: 0px;
+  padding-top: 0px;
+}
+
+#wrapper {
+  padding-left: 0px !important;
+  padding-right: 0px !important;
+  padding-top: 0px !important;
+}
+
+#app_body {
+  padding-left: 0px !important;
+}
+
+#app_body #header {
+  margin-bottom: 16px;
+  padding-right: 0px;
+}

--- a/company/index.md
+++ b/company/index.md
@@ -2,6 +2,7 @@
 
 - [**about.sourcegraph.com**](https://about.sourcegraph.com) for information about Sourcegraph (the product and the company)
   - [Careers](careers.md)
+  - [Working at Sourcegraph](working-at-sourcegraph.md)
   - [News](https://about.sourcegraph.com/news)
 - [Sourcegraph handbook](../handbook/index.md#company)
 - [All-remote](remote/index.md)

--- a/company/working-at-sourcegraph.md
+++ b/company/working-at-sourcegraph.md
@@ -6,7 +6,7 @@ Join us on our mission to make it so everyone, in every community, in every coun
 
 We're hiring! All our positions are remote. Our teammates are distributed [around the world](https://about.sourcegraph.com/company/team).
 
-Visit our [careers page to see all open positions](careers).
+Visit our [careers page to see all open positions](careers.md).
 
 ## Internships and new grad hiring
 

--- a/company/working-at-sourcegraph.md
+++ b/company/working-at-sourcegraph.md
@@ -1,0 +1,39 @@
+# Working at Sourcegraph
+
+Join us on our mission to make it so everyone, in every community, in every country, and in every industry can create products using the best technology. Read [Sourcegraph's strategy](strategy.md) to learn more about what we're building, and why it matters.
+
+## Open positions
+
+We're hiring! All our positions are remote. Our teammates are distributed [around the world](https://about.sourcegraph.com/company/team).
+
+Visit our [careers page to see all open positions](careers).
+
+## Internships and new grad hiring
+
+Generally, we are not hiring for interns and new grads. The decision to hire interns and new grads are determined by individual hiring managers. People considered for intern and new grad roles have demonstrated skills and project work above their peer group. Examples of this work are building an open source project related to Sourcegraph, acting as a primary maintainer for a significant open source dependency, significant contribution to open source projects, or something of that caliber.
+
+## Apply
+
+Apply by following the directions in the job description.
+
+If you're interested in Sourcegraph but aren't yet ready to apply, we are still happy to connect and answer any questions that you might have: [DM us on Twitter](https://twitter.com/srcgraph) or email hiring@sourcegraph.com.
+
+## Our team
+
+Our team consists of talented, collaborative, driven individuals who are attracted to the massive problem we are tackling. We work in an open environment that treats people in a first-class manner and provides them with ownership, responsibility, and autonomy. See the [Sourcegraph handbook](https://about.sourcegraph.com/handbook) for more about what it's like to work at Sourcegraph.
+
+## Our work
+
+Most of our work, including our main product, is [open source](https://github.com/sourcegraph)! You can check out our code to see the kinds of problems that we work on, file an issue if you run into any problems, or even submit a PR if you want to help make Sourcegraph better.
+
+## Our pledge
+
+We pledge to make participation in our company an open and welcoming experience for everyone, regardless of ability, age, body size, skin color, culture, education, ethnicity, gender identity and expression, immigration status, level of experience, mental and physical ability, nationality, personal appearance, political beliefs, race, relationship or family status, religion, sex, sexual identity and orientation, or socio-economic status.
+
+We care about the safety and comfort of everyone in our community, including colleagues, contributors, and users.
+
+See more about [diversity, equity, and inclusion](../handbook/communication/dei.md) at Sourcegraph.
+
+## Benefits
+
+[Benefits and perks](../handbook/people-ops/benefits-and-perks.md).


### PR DESCRIPTION
This update migrates us to using an embedded Greenhouse job board.

We may still throw this update away and simply link to Greenhouse instead.

**Job board**
![image](https://user-images.githubusercontent.com/5589410/114769679-604ae480-9d1f-11eb-921c-bb1b7b6539ac.png)

**Job listing example**
![image](https://user-images.githubusercontent.com/5589410/114770307-28906c80-9d20-11eb-959e-517309ff171a.png)
