### PR TITLE
release: update patch release template

### DIFF
--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -55,16 +55,16 @@ Create and test the first release candidate:
     ```sh
     N=1 yarn release release:create-candidate $N
     ```
-- [ ] Ensure that the following pipelines all pass for the `v$MAJOR.$MINOR.$PATCH-rc.1` tag:
+- [ ] Ensure that the following Buildkite pipelines all pass for the `v$MAJOR.$MINOR.$PATCH-rc.1` tag:
   - [ ] [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
   - [ ] [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
   - [ ] [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
 
 - [ ] File any failures and regressions in the pipelines as `release-blocker` issues and assign the appropriate teams.
 
-**Note**: You will need to check the above pipelines again for any subsequent release candidates. You'll need to tweak the "branch" in the buildkite URL to see the build status for these future candidates. In general, the URL scheme looks like the following (replacing `N` in the URL):
+**Note**: You will need to re-check the above pipelines for any subsequent release candidates. You can see the Buildkite logs by tweaking the "branch" query parameter in the URLs to point to the desired release candidate. In general, the URL scheme looks like the following (replacing `N` in the URL):
 
-- sourcegraph: `https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
+- Sourcegraph: `https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
 - QA: `https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
 - E2E: `https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
 

--- a/handbook/engineering/releases/patch_release_issue_template.md
+++ b/handbook/engineering/releases/patch_release_issue_template.md
@@ -55,8 +55,18 @@ Create and test the first release candidate:
     ```sh
     N=1 yarn release release:create-candidate $N
     ```
-- [ ] Ensure the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite passes.
+- [ ] Ensure that the following pipelines all pass for the `v$MAJOR.$MINOR.$PATCH-rc.1` tag:
+  - [ ] [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
+  - [ ] [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
+  - [ ] [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
+
 - [ ] File any failures and regressions in the pipelines as `release-blocker` issues and assign the appropriate teams.
+
+**Note**: You will need to check the above pipelines again for any subsequent release candidates. You'll need to tweak the "branch" in the buildkite URL to see the build status for these future candidates. In general, the URL scheme looks like the following (replacing `N` in the URL):
+
+- sourcegraph: `https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
+- QA: `https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
+- E2E: `https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
 
 ## Stage release
 
@@ -67,7 +77,11 @@ Create and test the first release candidate:
     ```sh
     yarn release release:create-candidate final
     ```
-- [ ] Ensure the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite passes, and for the release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags).
+- [ ] Ensure that the following pipelines all pass for the `v$MAJOR.$MINOR.$PATCH` tag:
+  - [ ] [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH)
+  - [ ] [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH)
+  - [ ] [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=v$MAJOR.$MINOR.$PATCH)
+- [ ] Wait for the `v$MAJOR.$MINOR.$PATCH` release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags)
 - [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes)):
   ```sh
   yarn release release:stage

--- a/handbook/engineering/releases/release_issue_template.md
+++ b/handbook/engineering/releases/release_issue_template.md
@@ -44,10 +44,21 @@ Upon branch cut, create and test release candidates:
   ```sh
   N=1 yarn release release:create-candidate $N
   ```
-- [ ] Wait for the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite to complete.
+- [ ] Ensure that the following Buildkite pipelines all pass for the `v$MAJOR.$MINOR.$PATCH-rc.1` tag:
+  - [ ] [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
+  - [ ] [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
+  - [ ] [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.1)
+
 - [ ] File any failures and regressions in the pipelines as `release-blocker` issues and assign the appropriate teams.
 
 Revert or disable features that may cause delays. As necessary, `git cherry-pick` bugfix (not feature!) commits from `main` into the release branch. Continue to create new release candidates as necessary, until no more `release-blocker` issues remain.
+
+
+**Note**: You will need to re-check the above pipelines for any subsequent release candidates. You can see the Buildkite logs by tweaking the "branch" query parameter in the URLs to point to the desired release candidate. In general, the URL scheme looks like the following (replacing `N` in the URL):
+
+- Sourcegraph: `https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
+- QA: `https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
+- E2E: `https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH-rc.N`
 
 - [ ] Post a release status update to Slack:
   ```sh
@@ -65,7 +76,11 @@ Once there are no more release-blocking issues (as reported by the `release:stat
   ```sh
   yarn release release:create-candidate final
   ```
-- [ ] Ensure the [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=$MAJOR.$MINOR), [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=$MAJOR.$MINOR), and [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=$MAJOR.$MINOR) in Buildkite passes, and for the release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags).
+- [ ] Ensure that the following pipelines all pass for the `v$MAJOR.$MINOR.$PATCH` tag:
+  - [ ] [Sourcegraph pipeline](https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v$MAJOR.$MINOR.$PATCH)
+  - [ ] [QA pipeline](https://buildkite.com/sourcegraph/qa/builds?branch=v$MAJOR.$MINOR.$PATCH)
+  - [ ] [E2E pipeline](https://buildkite.com/sourcegraph/e2e/builds?branch=v$MAJOR.$MINOR.$PATCH)
+- [ ] Wait for the `v$MAJOR.$MINOR.$PATCH` release Docker images to be available in [Docker Hub](https://hub.docker.com/r/sourcegraph/server/tags)
 - [ ] Open PRs that publish the new release and address any action items required to finalize draft PRs (track PR status via the [generated release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes)):
   ```sh
   yarn release release:stage
@@ -74,11 +89,10 @@ Once there are no more release-blocking issues (as reported by the `release:stat
 ## Finalize release
 
 - [ ] From the [release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes), merge the release-publishing PRs created previously.
-  - For [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph), also:
-    - [ ] Tag the `v$MAJOR.$MINOR.0` release at the most recent commit on the `v$MAJOR.$MINOR` branch.
-        ```sh
-        VERSION='v$MAJOR.$MINOR.0' bash -c 'git tag -a "$VERSION" -m "$VERSION" && git push origin "$VERSION"'
-        ```
+  - For [deploy-sourcegraph](https://github.com/sourcegraph/deploy-sourcegraph)
+    - [ ] Ensure the [release](https://github.com/sourcegraph/deploy-sourcegraph/releases) has the correct tag
+ - [ ] For [deploy-sourcegraph-docker](https://github.com/sourcegraph/deploy-sourcegraph-docker)
+    - [ ] Ensure the [release](https://github.com/sourcegraph/deploy-sourcegraph-docker/releases) has the correct tag
   - For [sourcegraph](https://github.com/sourcegraph/sourcegraph), also:
     - [ ] Cherry pick the release-publishing PR from `sourcegraph/sourcegraph@main` into the release branch.
 - [ ] Ask the product team (`#product`) to merge the blog post. Add the pull request to the release batch change:


### PR DESCRIPTION
This PR changes the templates in the release tool to have Buildkite URLs that point to the specific MAJOR.MINOR.PATCH builds instead of the generic MAJOR.MINOR build. 

For example, the buildkite urls for the `3.27.4` patch release used to only point to the `3.27` branch:

```
https://buildkite.com/sourcegraph/sourcegraph/builds?branch=3.27
...
```

Which was never the build status that you cared about. Now, they'll point to the specific release candidate

```
https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v3.27.4-rc.1
...
```

and the correct tag for the final build:

```
https://buildkite.com/sourcegraph/sourcegraph/builds?branch=v3.27.4
```