### PR TITLE
Document Search Core support process

### DIFF
--- a/handbook/engineering/search/core.md
+++ b/handbook/engineering/search/core.md
@@ -21,6 +21,16 @@ The search core team owns all parts of Sourcegraph that map an interpreted searc
 - #search channel or @search-core on Slack.
 - [`team/search-core` on GitHub](https://github.com/orgs/sourcegraph/teams/search-core)
 
+## Support rotation
+
+The Search Core team has a customer support rotation: each week, one team member will be responsible for fielding questions and requests from Customer Engineering and Customer Support.
+
+The engineer on support rotation can be contacted using the Slack alias `@search-core-support`.
+
+The support rotation can be viewed on Opsgenie: [search core schedule](https://sourcegraph.app.opsgenie.com/teams/dashboard/1cc52380-1d71-420e-9c80-2ccb161c648c/main).
+
+Should an engineer be unable to fulfill support responsibilities for any reason (for example, due to upcoming time off), they should swap with a teammate.
+
 ## Iterations
 
 The search core team plans its work in **2-week iterations**.


### PR DESCRIPTION
Document:
- What our support rotation is
- Where it is defined (Opsgenie)
- What an engineer should do if they're unable to take on support