### PR TITLE
Batch changes ce onboarding

### DIFF
--- a/handbook/ce/onboarding.md
+++ b/handbook/ce/onboarding.md
@@ -55,6 +55,7 @@ Welcome to Sourcegraph - we're very excited to have you on the Customer Engineer
 - Shadow as many customer/prospect calls as possible
 - Participate in any relevant training sessions or workshops
 - Deliver demo cert presentation to team
+- Go through the [Batch Change CE onboarding](../engineering/batch-changes/ce-onboarding.md)
 
 ### Month 2
 

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -34,6 +34,11 @@ Answer those questions:
 ### Step 2: comby
 Let's use [comby](https://comby.dev/). Batch Changes can run any code change tool, but comby is great for structural-type change. See how it works with Batch Changes in this [tutorial](https://docs.sourcegraph.com/batch_changes/tutorials/refactor_go_comby). Don't publish your changesets yet!
 
+Answer those question:
+- what is comby?
+- does batch change rely on comby?
+
+
 ### Step 3: The `on` attribute
 Can you scope down your batch change to only a few repos? Look at the [`on`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#on) attribute, and scope down your batch-change to <repo1> <repo2> <repo3>
 
@@ -41,7 +46,7 @@ Can you scope down your batch change to only a few repos? Look at the [`on`](htt
 Sometimes you want to publish only _some_ but not all changesets to the codehosts and keep the others unpublished, for example to test out if the repository owners will merge the changesets. Find out how to publish only on <repo> using the [`published`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#changesettemplate-published) attribute
 
 ### Step 5: Templating
-Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating) to TODO:find an approachable use case compatible with the comby example
+Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating) to TODO:find an approachable use case compatible with the comby example.
 
 ### Step 6: Tracking existing changesets
 Batch Changes can track changesets that have been created manually. Create a new batch change to track the last 10 changesets opened on [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -1,0 +1,55 @@
+# Batch Changes CE onboarding
+
+Welcome to Batch Changes! This page is primarily for new members of the CE team, but it could be helpful to others, too! After going through these steps, you should:
+
+- understand what Batch Changes is
+- be able to present it to customers from a value, usage, and functional perspective
+- be comfortable demoing Batch Changes to developers and answering questions
+
+## Prerequisites
+General [CE onboarding](../../ce/onboarding.md)
+
+## Part 1: Discover Batch Changes
+- Watch the [demo video](https://www.youtube.com/watch?v=eOmiyXIWTCw) and checkout the [landing page](https://about.sourcegraph.com/batch-changes/)
+- What is Batch Changes, and why does it matter to customers? Read about [product positioning and messaging](../../marketing/batch_changes_positioning.md)
+- How to demo Batch Changes? Watch the [Batch Changes deep dive](https://docs.google.com/presentation/d/1CN3KQf1Hfdb4RO6FgBgKuiHK4ERcOAHPgVnOcBu-MPU/edit#slide=id.ga366db8d9b_0_116)
+- How does Batch Changes work? Read the Batch Changes documentation section of the [Supporting Batch Changes guide](./supporting-batch-changes#batch-changes-documentation.md)
+
+
+## Part 2: Use Batch Changes
+
+- If you are blocked at any time during onboarding, ask for help in [#batch-changes](https://sourcegraph.slack.com/archives/CMMTWQQ49).
+- Feel free to document your onboarding experience and share it back with the Bacth Changes team so that we can make this even better!
+- In this tutorial, we will use [k8s.sgdev.org](https://k8s.sgdev.org) as our environment. You should have access by default using SSO.
+- Tip: Use the docs extensively to complete the tutorial steps.
+
+### Step 1: Quickstart
+Let's start with a quick setup example to warm up: [Quickstart](https://docs.sourcegraph.com/batch_changes/quickstart).
+
+Answer those questions:
+- what does `on` do?
+- what are `steps`?
+- what is the difference between *apply* and *publish*?
+
+### Step 2: comby
+Let's use [comby](https://comby.dev/). Batch Changes can run any code change tool, but comby is great for structural-type change. See how it works with Batch Changes in this [tutorial](https://docs.sourcegraph.com/batch_changes/tutorials/refactor_go_comby). Don't publish your changesets yet!
+
+### Step 3: The `on` attribute
+Can you scope down your batch change to only a few repos? Look at the [`on`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#on) attribute, and scope down your batch-change to <repo1> <repo2> <repo3>
+
+### Step 4: Publishing
+Sometimes you want to publish only _some_ but not all changesets to the codehosts and keep the others unpublished, for example to test out if the repository owners will merge the changesets. Find out how to publish only on <repo> using the [`published`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#changesettemplate-published) attribute
+
+### Step 5: Templating
+Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating) to TODO:find an approachable use case compatible with the comby example
+
+### Step 6: Tracking existing changesets
+Batch Changes can track changesets that have been created manually. Create a new batch change to track the last 10 changesets opened on [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).
+
+## Part 3: Get feedback
+Record yourself demo-ing Batch Changes, and send a link to your video to @malo to get feedback and fine tune your approach!
+
+## There's always more!
+Congrats!!! This is the end of the Batch Changes CE onboarding, we hope it was useful to you!
+
+Feel free to continue exploring the docs, and check out our [Batch Changes examples](https://github.com/sourcegraph/batch-change-examples) (contributions welcome).

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -20,13 +20,13 @@ General [CE onboarding](../../ce/onboarding.md)
 
 - If you are blocked at any time during onboarding, ask for help in [#batch-changes](https://sourcegraph.slack.com/archives/CMMTWQQ49).
 - Feel free to document your onboarding experience and share it back with the Bacth Changes team so that we can make this even better!
-- In this tutorial, we will use [k8s.sgdev.org](https://k8s.sgdev.org) as our environment. You should have access by default using SSO.
+- In this tutorial, we will use [demo.sourcegraph.com](https://demo.sourcegraph.com) as our environment. You should have access by default using SSO.
 - Tip: Use the docs extensively to complete the tutorial steps.
 
 ### Step 1: Quickstart
 Let's start with a quick setup example to warm up: [Quickstart](https://docs.sourcegraph.com/batch_changes/quickstart).
 
-Answer those questions:
+By the end of this step, you should be able to answer:
 - what does `on` do?
 - what are `steps`?
 - what is the difference between *apply* and *publish*?
@@ -34,7 +34,7 @@ Answer those questions:
 ### Step 2: comby
 Let's use [comby](https://comby.dev/). Batch Changes can run any code change tool, but comby is great for structural-type change. See how it works with Batch Changes in this [tutorial](https://docs.sourcegraph.com/batch_changes/tutorials/refactor_go_comby). Don't publish your changesets yet!
 
-Answer those question:
+By the end of this step, you should be able to answer:
 - what is comby?
 - does Batch Changes rely on comby?
 

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -46,9 +46,12 @@ Can you scope down your batch change to only a two repositories? Modify the spec
 Sometimes you want to publish only _some_ but not all changesets to the codehosts and keep the others unpublished, for example to test out if the repository owners will merge the changesets. Find out how to publish only on [sourcegraph-ce-onboarding/tiny-go-testing-repository] using [`published`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#changesettemplate-published).
 
 ### Step 5: Templating
-Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating) to TODO:find an approachable use case compatible with the comby example.
+Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating) to add an additional step to the spec, and run a linter _only_ on the files that have been modified?
 
 Tip: we maintain a [cheat sheet](https://docs.sourcegraph.com/batch_changes/references/batch_spec_cheat_sheet) with commonly used patterns
+
+By the end of this step, you should be able to answer:
+- what is templating? why is it useful?
 
 ### Step 6: Tracking existing changesets
 Batch Changes can track changesets that have been created manually. Create a new batch change to track the last 10 changesets opened on [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -57,7 +57,11 @@ By the end of this step, you should be able to answer:
 Batch Changes can track changesets that have been created manually. Create a new batch change to track the last 10 changesets opened on [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).
 
 ## Part 3: Get feedback
-Record yourself demo-ing Batch Changes, and send a link to your video to @malo to get feedback and fine tune your approach!
+Record yourself demo-ing Batch Changes, and send a link to your video to @malo on slack to get feedback and fine tune your approach! Aim for a demo of less than 10 minutes, and feel free to use this structure:
+
+- Explain the high level value
+- Run the user through how to create a batch change (feel free to skip the CLI execution time)
+- Run the user though tracking batch changes from the GUI?
 
 ## There's always more!
 Congrats!!! This is the end of the Batch Changes CE onboarding, we hope it was useful to you.

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -1,6 +1,6 @@
 # Batch Changes CE onboarding
 
-Welcome to Batch Changes! This page is primarily for new members of the CE team, but it could be helpful to other teams, too! After going through these steps, you should:
+Welcome to Batch Changes! This page is primarily for new members of the CE team, but it could be helpful to other teams, too. After going through these steps, you should:
 
 - understand what Batch Changes is
 - be able to present it to customers from a value, usage, and functional perspective
@@ -57,6 +57,6 @@ Batch Changes can track changesets that have been created manually. Create a new
 Record yourself demo-ing Batch Changes, and send a link to your video to @malo to get feedback and fine tune your approach!
 
 ## There's always more!
-Congrats!!! This is the end of the Batch Changes CE onboarding, we hope it was useful to you!
+Congrats!!! This is the end of the Batch Changes CE onboarding, we hope it was useful to you.
 
 Feel free to continue exploring the docs, and check out our [Batch Changes examples](https://github.com/sourcegraph/batch-change-examples) (contributions welcome).

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -32,7 +32,7 @@ By the end of this step, you should be able to answer:
 - what is the difference between *apply* and *publish*?
 
 ### Step 2: comby
-Let's use [comby](https://comby.dev/). Batch Changes can run any code change tool, but comby is great for structural-type change. See how it works with Batch Changes in this [tutorial](https://docs.sourcegraph.com/batch_changes/tutorials/refactor_go_comby). Don't publish your changesets yet!
+Let's use [comby](https://comby.dev/). Batch Changes can run any code change tool, but comby is great for structural-type change. See how it works with Batch Changes in this [tutorial](https://docs.sourcegraph.com/batch_changes/tutorials/refactor_go_comby). We have created three playground repositories that you can open changesets on: add `repo:sourcegraph-ce-onboarding` to the search query to limit the search results to those. Don't publish your changesets yet!
 
 By the end of this step, you should be able to answer:
 - what is comby?
@@ -40,10 +40,10 @@ By the end of this step, you should be able to answer:
 
 
 ### Step 3: The `on` attribute
-Can you scope down your batch change to only a few repos? Modify the spec to scope down your batch change to <repo1> <repo2> <repo3>. Tip: you may find [`on`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#on) useful.
+Can you scope down your batch change to only a two repositories? Modify the spec to scope down your batch change to [sourcegraph-ce-onboarding/titan](https://github.com/sourcegraph-ce-onboarding/titan) and [sourcegraph-ce-onboarding/tiny-go-testing-repository](https://github.com/sourcegraph-ce-onboarding/tiny-go-testing-repository). Tip: you may find [`on`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#on) useful.
 
 ### Step 4: Publishing
-Sometimes you want to publish only _some_ but not all changesets to the codehosts and keep the others unpublished, for example to test out if the repository owners will merge the changesets. Find out how to publish only on <repo> using the [`published`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#changesettemplate-published) attribute
+Sometimes you want to publish only _some_ but not all changesets to the codehosts and keep the others unpublished, for example to test out if the repository owners will merge the changesets. Find out how to publish only on [sourcegraph-ce-onboarding/tiny-go-testing-repository] using [`published`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#changesettemplate-published).
 
 ### Step 5: Templating
 Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating) to TODO:find an approachable use case compatible with the comby example.

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -12,14 +12,13 @@ General [CE onboarding](../../ce/onboarding.md)
 ## Part 1: Discover Batch Changes
 - Watch the [demo video](https://www.youtube.com/watch?v=eOmiyXIWTCw) and checkout the [landing page](https://about.sourcegraph.com/batch-changes/)
 - What is Batch Changes, and why does it matter to customers? Read about [product positioning and messaging](../../marketing/batch_changes_positioning.md)
-- How to demo Batch Changes? Watch the [Batch Changes deep dive](https://docs.google.com/presentation/d/1CN3KQf1Hfdb4RO6FgBgKuiHK4ERcOAHPgVnOcBu-MPU/edit#slide=id.ga366db8d9b_0_116)
+- How to demo Batch Changes? Read the [Batch Changes deep dive](https://docs.google.com/presentation/d/1CN3KQf1Hfdb4RO6FgBgKuiHK4ERcOAHPgVnOcBu-MPU/edit#slide=id.ga366db8d9b_0_116)
 - How does Batch Changes work? Read the Batch Changes documentation section of the [Supporting Batch Changes guide](./supporting-batch-changes.md#batch-changes-documentation)
-
 
 ## Part 2: Use Batch Changes
 
-- If you are blocked at any time during onboarding, ask for help in [#batch-changes](https://sourcegraph.slack.com/archives/CMMTWQQ49).
-- Feel free to document your onboarding experience and share it back with the Bacth Changes team so that we can make this even better!
+- If you are blocked at any time during onboarding, ask for help in [#batch-changes](https://sourcegraph.slack.com/archives/CMMTWQQ49). If you are blocked, others will be as well and we want to know about it.
+- Feel free to document your onboarding experience and share it back with the Batch Changes team so that we can make this even better!
 - In this tutorial, we will use [demo.sourcegraph.com](https://demo.sourcegraph.com) as our environment. You should have access by default using SSO.
 - Tip: Use the docs extensively to complete the tutorial steps.
 
@@ -27,14 +26,17 @@ General [CE onboarding](../../ce/onboarding.md)
 Let's start with a quick setup example to warm up: [Quickstart](https://docs.sourcegraph.com/batch_changes/quickstart).
 
 By the end of this step, you should be able to answer:
+
 - what does `on` do?
 - what are `steps`?
-- what is the difference between *apply* and *publish*?
+- what is the difference between *applying* and *publishing*?
+- what are steps required to configure Batch Changes?
 
 ### Step 2: comby
 Let's use [comby](https://comby.dev/). Batch Changes can run any code change tool, but comby is great for structural-type change. See how it works with Batch Changes in this [tutorial](https://docs.sourcegraph.com/batch_changes/tutorials/refactor_go_comby). We have created three playground repositories that you can open changesets on: add `repo:sourcegraph-ce-onboarding` to the search query to limit the search results to those. Don't publish your changesets yet!
 
 By the end of this step, you should be able to answer:
+
 - what is comby?
 - does Batch Changes rely on comby?
 
@@ -43,7 +45,7 @@ By the end of this step, you should be able to answer:
 Can you scope down your batch change to only a two repositories? Modify the spec to scope down your batch change to [sourcegraph-ce-onboarding/titan](https://github.com/sourcegraph-ce-onboarding/titan) and [sourcegraph-ce-onboarding/tiny-go-testing-repository](https://github.com/sourcegraph-ce-onboarding/tiny-go-testing-repository). Tip: you may find [`on`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#on) useful.
 
 ### Step 4: Publishing
-Sometimes you want to publish only _some_ but not all changesets to the codehosts and keep the others unpublished, for example to test out if the repository owners will merge the changesets. Find out how to publish only on [sourcegraph-ce-onboarding/tiny-go-testing-repository] using [`published`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#changesettemplate-published).
+Sometimes you want to publish only _some_ but not all changesets to the code host and keep the others unpublished, for example to test out if the repository owners will merge the changesets. Find out how to publish only on [sourcegraph-ce-onboarding/tiny-go-testing-repository](https://github.com/sourcegraph-ce-onboarding/tiny-go-testing-repository) using [`published`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#changesettemplate-published).
 
 ### Step 5: Templating
 Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating) to add an additional step to the spec, and run a linter _only_ on the files that have been modified?
@@ -51,10 +53,11 @@ Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/b
 Tip: we maintain a [cheat sheet](https://docs.sourcegraph.com/batch_changes/references/batch_spec_cheat_sheet) with commonly used patterns
 
 By the end of this step, you should be able to answer:
+
 - what is templating? why is it useful?
 
 ### Step 6: Tracking existing changesets
-Batch Changes can track changesets that have been created manually. Create a new batch change to track the last 10 changesets opened on [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).
+Batch Changes can [track changesets](https://docs.sourcegraph.com/batch_changes/how-tos/tracking_existing_changesets) that have been created manually. Create a new batch change to track the last 10 changesets opened on [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).
 
 ## Part 3: Get feedback
 Record yourself demo-ing Batch Changes, and send a link to your video to @malo on slack to get feedback and fine tune your approach! Aim for a demo of less than 10 minutes, and feel free to use this structure:

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -13,7 +13,7 @@ General [CE onboarding](../../ce/onboarding.md)
 - Watch the [demo video](https://www.youtube.com/watch?v=eOmiyXIWTCw) and checkout the [landing page](https://about.sourcegraph.com/batch-changes/)
 - What is Batch Changes, and why does it matter to customers? Read about [product positioning and messaging](../../marketing/batch_changes_positioning.md)
 - How to demo Batch Changes? Watch the [Batch Changes deep dive](https://docs.google.com/presentation/d/1CN3KQf1Hfdb4RO6FgBgKuiHK4ERcOAHPgVnOcBu-MPU/edit#slide=id.ga366db8d9b_0_116)
-- How does Batch Changes work? Read the Batch Changes documentation section of the [Supporting Batch Changes guide](./supporting-batch-changes#batch-changes-documentation.md)
+- How does Batch Changes work? Read the Batch Changes documentation section of the [Supporting Batch Changes guide](./supporting-batch-changes.md#batch-changes-documentation)
 
 
 ## Part 2: Use Batch Changes

--- a/handbook/engineering/batch-changes/ce-onboarding.md
+++ b/handbook/engineering/batch-changes/ce-onboarding.md
@@ -1,6 +1,6 @@
 # Batch Changes CE onboarding
 
-Welcome to Batch Changes! This page is primarily for new members of the CE team, but it could be helpful to others, too! After going through these steps, you should:
+Welcome to Batch Changes! This page is primarily for new members of the CE team, but it could be helpful to other teams, too! After going through these steps, you should:
 
 - understand what Batch Changes is
 - be able to present it to customers from a value, usage, and functional perspective
@@ -36,17 +36,19 @@ Let's use [comby](https://comby.dev/). Batch Changes can run any code change too
 
 Answer those question:
 - what is comby?
-- does batch change rely on comby?
+- does Batch Changes rely on comby?
 
 
 ### Step 3: The `on` attribute
-Can you scope down your batch change to only a few repos? Look at the [`on`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#on) attribute, and scope down your batch-change to <repo1> <repo2> <repo3>
+Can you scope down your batch change to only a few repos? Modify the spec to scope down your batch change to <repo1> <repo2> <repo3>. Tip: you may find [`on`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#on) useful.
 
 ### Step 4: Publishing
 Sometimes you want to publish only _some_ but not all changesets to the codehosts and keep the others unpublished, for example to test out if the repository owners will merge the changesets. Find out how to publish only on <repo> using the [`published`](https://docs.sourcegraph.com/batch_changes/references/batch_spec_yaml_reference#changesettemplate-published) attribute
 
 ### Step 5: Templating
 Can you use [templating](https://docs.sourcegraph.com/batch_changes/references/batch_spec_templating) to TODO:find an approachable use case compatible with the comby example.
+
+Tip: we maintain a [cheat sheet](https://docs.sourcegraph.com/batch_changes/references/batch_spec_cheat_sheet) with commonly used patterns
 
 ### Step 6: Tracking existing changesets
 Batch Changes can track changesets that have been created manually. Create a new batch change to track the last 10 changesets opened on [sourcegraph/sourcegraph](https://github.com/sourcegraph/sourcegraph).

--- a/handbook/engineering/batch-changes/index.md
+++ b/handbook/engineering/batch-changes/index.md
@@ -129,6 +129,7 @@ The Batch Changes team is the current owner of [src-cli](https://github.com/sour
 - [Developer documentation](https://docs.sourcegraph.com/dev/background-information/batch_changes)
 - [Onboarding](onboarding.md)
 - [Supporting Batch Changes](supporting-batch-changes.md)
+- [CE onboarding](ce-onboarding.md)
 - [Batch Changes Drive Folder (private)](https://drive.google.com/drive/u/0/folders/18Sa_NpsVRvVV8MIvuXyoDEinpEf8fbGn)
 - [Batch Changes Product Marketing Brief](https://docs.google.com/document/d/1yQpCKF50gx8_T-KDnU4s9TjW6fZpMUfWLF2h4xSM8jk)
 


### PR DESCRIPTION
A more guided Batch Changes onboarding checklist for new CEs. As the CE team grows, new CEs will be rapidly exposed to demo-ing Batch Changes. When I first joined, I experienced the pain of getting to a state where I was comfortable with demos, given that Batch Changes has many components, a templating language, is still evolving fast and elicits complex questions from customers.

This is an attempt to provide an onboarding so that, upon completion, new CEs are comfortable with most demos.

### TODO
- [x] add an (approachable) templating example 
- [x] create a few repository forks, containing matches for the comby example, where it's OK for CEs to open PRs

### TODO (in future versions)
- [ ] decide on compatibility with support quests
- [ ] update to account for new [high level demo flow](https://sourcegraph.slack.com/archives/CMMTWQQ49/p1621009232053600)
- [ ] add a recording of a CE demo-ing Batch Changes

### Limitations
- This might eventually be moved to a dedicated training platform, depending on what people ops decide.
- It would be nice to have a Q&A mechanism to replace the open-ended "answer these questions"
- The Batch Changes deep dive is a bit outdated, and is not maintained regularly (at each release). It would be nice to break down the training video into small, atomic feature by feature video that don't get outdated that fast, and add new ones when we release updates

### Success
We know this is successful if 
- this is adopted, i.e. we receive demo videos from new CEs
- CE report being comfortable demo-ing Batch Changes rapidly after joining (I won't measure that, but could be a question for onboarding questionnaires)
