### PR TITLE
Highlight dates, fiscal years/quarters and add tooltips that show the date in the user's local date format

### DIFF
--- a/_resources/assets/content.css
+++ b/_resources/assets/content.css
@@ -3,6 +3,14 @@
   content: "\A";
 }
 
+time {
+  text-decoration: underline;
+  text-decoration-style: dotted;
+  text-decoration-color: #bbb;
+  text-underline-offset: 0.2em;
+  cursor: help;
+}
+
 .pre-wrap {
   white-space: pre-wrap;
 }

--- a/_resources/assets/dateHighlighter.js
+++ b/_resources/assets/dateHighlighter.js
@@ -1,0 +1,41 @@
+import { parse } from 'https://cdn.skypack.dev/chrono-node'
+
+window.addEventListener('DOMContentLoaded', () => {
+    for (const element of document.querySelectorAll('time')) {
+        element.title = getDateTooltip(element)
+    }
+})
+
+/**
+ * @param {HTMLTimeElement} element
+ * @returns {string}
+ */
+function getDateTooltip(element) {
+    // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#valid_datetime_values for possible values of `element.dateTime`.
+
+    // Handle MM-DD reference
+    if (/^\d\d-\d\d$/.test(element.dateTime)) {
+        return new Date(`${new Date().getFullYear()}-${element.dateTime}`).toLocaleString(undefined, {
+            month: 'long',
+            day: 'numeric',
+        })
+    }
+
+    // Handle all other possible values with a lenient parser.
+    const parsed = parse(element.dateTime)[0]?.start
+    if (!parsed) {
+        return element.dateTime
+    }
+    /** @type {Intl.DateTimeFormatOptions} */
+    const options = {
+        year: parsed.isCertain('year') ? 'numeric' : undefined,
+        month: parsed.isCertain('month') ? 'long' : undefined,
+        day: parsed.isCertain('day') ? 'numeric' : undefined,
+        weekday: parsed.isCertain('day') ? 'long' : undefined,
+        hour: parsed.isCertain('hour') ? 'numeric' : undefined,
+        minute: parsed.isCertain('minute') ? 'numeric' : undefined,
+        second: parsed.isCertain('second') ? 'numeric' : undefined,
+        timeZoneName: parsed.isCertain('hour') ? 'long' : undefined,
+    }
+    return parsed.date().toLocaleString(undefined, options)
+}

--- a/_resources/assets/dateHighlighter.js
+++ b/_resources/assets/dateHighlighter.js
@@ -1,8 +1,16 @@
 import { parse } from 'https://cdn.skypack.dev/chrono-node'
+import tippy from 'https://cdn.skypack.dev/tippy.js'
 
 window.addEventListener('DOMContentLoaded', () => {
     for (const element of document.querySelectorAll('time')) {
-        element.title = getDateTooltip(element)
+        tippy(element, {
+            content: getDateTooltip(element),
+            placement: 'bottom-end',
+            arrow: false,
+            duration: 0,
+            offset: [0, 6],
+            theme: 'light',
+        })
     }
 })
 

