### PR TITLE
Integrate Swiftype search for handbook

### DIFF
--- a/_resources/assets/layout.css
+++ b/_resources/assets/layout.css
@@ -155,6 +155,10 @@ footer a {
 	border: solid 1px var(--border-color);
 	border-radius: 0;
 	width: 10rem;
+  /* the styles below are related to the Swiftype search integration */
+  height: initial;
+  padding-left: 30px;
+  background-position-y: 10px;
 }
 #search-button {
 	margin-left: 0.125rem;

--- a/_resources/templates/root.html
+++ b/_resources/templates/root.html
@@ -24,7 +24,7 @@
 			analytics_storage: "denied",
 			wait_for_update: 500
 		});
-		gtag("set", "ads_data_redaction", true);	
+		gtag("set", "ads_data_redaction", true);
 	</script>
 	<!-- Google Tag Manager -->
 	<script data-cookieconsent="ignore">(function (w, d, s, l, i) {
@@ -55,7 +55,7 @@
 			<nav>
 				<form id="search-form" method="get" action="/search">
 					<input type="text" id="search-input" name="q" value="{{block "query" .}}{{end}}"
-						placeholder="Search handbook..." spellcheck="false" />
+						placeholder="Search handbook..." spellcheck="false" class="st-default-search-input"/>
 					<button id="search-button" type="submit">Search</button>
 				</form>
 				<a href="https://about.sourcegraph.com">About</a>
@@ -81,6 +81,14 @@
 			</div>
 		</footer>
 	</div>
+  <script type="text/javascript">
+    (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+    (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+    e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+    })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+
+    _st('install','JAPrEEBxHhYT4SnMJQmX','2.0.0');
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
This integrates the [Swiftype site search](https://swiftype.com/) into the handbook to allow us more fine-grained control over search results.

This is very much a trial to see if we can get a better user experience over the existing search experience.