### PR TITLE
Updating Target Opportunity Profile definition

### DIFF
--- a/handbook/sales/index.md
+++ b/handbook/sales/index.md
@@ -99,9 +99,9 @@ OR
 
 Title/role includes developer productivity, developer experience, API services, distinguished eng, platform engineer, director+ eng
 
-AND
+AND 
 
-Company has 50+ devs
+Company has 50+ devs **OR** Company is a Commercial account ( <250 employees)
 
 ### Target Account
 


### PR DESCRIPTION
Slightly tweaking the Target Opportunity Profile definition to account for the new addition of a Commercial team