### PR TITLE
Clarify where to run make serve from

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,6 @@ The [Sourcegraph handbook](https://about.sourcegraph.com/handbook) also lives in
 
 The handbook uses [docsite](https://github.com/sourcegraph/docsite).
 
-- To preview changes to handbook content locally, run `make serve`, and open http://localhost:5082.
+- To preview changes to handbook content locally, run `make serve` from the root of the handbook repository (/about), and open http://localhost:5082.
 - To check for broken links and other lint problems, run `make docsite-check`.
 - See [detailed `docsite` instructions](handbook/editing.md#running-a-local-handbook-site).


### PR DESCRIPTION
Clarifies when and where to run `make serve` to preview the handbook