### PR TITLE
Clarify + simplify: surface all product feedback in #feedback

### DIFF
--- a/handbook/ce/index.md
+++ b/handbook/ce/index.md
@@ -8,7 +8,7 @@ On the Customer Engineering team, we help developers use Sourcegraph to solve th
 We work with many other teams at Sourcegraph, including:
 
 - with the [Sales team](../sales/index.md) in our relationships with prospects and customers; and
-- with the [Product team](../product/index.md) and [Engineering team](../engineering/index.md) on product feedback and requirements (by aggregating and relaying what users tell us, and by helping team members get in touch with or solicit feedback from the right users).
+- with the [Product team](../product/index.md) and [Engineering team](../engineering/index.md) on product feedback and requirements (by aggregating and relaying what users tell us, and by helping team members get in touch with or solicit feedback from the right users – see [surfacing feedback to the product team](../product/surfacing_product_feedback.md)). 
 
 ### What is the difference between a Customer Engineer and Customer Support Engineer?
 CSEs are the go-to technical team for our CEs, helping customers both pre- and post-sales, and allowing CEs to do more proactive work by taking on the reactive technical troubleshooting work when customers experience issues. We can think of CE and CSE as work best friends, working closely together every day. Where Sales is focused on the commercial relationship, CE is focused on product success/usage/adoption. If the CE is stuck, doesn’t know the answer, that is the exact right time to bring in a CSE and let support do the heads-down troubleshooting work.

--- a/handbook/marketing/website_style_guide.md
+++ b/handbook/marketing/website_style_guide.md
@@ -45,19 +45,19 @@ Sourcegraph logomark
 <div class="square blue">
 </div>
 #0fb6f2<br />
-R15 G182 B242
+R15 G182 B242<br />
 PMS 801c
 
 <div class="square purple">
 </div>
 #b114f7<br />
-R177 G20 B247
+R177 G20 B247<br />
 PMS 2592c
 
 <div class="square orange">
 </div>
 #f86012<br />
-R248 G96 B18
+R248 G96 B18<br />
 PMS 1655c
 
 ## Buttons

--- a/handbook/marketing/website_style_guide.md
+++ b/handbook/marketing/website_style_guide.md
@@ -7,7 +7,7 @@ Sourcegraph uses the following styles on <a href="https://about.sourcegraph.com"
 
 ## Logos and icons
 