--- a/_resources/assets/dateHighlighter.js
+++ b/_resources/assets/dateHighlighter.js
@@ -46,6 +46,8 @@ function formatDateTime(timeElement) {
     if (!parsed) {
         return timeElement.dateTime
     }
+
+    // Only include the parts of the date that we know about
     /** @type {Intl.DateTimeFormatOptions} */
     const options = {
         year: parsed.isCertain('year') ? 'numeric' : undefined,

--- a/_resources/assets/dateHighlighter.js
+++ b/_resources/assets/dateHighlighter.js
@@ -19,6 +19,18 @@ window.addEventListener('DOMContentLoaded', () => {
  * @returns {string}
  */
 function getDateTooltip(element) {
+    let tooltip = formatDateTime(element)
+    if (element.dataset.isStartOfInterval) {
+        tooltip = 'Begins on ' + tooltip
+    }
+    return tooltip
+}
+
+/**
+ * @param {HTMLTimeElement} element
+ * @returns {string}
+ */
+function formatDateTime(element) {
     // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#valid_datetime_values for possible values of `element.dateTime`.
 
     // Handle MM-DD reference

--- a/_resources/assets/dateHighlighter.js
+++ b/_resources/assets/dateHighlighter.js
@@ -15,36 +15,36 @@ window.addEventListener('DOMContentLoaded', () => {
 })
 
 /**
- * @param {HTMLTimeElement} element
+ * @param {HTMLTimeElement} timeElement
  * @returns {string}
  */
-function getDateTooltip(element) {
-    let tooltip = formatDateTime(element)
-    if (element.dataset.isStartOfInterval) {
+function getDateTooltip(timeElement) {
+    let tooltip = formatDateTime(timeElement)
+    if (timeElement.dataset.isStartOfInterval) {
         tooltip = 'Begins on ' + tooltip
     }
     return tooltip
 }
 
 /**
- * @param {HTMLTimeElement} element
+ * @param {HTMLTimeElement} timeElement
  * @returns {string}
  */
-function formatDateTime(element) {
-    // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#valid_datetime_values for possible values of `element.dateTime`.
+function formatDateTime(timeElement) {
+    // See https://developer.mozilla.org/en-US/docs/Web/HTML/Element/time#valid_datetime_values for possible values of `timeElement.dateTime`.
 
     // Handle MM-DD reference
-    if (/^\d\d-\d\d$/.test(element.dateTime)) {
-        return new Date(`${new Date().getFullYear()}-${element.dateTime}`).toLocaleString(undefined, {
+    if (/^\d\d-\d\d$/.test(timeElement.dateTime)) {
+        return new Date(`${new Date().getFullYear()}-${timeElement.dateTime}`).toLocaleString(undefined, {
             month: 'long',
             day: 'numeric',
         })
     }
 
     // Handle all other possible values with a lenient parser.
-    const parsed = parse(element.dateTime)[0]?.start
+    const parsed = parse(timeElement.dateTime)[0]?.start
     if (!parsed) {
-        return element.dateTime
+        return timeElement.dateTime
     }
     /** @type {Intl.DateTimeFormatOptions} */
     const options = {

--- a/_resources/assets/dateHighlighter.js
+++ b/_resources/assets/dateHighlighter.js
@@ -1,5 +1,5 @@
-import { parse } from 'https://cdn.skypack.dev/chrono-node'
-import tippy from 'https://cdn.skypack.dev/tippy.js'
+import { parse } from 'https://cdn.skypack.dev/chrono-node@2'
+import tippy from 'https://cdn.skypack.dev/tippy.js@6'
 
 window.addEventListener('DOMContentLoaded', () => {
     for (const element of document.querySelectorAll('time')) {

--- a/_resources/templates/root.html
+++ b/_resources/templates/root.html
@@ -91,6 +91,7 @@
 
     _st('install','JAPrEEBxHhYT4SnMJQmX','2.0.0');
   </script>
+  <script type="module" src="{{asset "dateHighlighter.js"}}"></script>
 </body>
 
 </html>

--- a/_resources/templates/root.html
+++ b/_resources/templates/root.html
@@ -11,6 +11,8 @@
 	<link rel="stylesheet" type="text/css" href="{{asset "document.css"}}" />
 	<link rel="stylesheet" type="text/css" href="{{asset "search.css"}}" />
 	<link rel="stylesheet" type="text/css" href="{{asset "content.css"}}" />
+	<link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/tippy.js/dist/tippy.css" />
+	<link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/tippy.js/themes/light.css" />
 	<script type="text/javascript" src="{{asset "scripts.js"}}"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 	<!-- Google Consent Mode and Cookiebot -->

--- a/_resources/templates/root.html
+++ b/_resources/templates/root.html
@@ -11,8 +11,9 @@
 	<link rel="stylesheet" type="text/css" href="{{asset "document.css"}}" />
 	<link rel="stylesheet" type="text/css" href="{{asset "search.css"}}" />
 	<link rel="stylesheet" type="text/css" href="{{asset "content.css"}}" />
-	<link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/tippy.js/dist/tippy.css" />
-	<link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/tippy.js/themes/light.css" />
+  <!-- Keep version in sync with tippy.js imports in JS -->
+	<link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/tippy.js@6/dist/tippy.css" />
+	<link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/tippy.js@6/themes/light.css" />
 	<script type="text/javascript" src="{{asset "scripts.js"}}"></script>
 	<meta name="viewport" content="width=device-width, initial-scale=1, user-scalable=no" />
 	<!-- Google Consent Mode and Cookiebot -->

--- a/_resources/templates/root.html
+++ b/_resources/templates/root.html
@@ -11,7 +11,7 @@
 	<link rel="stylesheet" type="text/css" href="{{asset "document.css"}}" />
 	<link rel="stylesheet" type="text/css" href="{{asset "search.css"}}" />
 	<link rel="stylesheet" type="text/css" href="{{asset "content.css"}}" />
-  <!-- Keep version in sync with tippy.js imports in JS -->
+	<!-- Keep version in sync with tippy.js imports in JS -->
 	<link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/tippy.js@6/dist/tippy.css" />
 	<link rel="stylesheet" type="text/css" href="https://cdn.skypack.dev/tippy.js@6/themes/light.css" />
 	<script type="text/javascript" src="{{asset "scripts.js"}}"></script>
@@ -61,10 +61,10 @@
 						placeholder="Search handbook..." spellcheck="false" class="st-default-search-input"/>
 					<button id="search-button" type="submit">Search</button>
 				</form>
-        <div>
-          <a href="https://about.sourcegraph.com">About Sourcegraph</a>
-          <a href="https://sourcegraph.com">Sourcegraph.com</a>
-        </div>
+				<div>
+					<a href="https://about.sourcegraph.com">About Sourcegraph</a>
+					<a href="https://sourcegraph.com">Sourcegraph.com</a>
+				</div>
 			</nav>
 		</div>
 	</header>
@@ -86,15 +86,15 @@
 			</div>
 		</footer>
 	</div>
-  <script type="text/javascript">
-    (function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
-    (w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
-    e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
-    })(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
+	<script type="text/javascript">
+		(function(w,d,t,u,n,s,e){w['SwiftypeObject']=n;w[n]=w[n]||function(){
+		(w[n].q=w[n].q||[]).push(arguments);};s=d.createElement(t);
+		e=d.getElementsByTagName(t)[0];s.async=1;s.src=u;e.parentNode.insertBefore(s,e);
+		})(window,document,'script','//s.swiftypecdn.com/install/v2/st.js','_st');
 
-    _st('install','JAPrEEBxHhYT4SnMJQmX','2.0.0');
-  </script>
-  <script type="module" src="{{asset "dateHighlighter.js"}}"></script>
+		_st('install','JAPrEEBxHhYT4SnMJQmX','2.0.0');
+	</script>
+	<script type="module" src="{{asset "dateHighlighter.js"}}"></script>
 </body>
 
 </html>


### PR DESCRIPTION
If you keep forgetting when different fiscal quarters start (like me), or if you're confused by the YYYY-MM-DD date format we use, or just would like to be able to know what day of the week a date referenced in the handbook is, this PR is for you.

It highlights all references to fiscal years, quarters, and dates/times with a dotted underline, and when hovered, will show the date (or start of the quarter) in the user's local date format complete with day of the week, timezone, etc.

![2021-06-21 12 58 11](https://user-images.githubusercontent.com/10532611/122751697-62d23900-d290-11eb-989a-46fdd50f5b07.gif)

![2021-06-21 13 00 31](https://user-images.githubusercontent.com/10532611/122751962-b04ea600-d290-11eb-9453-c776af9bb734.gif)

Depends on https://github.com/sourcegraph/docsite/pull/73