### PR TITLE
New process for customer names in public places (avoids needing hubspot/salesforce access)

### DIFF
--- a/handbook/communication/rfcs/index.md
+++ b/handbook/communication/rfcs/index.md
@@ -116,11 +116,7 @@ The default sharing state of documents in our [Google Drive's RFCs](https://driv
 
 Sometimes there is information relevant to an RFC, but that information can't be made public.
 
-- RFCs should never reference customer names directly, even if they are listed on our homepage. Instead, you can use a Hubspot link or an arbitrary code name (e.g. "ACME", "Customer X") for each customer that you need to reference in the document. Code names do not need to be consistent across documents. The first usage of each code name should be linked to the actual company's profile in Hubspot.
-    - To make this easy, add a search engine to your browser so that you can quickly type `h ACME` or `h sourcegraph` to find the company in HubSpot. Use this URL [https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s](https://app.hubspot.com/contacts/2762526/companies/list/view/all/?query=%s)
-    ![Hubspot search](hubspot-search.png)
-    - Don't share the link to the search results (it has the company name in the search)! Instead, share the direct link to the company; it should look like this: [https://app.hubspot.com/contacts/2762526/company/557690851/](https://app.hubspot.com/contacts/2762526/company/557690851/)
-    ![Hubspot results](hubspot-results.png)
+- RFCs should never reference customer names directly, even if they are listed on our homepage. Instead, you can use our [process for linking to customer names in public places](../../ops/bizops/customer_ops_tools.md#linking-to-customer-or-prospect-names-in-public-places). Optionally, use an arbitrary code name (e.g. "ACME", "Customer X") for each customer that you need to reference in the document. Code names do not need to be consistent across documents. The first usage of each code name should be linked to the actual customer. 
 - If there is strategic information that shouldn't be public, you can post it in Slack and link to it from the public RFC.
 - If most of the content is non-public, then it is OK to make the RFC only accessible to the Sourcegraph team. Add "PRIVATE" after the [status](#status) in the title, move it to the [private RFCs folder in GDrive](https://drive.google.com/drive/folders/1KCq4tMLnVlC0a1rwGuU5OSCw6mdDxLuv), and explain why it's private in the doc.
 

--- a/handbook/ops/bizops/customer_ops_tools.md
+++ b/handbook/ops/bizops/customer_ops_tools.md
@@ -104,7 +104,7 @@ We use Google Tag Manager to:
 
 It's often useful to include a customer or prospect name in a public RFC, GitHub issue, or other publicly-viewable place. In order to do so without leaking this information to the public, we use a private [Customer/Prospect Names Mapping Index](https://docs.google.com/spreadsheets/d/1OEhzdMSlkGOaWyGKwdiAGlirsKKj9EN45Izn7kdKNTg/edit#) Google sheet.
 
-To use it, copy a link to the cell with the name you want to include, and use that link in place of the customer name. For example, if the customer was Sourcegraph, you might write: ...and is affecting [this customer](https://docs.google.com/spreadsheets/d/1OEhzdMSlkGOaWyGKwdiAGlirsKKj9EN45Izn7kdKNTg/edit#gid=0&range=A1901).  
+To use it, copy a link to the cell with the name you want to include, and use that link in place of the customer name. For example, if the customer was "Sourcegraph", you might write: "We heard from [this customer](https://docs.google.com/spreadsheets/d/1OEhzdMSlkGOaWyGKwdiAGlirsKKj9EN45Izn7kdKNTg/edit#gid=0&range=A1901) that...".  
 
 Anyone can add new customers or prospects to the bottom of the index as necessary. 
 

--- a/handbook/ops/bizops/customer_ops_tools.md
+++ b/handbook/ops/bizops/customer_ops_tools.md
@@ -100,6 +100,14 @@ We use Google Tag Manager to:
 - run small scripts to populate cookie variables on info.sourcegraph.com ("Populate info forms with anonymousUid and sourceURL)
 - add conversion actions (i.e. actions that we want to measure as a conversion/success) for non-Google ads (e.g. LinkedIn and Bing)
 
+## Linking to customer or prospect names in public places 
+
+It's often useful to include a customer or prospect name in a public RFC, GitHub issue, or other publicly-viewable place. In order to do so without leaking this information to the public, we use a private [Customer/Prospect Names Mapping Index](https://docs.google.com/spreadsheets/d/1OEhzdMSlkGOaWyGKwdiAGlirsKKj9EN45Izn7kdKNTg/edit#) Google sheet.
+
+To use it, copy a link to the cell with the name you want to include, and use that link in place of the customer name. For example, if the customer was Sourcegraph, you might write: ...and is affecting [this customer](https://docs.google.com/spreadsheets/d/1OEhzdMSlkGOaWyGKwdiAGlirsKKj9EN45Izn7kdKNTg/edit#gid=0&range=A1901).  
+
+Anyone can add new customers or prospects to the bottom of the index as necessary. 
+
 ## Addendum
 
 More useful links for the HubSpot to Salesforce integration:

--- a/handbook/product/surfacing_product_feedback.md
+++ b/handbook/product/surfacing_product_feedback.md
@@ -16,7 +16,7 @@ If you have gotten a specific feedback requests that a customer(s) would like to
 
 GitHub issues with the `feedback` label will automatically post to the #feedback Slack channel on creation; you do not need to manually copy the issue link into #feedback. 
 
-Because a shareable issue is by definition public, you should not include any private customer information. You should still include things like the customer name, by including a link to the customer in Salesforce.
+Because a shareable issue is by definition public, you should not include any private customer information. You should still include things like the customer name, by using our [process for linking customer names in public places](../ops/bizops/customer_ops_tools.md#linking-to-customer-or-prospect-names-in-public-places). 
 
 If you need to create an issue with more specific customer information, you should [create a new issue in Sourcegraph/Customer](https://github.com/sourcegraph/customer/issues/new/choose), which is private. You can then link that to a public issue in Sourcegraph/Sourcegraph.
 


### PR DESCRIPTION
We previously used hubspot and/or salesforce links as just a private customer names mapping index, but as we grow it doesn't make sense to pay for company-wide access to these tools just for this purpose. To come up with an inclusive and much cheaper alternative, we've aligned on using a [private google sheet ](https://docs.google.com/spreadsheets/d/1OEhzdMSlkGOaWyGKwdiAGlirsKKj9EN45Izn7kdKNTg/edit#gid=0) (as you can link to individual cells). 

For full context, see [this slack thread](https://sourcegraph.slack.com/archives/C01CSS3TC75/p1621979783082400?thread_ts=1620917012.395600&cid=C01CSS3TC75)