-- [Download all logo formats](https://f.hubspotusercontent20.net/hubfs/2762526/Brand%20assets/Sourcegraph%20Logos%20(official).zip)
+- [Download all logo formats](https://f.hubspotusercontent20.net/hubfs/2762526/Brand%20assets/Sourcegraph%20Logos_official.zip)
 - [Material design icons](https://materialdesignicons.com/)
 
 <img class="mark" src="https://f.hubspotusercontent20.net/hubfs/2762526/Brand%20assets/sourcegraph-logo.svg" alt="Sourgraph logo">

--- a/handbook/product/product_management/responding_to_user_feedback.md
+++ b/handbook/product/product_management/responding_to_user_feedback.md
@@ -24,6 +24,13 @@ A detailed explanation of the current process and the suggested reply structures
 
 We label and forward issues that others create to the right teams, because those outside the Sourcegraph GitHub organization cannot add labels. [This GitHub search](https://github.com/sourcegraph/sourcegraph/issues?page=2&q=is%3Aissue+no%3Alabel+is%3Aopen) is a fast way to find these issues. 
 
+### Slack [`#feedback`](https://sourcegraph.slack.com/archives/C0W2E592M) channel 
+
+For both self-contained product feedback slack posts and for new GitHub issues with #feedback labels (which automatically cross-post to Slack), the product manager on feedback rotation: 
+
+- Sends the feedback to Productboard
+- Tags the relevant team's stakeholders – usually the product manager and/or engineering manager – in the Slack thread
+
 ## Browser uninstall form feedback
 
 See the [browser uninstall feedback section](https://docs.google.com/document/d/1TTRjK-CL38fdCvrVUgRL70agUiwDbQFJXCo8IuJmLls/edit#bookmark=id.hmb2g29ltsnr) of the feedback workflow doc. 

--- a/handbook/product/surfacing_product_feedback.md
+++ b/handbook/product/surfacing_product_feedback.md
@@ -1,0 +1,30 @@
+# Surfacing feedback to the product team
+
+> If you're working with a specific customer on a bug or issue and need to directly involve a product engineering team, please refer to [engaging other teams](../ce/engaging-other-teams.md). 
+
+CEs, CSEs, sales, marketing, engineering, and other teammates that interact directly with Sourcegraph users and/or Sourcegraph itself should share product feedback with the product team. 
+
+We deeply value this feedback, so we make this process as frictionless for teammates as possible: 
+
+## Post the feedback in [`#feedback`](https://sourcegraph.slack.com/archives/C0W2E592M) on Slack
+
+You're welcome to tag teammates or teams, but that's not necessary – once the feedback is in [#feedback](https://sourcegraph.slack.com/archives/C0W2E592M) the product team will make sure it's routed correctly. 
+
+## When to create a GitHub issue
+
+If you have gotten a specific feedback requests that a customer(s) would like to track the progress of and a GitHub issue for the feedback [does not already exist](https://github.com/sourcegraph/sourcegraph/issues), you can also document this in a [new GitHub issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose) to share with the customer. 
+
+Because a shareable issue is by definition public, you should not include any private customer information. You should still include things like the customer name, by including a link to the customer in Salesforce.
+
+After you create a GitHub issue to share with a customer, please note in the body of the issue that `This issue was created so that a customer can track its progress` so the team is aware. Then you should share a link to this issue in `#feedback`. 
+
+## What if the feedback is [a possible exception]? 
+
+There are no exceptions to the above process! Please do post all product feedback to the #feedback channel – **this includes feedback that you feel might be: minor, not worth surfacing, too harsh, just a personal opinion, or from you rather than a customer**. All feedback helps us make Sourcegraph the best product possible. 
+
+## If you are uncomfortable posting the feedback 
+
+If you are uncomfortable posting feedback directly to #feedback for any reason at all, you are very welcome to DM it on Slack to any [member of the product team](index.md#members). They will make sure it reaches the right folks. In some cases, this may mean they post the feedback to slack after removing any possible connection to you. 
+
+
+

--- a/handbook/product/surfacing_product_feedback.md
+++ b/handbook/product/surfacing_product_feedback.md
@@ -8,15 +8,17 @@ We deeply value this feedback, so we make this process as frictionless for teamm
 
 ## Post the feedback in [`#feedback`](https://sourcegraph.slack.com/archives/C0W2E592M) on Slack
 
-You're welcome to tag teammates or teams, but that's not necessary – once the feedback is in [#feedback](https://sourcegraph.slack.com/archives/C0W2E592M) the product team will make sure it's routed correctly. 
+You're welcome to tag teammates or teams, but that's not necessary – once the feedback is in [#feedback](https://sourcegraph.slack.com/archives/C0W2E592M) the product team will make sure it's routed correctly.  
 
 ## When to create a GitHub issue
 
-If you have gotten a specific feedback requests that a customer(s) would like to track the progress of and a GitHub issue for the feedback [does not already exist](https://github.com/sourcegraph/sourcegraph/issues), you can also document this in a [new GitHub issue](https://github.com/sourcegraph/sourcegraph/issues/new/choose) to share with the customer. 
+If you have gotten a specific feedback requests that a customer(s) would like to track the progress of and a GitHub issue for the feedback [does not already exist](https://github.com/sourcegraph/sourcegraph/issues), you can document this in a [new GitHub issue](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=%23feedback&template=customer_feedback.md&title=) to share with the customer. 
 
-Because a shareable issue is by definition public, you should not include any private customer information. You should still include things like the customer name, by including a link to the customer in Salesforce.
+GitHub issues with the `#feedback` label will automatically post to the #feedback Slack channel on creation; you do not need to manually copy the issue link into #feedback. 
 
-After you create a GitHub issue to share with a customer, please note in the body of the issue that `This issue was created so that a customer can track its progress` so the team is aware. Then you should share a link to this issue in `#feedback`. 
+Because a shareable issue is by definition public, you should not include any private customer information. You should still include things like the customer name, by including a link to the customer in Salesforce. 
+
+If you need to create an issue with more specific customer information, you should [create a new issue in Sourcegraph/Customer](https://github.com/sourcegraph/customer/issues/new/choose), which is private. You can then link that to a public issue in Sourcegraph/Sourcegraph.
 
 ## What if the feedback is [a possible exception]? 
 

--- a/handbook/product/surfacing_product_feedback.md
+++ b/handbook/product/surfacing_product_feedback.md
@@ -8,7 +8,7 @@ We deeply value this feedback, so we make this process as frictionless for teamm
 
 ## Post the feedback in [`#feedback`](https://sourcegraph.slack.com/archives/C0W2E592M) on Slack
 
-You're welcome to tag teammates or teams, but that's not necessary – once the feedback is in [#feedback](https://sourcegraph.slack.com/archives/C0W2E592M) the product team will make sure it's routed correctly.  
+You're welcome to tag teammates or teams, but that's not necessary – once the feedback is in [#feedback](https://sourcegraph.slack.com/archives/C0W2E592M) the product team will [make sure it's routed correctly](product_management/responding_to_user_feedback.md#slack-feedback-channel).  
 
 ## When to create a GitHub issue
 

--- a/handbook/product/user_feedback.md
+++ b/handbook/product/user_feedback.md
@@ -48,7 +48,7 @@ We have a few different email lists that are used to send us feedback.
 ### Slack
 
 - **Purpose:** Slack is a fast way for existing customers and Sourcegraph teammates to provide feedback. 
-- **Owner:** Most feedback in Slack appears in or gets forwarded into a relevant channel that already has clear owners. For feedback that does not have an obvious other location, whoever comes across it should post to the `#feedback` Slack channel. This channel is owned by the Product team. 
+- **Owner:** We [ask that teammates surface product feedback](surfacing_product_feedback.md) in [`#feedback`](https://sourcegraph.slack.com/archives/C0W2E592M). The product manager on [feedback rotation](product_management/responding_to_user_feedback.md#feedback-rotation) owns [routing and logging this feedback](product_management/responding_to_user_feedback.md#slack-feedback-channel).
 
 ### Support tickets
 
@@ -75,7 +75,7 @@ We have a few different email lists that are used to send us feedback.
 ### CE feedback
 
 - **Purpose:** CE teammates work closely with customers and often collect explicit customer feedback, general patterns of feedback they notice with a customer(s), and feedback from using the product themselves. 
-- **Owner:** CE owns putting this feedback in the `#feedback` slack channel, at which point the product team then owns the feedback. 
+- **Owner:** CE owns putting this feedback in the `#feedback` slack channel the [same way](surfacing_product_feedback.md) we ask of other teammates, at which point the product team then owns the feedback. 
 
 ## Productboard
 

--- a/handbook/product/user_feedback.md
+++ b/handbook/product/user_feedback.md
@@ -2,18 +2,19 @@
 
 Our passionate users provide a constant stream of thoughtful feedback and love engaging with us to help them and their teams solve their toughest problems. This trust and feedback is a gift, and we take it seriously and listen carefully to what users tell us.
 
+*This page is most relevant to product team members. If you want to know how to best share feedback with the product team, please see [surfacing product feedback](surfacing_product_feedback.md).* 
+
 ## Sources of feedback
 
-- GitHub issues
-- Twitter
-- Slack
-- Support emails
-- Support tickets
-- Sales feedback
-- HubSpot forms
-- NPS survey
-- Browser extension uninstall feedback
-- Product feedback
+- [Support emails](#support-sourcegraph-com)
+- [GitHub issues](#github-issues)
+- [Twitter](#twitter)
+- [Slack](#slack)
+- [Support tickets](#support-tickets)
+- [Sales feedback](#sales-feedback)
+- [HubSpot forms](#hubspot-forms)
+- [NPS survey](#nps-survey)
+- [Browser extension uninstall feedback](#browser-extension-uninstall-feedback)
 
 ### Email lists
 
@@ -47,7 +48,7 @@ We have a few different email lists that are used to send us feedback.
 ### Slack
 
 - **Purpose:** Slack is a fast way for existing customers and Sourcegraph teammates to provide feedback. 
-- **Owner:** Most feedback in Slack appears in or gets forwarded into a relevant channel that already has clear owners. For feedback that does not have an obvious other location, whoever comes across it should post to the `#feedback` Slack channel.This channel is owned by the Product team. 
+- **Owner:** Most feedback in Slack appears in or gets forwarded into a relevant channel that already has clear owners. For feedback that does not have an obvious other location, whoever comes across it should post to the `#feedback` Slack channel. This channel is owned by the Product team. 
 
 ### Support tickets
 
@@ -70,6 +71,11 @@ We have a few different email lists that are used to send us feedback.
 #### Browser Extension Uninstall Feedback 
 - **Purpose:** We ask everyone who uninstalls the browser extension why they no longer want it. 
 - **Owner:** The browser extension product manager (currently the [Web team product manager](../engineering/web/index.md#members)) owns responding to this feedback. 
+
+### CE feedback
+
+- **Purpose:** CE teammates work closely with customers and often collect explicit customer feedback, general patterns of feedback they notice with a customer(s), and feedback from using the product themselves. 
+- **Owner:** CE owns putting this feedback in the `#feedback` slack channel, at which point the product team then owns the feedback. 
 
 ## Productboard
 


### PR DESCRIPTION
A couple of times in the last few weeks, CE and others have [asked](https://sourcegraph.slack.com/archives/C0C324C91/p1615999158003300) the best way to log product feedback (productboard? GitHub? Slack?). This documents the [process aligned on in a product+CE meeting](https://docs.google.com/document/d/1YkqUQ5QBN7nfKoDia74L5-C4ktvHR9hnoorBTeILJWU/edit?disco=AAAAIRUSmaQ). 

I created a separate page because we had a great set of docs for product team members that explained where we collect and what to do with user feedback, but lacked a page that was directed to non product-team members. 