### PR TITLE
Hotfix eng leadership link to fix handbook build

### DIFF
--- a/handbook/engineering/hiring/index.md
+++ b/handbook/engineering/hiring/index.md
@@ -13,3 +13,5 @@ See our [careers page](https://boards.greenhouse.io/sourcegraph91) for open posi
 [Software engineer pairing exercise](software-engineer-pairing-exercise.md).
 
 [Frontend Engineer (Extensibility) Interview](./frontend-engineer-extensibility.md)
+
+[Engineering-leadership](engineering-leadership.md)


### PR DESCRIPTION
Temporary fix to turn the build green. (This page also looks a bit out of date to me but that's out of scope for this.) Looks like [it broke here](https://github.com/sourcegraph/about/pull/3546/files#diff-63c857b0a99b813d72fa0182e3b9897c4599c2d1d4208db7ee461e00f3a9c312L10)