### PR TITLE
release: sourcegraph@3.29.1

### DIFF
--- a/website/src/components/GetStarted.tsx
+++ b/website/src/components/GetStarted.tsx
@@ -34,7 +34,7 @@ export default class GetStarted extends React.PureComponent<GetStartedProps> {
                                     --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm <br />
                                     --volume ~/.sourcegraph/config:/etc/sourcegraph <br />
                                     --volume ~/.sourcegraph/data:/var/opt/sourcegraph <br />
-                                    sourcegraph/server:3.29.0</span>
+                                    sourcegraph/server:3.29.1</span>
                                 <span className="get-started__copytext">
                                     <FileDocumentMultipleOutlineIcon
                                         className="copytext icon-inline ml-1 medium"


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.29.1 release.


* [Release campaign](https://k8s.sgdev.org/organizations/sourcegraph/campaigns/release-sourcegraph-3.29.1)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/22397)