### PR TITLE
Document how Product can get info and trends from Customer Support

### DIFF
--- a/handbook/product/user_feedback.md
+++ b/handbook/product/user_feedback.md
@@ -33,7 +33,7 @@ We have a few different email lists that are used to send us feedback.
 #### support@sourcegraph.com
 
 - **Purpose:** This email list is for customers to request help and connects to Zendesk. 
-- **Owner:** The Customer Support team is [responsible for all support issues](../support/support-workflow#support-workflow) and will pull in as needed engineering teams or product to help answer questions.
+- **Owner:** The Customer Support team is [responsible for all support issues](../support/support-workflow.md#support-workflow) and will pull in as needed engineering teams or product to help answer questions.
 
 ### GitHub issues
 

--- a/handbook/product/user_feedback.md
+++ b/handbook/product/user_feedback.md
@@ -32,8 +32,8 @@ We have a few different email lists that are used to send us feedback.
 
 #### support@sourcegraph.com
 
-- **Purpose:** This email list is for customers to request help and creates tickets in JIRA for our Customer Engineering team.
-- **Owner:** The Customer Engineering team is responsible for all support issues and will pull in as needed engineering teams or product to help answer questions.
+- **Purpose:** This email list is for customers to request help and connects to Zendesk. 
+- **Owner:** The Customer Support team is [responsible for all support issues](../support/support-workflow#support-workflow) and will pull in as needed engineering teams or product to help answer questions.
 
 ### GitHub issues
 
@@ -53,7 +53,7 @@ We have a few different email lists that are used to send us feedback.
 ### Support tickets
 
 - **Purpose:** A path for existing customers to get responsive support.
-- **Owner:** CS team owns support tickets in Zendesk. If product team members want more insight into the support feedback, they can review [the support dashboard](https://sourcegraph.looker.com/dashboards-next/177.) or scan the [customer issues repo](https://github.com/sourcegraph/customer/issues), and cross-reference both with slack searches in support channels. Additionally, at the end of every quarter, the Head of Customer Support provides the product team with a qualitative summary and links to details of the major support trends from the prior three months. 
+- **Owner:** CS team owns support tickets in Zendesk. If product team members want more insight into the support feedback, they can review [the support dashboard](https://sourcegraph.looker.com/dashboards-next/177) or scan the [customer issues repo](https://github.com/sourcegraph/customer/issues), and cross-reference both with slack searches in support channels. Additionally, at the end of every quarter, the Head of Customer Support provides the product team with a qualitative summary and links to details of the major support trends from the prior three months. 
 
 ### Sales feedback
 

--- a/handbook/product/user_feedback.md
+++ b/handbook/product/user_feedback.md
@@ -53,7 +53,7 @@ We have a few different email lists that are used to send us feedback.
 ### Support tickets
 
 - **Purpose:** A path for existing customers to get responsive support.
-- **Owner:** CE team owns support tickets in a Jira project.
+- **Owner:** CS team owns support tickets in Zendesk. If product team members want more insight into the support feedback, they can review [the support dashboard](https://sourcegraph.looker.com/dashboards-next/177.) or scan the [customer issues repo](https://github.com/sourcegraph/customer/issues), and cross-reference both with slack searches in support channels. Additionally, at the end of every quarter, the Head of Customer Support provides the product team with a qualitative summary and links to details of the major support trends from the prior three months. 
 
 ### Sales feedback
 


### PR DESCRIPTION
Very often ([1](https://sourcegraph.slack.com/archives/C01HW836940/p1622069711161900), [2](https://sourcegraph.slack.com/archives/C01SD4A49E1/p1624438068019400?thread_ts=1624415946.017900&cid=C01SD4A49E1), [3](https://sourcegraph.slack.com/archives/C01HW836940/p1625242441450500) ) a product team member has noted that support tickets are a valuable source of product feedback if we can have insight into them, and they are right. But instead of asking this in slack, we should document it here. My bad for not doing so sooner – and for not doing so after the first repeat. Had no idea it'd be such a popular question 🙂.

@virginiaulrich I imagine if the process goes well, when you document the quarterly handoff we should link it from here (I'll try to do that but sharing that thought now).  I've also tried to update a few other moments where it's CS instead of CE now but please do correct any mistakes. 