### PR TITLE
Refresh personal pronoun guidelines, add suggestion to use new Zoom pronouns setting

### DIFF
--- a/handbook/people-ops/personal-pronouns.md
+++ b/handbook/people-ops/personal-pronouns.md
@@ -1,10 +1,8 @@
 # Personal pronouns
 
-To help make everyone feel welcome at Sourcegraph, we ask everyone to use people’s personal pronouns. For our colleagues, these are listed on [our team page](https://about.sourcegraph.com/handbook/company/team) next to each person’s name.
+To help make everyone feel welcome at Sourcegraph, we ask everyone to use people’s personal pronouns. For most of our colleagues, these are listed on [our team page](https://about.sourcegraph.com/handbook/company/team) next to each person’s name.
 
-Pronouns differ for everyone, and referring to someone with an incorrect pronoun can be harmful. You can privately ask “What pronouns do you use?” or “How should I refer to you?”, and you can fall back to “they/them/their” if you are unsure.
-
-Some may choose to use singular “they” pronouns, eg:
+Some may choose to use singular “they” pronouns, e.g.:
 
 - "X would probably love these extra adorable pictures I took of my cat today, I should send them some!""
 - "X deleted all the databases and their backups!? How did they even do that?
@@ -12,22 +10,32 @@ Some may choose to use singular “they” pronouns, eg:
 
 Other [enby](https://www.dictionary.com/e/gender-sexuality/enby/) pronouns include: ze/hir, co/cos, xe/xem/xyr, hy/hym/hys, or no pronoun and using that person’s name instead.
 
-Here are some things that colleagues do to help make others feel comfortable sharing their pronouns:
+## Sharing your pronouns
 
-- Including pronouns in your email signature and on various profiles (Slack, LinkedIn, Twitter)
-- Mentioning your pronoun when introducing yourself to a new colleague
+Even if you've used the same pronouns your whole life, sharing your own pronouns is one of the best ways to help others feel comfortable sharing theirs with you. Here are some things that colleagues can do to share their pronouns:
+
+- Include your pronouns on our [team page](https://about.sourcegraph.com/handbook/company/team) if you haven't added them already
+- Include your pronouns next to your name in your [email signature](https://about.sourcegraph.com/handbook/communication#getting-nice-email-signatures)
+- Fill out your personal pronouns on your Slack profile
+- Add your pronouns and manage how you want them to be displayed on your [Zoom profile](https://blog.zoom.us/zoom-pronoun-sharing/)
+- Add your pronouns to your LinkedIn profile, your Twitter bio, your GitHub profile, or other social media platforms you use
+- Introduce yourself by name and pronouns when meeting a new colleague
+
+And remember that if someone asks you for your pronouns, they are doing so out of respect!
+
+## Someone I am interacting with has not shared their pronouns. How do I know which pronouns to use?
+
+Pronouns differ for everyone, and incorrectly assuming someone's pronouns and referring to them by the wrong pronouns, either to their face or in conversation with other colleagues, can be harmful. **If you are at all unsure, it's generally always safe to fall back on “they/them/their”!** You can also listen for how others refer to the person, though this is not a guarantee that these are the pronouns they would prefer, and the best way to know is to ask them directly. If you are comfortable asking, you can privately message them “What pronouns do you use?” or “What pronouns should I use to refer to you?”.
 
 _Please note that we are not allowed to ask for pronouns during the interview process for legal reasons. We encourage hiring managers, interviewers, and others to use the default “they/them/their” during the interview process. You may also choose to offer your pronouns when introducing yourself to interviewees, which can give the interviewee an opportunity to share theirs._
-
 
 ## What if you make a mistake?
 
 - Quickly correcting yourself is more likely to make the misgendered person comfortable than doing something that requires spending more time on it.
-- You can gently correct others when they make a mistake.
-    - e.g. : \
-Person A: “in our last meeting, he said -”  \
-Person B: “they said” \
-Person A: “thanks, they said their cat actually wrote most of the PR”
+- You can gently correct others when they make a mistake, e.g.:
+  - Person A: “in our last meeting, he said -”
+  - Person B: “they said”
+  - Person A: “thanks, they said their cat actually wrote most of the PR”
 - If there is no opportunity to correct someone in real time without being disruptive, a private follow-up later is also helpful.
 
 


### PR DESCRIPTION
This PR is mostly to add the new instructions for adding your personal pronouns to Zoom since the previous way was a bit clunky. I decided while I was there to lightly refresh some of the other sections on this page to make it (hopefully) a bit easier to consume. 🙂 The content stayed the same, but I added a couple small things and reorganized the sections slightly!