### PR TITLE
Add browser bookmarks to the code insights team page

### DIFF
--- a/docsite.json
+++ b/docsite.json
@@ -7,6 +7,6 @@
   "assets": "_resources/assets",
   "assetsBaseURLPath": "/assets/",
   "check": {
-    "ignoreURLPattern": "(^https?://)|(^#)|(^mailto:[\\w.-]+@([\\w.-]+\\.)+\\w+(\\?|$))|(^chrome://)|(^/@)"
+    "ignoreURLPattern": "(^https?://)|(^#)|(^javascript:)|(^mailto:[\\w.-]+@([\\w.-]+\\.)+\\w+(\\?|$))|(^chrome://)|(^/@)"
   }
 }

--- a/handbook/engineering/developer-insights/code-insights/CODENOTIFY
+++ b/handbook/engineering/developer-insights/code-insights/CODENOTIFY
@@ -1,0 +1,3 @@
+# See https://github.com/sourcegraph/codenotify for documentation
+
+**/* @sourcegraph/code-insights

--- a/handbook/engineering/developer-insights/code-insights/index.md
+++ b/handbook/engineering/developer-insights/code-insights/index.md
@@ -58,6 +58,16 @@ For more information about code insights, see the original [product document](ht
 
 [Goals and roadmap](goals.md)
 
+## Useful browser bookmarks ⭐️
+
+The following bookmarks are useful to add to your browser's bookmark bar if you're on the code insights team. You can drag & drop these directly into your bookmarks bar.
+
+- [GitHub Project Board](https://github.com/orgs/sourcegraph/projects/118?fullscreen=true) (fullscreen)
+- [New code insights issue](https://github.com/sourcegraph/sourcegraph/issues/new?labels=team/code-insights&projects=sourcegraph/118) (pre-fills labels and project)
+- <a href="javascript:location.search='?expand=1&template=developer_insights.md&labels=team/code-insights'">Use Developer Insights PR template</a> (bookmarklet, run on the open-PR GitHub page to add our checklist template)
+- [Code Insights GDrive folder](https://drive.google.com/drive/folders/16DrxdYnJAQ-fCIy3n1DXheReqWNV5U12) (all our documents are here or linked from here)
+- [Code Insights Roadmap](https://sourcegraph.productboard.com/roadmap/2809900-code-insights-features-timeline-roadmap)
+
 ## Processes
 
 We share the [Developer Insights org's processes](../index.md#processes), plus the following for our team.


### PR DESCRIPTION
Adds a list of useful links that code insights team members would frequently need access to, and can be useful to bookmark as mentioned in our last retro