### PR TITLE
Update engineering/roles.md to correct links

### DIFF
--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -21,7 +21,7 @@ Engineering managers lead, grow, and develop teams of software engineers.
 ### Responsibilities
 
 - Facilitate and sustain a healthy, inclusive team culture where everyone is set up to do their best work (examples: [retrospectives](../../retrospectives/index.md), [team events](../people-ops/travel.md#team-events), [compensation](../people-ops/compensation/index.md)).
-- Model, teach, and apply [our values](../../../company/values.md) and [our guiding engineering principles](principles-and-practices).
+- Model, teach, and apply [our values](../../../company/values.md) and [our guiding engineering principles](principles-and-practices.md).
 - Ensure the team has clear incremental goals that are documented and are always up-to-date (example: [PM – EM partnership responsibilities](../product/roles/product_manager_engineering_manager_responsibilities.md)).
 - Regularly communicate the team's progress toward their goals as well as changes in team goals to appropriate stakeholders (examples: presenting a slide at [company meeting](../communication/company_meeting.md), [weekly updates](engineering-management.md#status-updates))
 - Support and coach teammates to grow in their careers and fulfill their responsibilities (examples: [1-1s](../leadership/1-1.md), [retrospectives](), [review cycles](https://about.sourcegraph.com/handbook/people-ops/review-cycles/index.md), [compensation](../people-ops/compensation/index.md))

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -8,7 +8,7 @@ Software engineers build our product and infrastructure.
 
 ### Responsibilities
 
-- Model and apply [our company values](../../company/values.md) and our [guiding engineering principles](principles-and-practices) throughout all your interactions and work.
+- Model and apply [our company values](../../company/values.md) and our [guiding engineering principles](principles-and-practices.md) throughout all your interactions and work.
 - Iteratively create, ship, and maintain high quality architecture, code, tests, and documentation that aligns with team goals.
 - Document and share your progress in relevant locations at least once a week (for example: in GitHub issues, team slack channel, #progress, [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)).
 - Prioritize unblocking and supporting your teammates (for example: sharing knowledge, answering questions, providing feedback).

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -8,7 +8,7 @@ Software engineers build our product and infrastructure.
 
 ### Responsibilities
 
-- Model and apply [our company values](../../company/values.md) and our [guiding engineering principles](index.md#guiding-principles) throughout all your interactions and work.
+- Model and apply [our company values](../../company/values.md) and our [guiding engineering principles](principles-and-practices) throughout all your interactions and work.
 - Iteratively create, ship, and maintain high quality architecture, code, tests, and documentation that aligns with team goals.
 - Document and share your progress in relevant locations at least once a week (for example: in GitHub issues, team slack channel, #progress, [CHANGELOG.md](https://github.com/sourcegraph/sourcegraph/blob/main/CHANGELOG.md)).
 - Prioritize unblocking and supporting your teammates (for example: sharing knowledge, answering questions, providing feedback).
@@ -21,7 +21,7 @@ Engineering managers lead, grow, and develop teams of software engineers.
 ### Responsibilities
 
 - Facilitate and sustain a healthy, inclusive team culture where everyone is set up to do their best work (examples: [retrospectives](../../retrospectives/index.md), [team events](../people-ops/travel.md#team-events), [compensation](../people-ops/compensation/index.md)).
-- Model, teach, and apply [our values](../../../company/values.md) and [our guiding engineering principles](../index.md#guiding-principles).
+- Model, teach, and apply [our values](../../../company/values.md) and [our guiding engineering principles](principles-and-practices).
 - Ensure the team has clear incremental goals that are documented and are always up-to-date (example: [PM – EM partnership responsibilities](../product/roles/product_manager_engineering_manager_responsibilities.md)).
 - Regularly communicate the team's progress toward their goals as well as changes in team goals to appropriate stakeholders (examples: presenting a slide at [company meeting](../communication/company_meeting.md), [weekly updates](engineering-management.md#status-updates))
 - Support and coach teammates to grow in their careers and fulfill their responsibilities (examples: [1-1s](../leadership/1-1.md), [retrospectives](), [review cycles](https://about.sourcegraph.com/handbook/people-ops/review-cycles/index.md), [compensation](../people-ops/compensation/index.md))


### PR DESCRIPTION
Links to engineering guiding principles were incorrect. Updated in both Software Engineer and Engineering Manager role sections.