### PR TITLE
Update Firefox handbook shortcut instructions

### DIFF
--- a/handbook/usage.md
+++ b/handbook/usage.md
@@ -75,6 +75,8 @@ If you use Firefox, you can add a Sourcegraph handbook search shortcut to the ad
 1. Right-click the search bar on https://about.sourcegraph.com/handbook.
 1. Choose `Add a keyword for this Search`.
 1. Enter a keyword that you would like to use (e.g. `hb`).
+1. Open your bookmarks and edit the handbook bookmark that was just created
+1. Change the URL on the bookmark to `https://about.sourcegraph.com/handbook#stq=%s`
 
 ### Usage
 


### PR DESCRIPTION
With the new handbook search enabled, using the "Add keyword for this
search" context menu option doesn't create a bookmark with the correct
URL. This updates the instructions to manually set that URL on Firefox.