### PR TITLE
Fix docsite check

### DIFF
--- a/handbook/index.md
+++ b/handbook/index.md
@@ -66,6 +66,8 @@ The handbook is a living document and we expect every teammate to propose improv
 
 ### [Talent](talent/index.md)
 
+- [Careers](careers.md)
+
 ### [Operations](ops/index.md)
 
 - [Business Operations & Strategy](ops/bizops/index.md)


### PR DESCRIPTION
Docsite check is failing with 
`handbook/careers.md: disconnected page (no inlinks from other pages)` 

This adds a small link under the **Talent** heading