### PR TITLE
Update brain food docs

### DIFF
--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -146,31 +146,6 @@ Most meetings at Sourcegraph are video calls. We prefer [Zoom](https://zoom.us) 
 - [Clean escalation](./conflicts.md#clean-resolution)
 - [Customer ethics policy](customer_ethics.md)
 
-## Brain Food
-
-Brain Food meetings are our internal knowledge sharing sessions. These meetings can be formal presentations or informal discussions and are open to anyone in the company. Subjects of talks are completely free and are not limited to tech discussions. Here are a few examples:
-
-- Sharing internal team knowledge to the rest of the company
-- Presenting a useful tool
-- Presenting a personal project
-- Hands on session / workshops
-- Brainstorming session about an experimental subject
-- Preparing an external talk
-
-Brain Food sessions take place every other friday and, to accomodate timezone differences, are split in two separate sessions:
-
-- EMEA friendly session time: 16:00 CET
-- NA friendly session time: 2:00PM PST
-
-Each session is 1-hour long, however the session is only as long as the group needs to present and wants to keep the discussion going. They will both be recorded and published on Slack. Speakers can sign-up for either one of them depending on their own timezone.
-
-Presentations can use one of two formats:
-
-- Lightning Talks: Maximum 7 minutes long
-- Presentation: Maximum 15 minutes long
-
-To sign-up, use this [Google Sheet](https://docs.google.com/spreadsheets/d/1HLVFH9JUxchPNH4FoIQAThorbpdvmTl0ndmZzmpjsuU/edit?usp=sharing). The talk will be added to the Google Calendar invitation which will be sent to everyone.
-
 ## Getting nice email signatures
 
 1. In Gmail **Settings** > **General** scroll down to signature:

--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -146,6 +146,19 @@ Most meetings at Sourcegraph are video calls. We prefer [Zoom](https://zoom.us) 
 - [Clean escalation](./conflicts.md#clean-resolution)
 - [Customer ethics policy](customer_ethics.md)
 
+## Brain Food
+
+Brain Food meetings are our internal knowledge sharing sessions. These meetings can be formal presentations or informal discussions and are open to anyone in the company. Subjects of talks are completely free and are not limited to tech discussions. Here are a few examples:
+
+- Sharing internal team knowledge to the rest of the company
+- Presenting a useful tool
+- Presenting a personal project
+- Hands on session / workshops
+- Brainstorming session about an experimental subject
+- Preparing an external talk
+
+If you have an idea for a session, add an event to the calendar and invite the engineering-team@sourcegraph.com
+
 ## Getting nice email signatures
 
 1. In Gmail **Settings** > **General** scroll down to signature:


### PR DESCRIPTION
Looks like the brain food event trickled off and got removed from the calendar, so I am updating the docs to reflect this.