### PR TITLE
deployments: update instances documentation, add ArgoCD, add 'sg live'

### DIFF
--- a/handbook/engineering/deployments/index.md
+++ b/handbook/engineering/deployments/index.md
@@ -3,40 +3,25 @@
 We maintain multiple [instances](instances.md) of Sourcegraph:
 
 - [Instances](./instances.md): information about our different instances
-  - [sourcegraph.com](instances.md#sourcegraph-com) is our production deployment for open source code.
-  - [sourcegraph.sgdev.org](instances.md#sourcegraph-sgdev-org) is our private deployment of Sourcegraph that contains some of our private code.
-  - [k8s.sgdev.org](instances.md#k8s-sgdev-org) is a dogfood deployment that replicates the scale of our largest customers. Note that this also contains all of our private code. - [Managed instances](../distribution/managed/index.md) are deployments of Sourcegraph we manage for customers.
-  - [demo.sourcegraph.com](instances.md#demo-sourcegraph-com) is a managed instance used for CE demos.
-  - [devmanaged.sourcegraph.com](instances.md#devmanaged-sourcegraph-com) is a managed instance used for managed instances development.
 
 Learn more about how these work in:
 
 - [Deployment basics](#deployment-basics)
-  - [Kubernetes](./kubernetes.md): setting up access, tips, and more
-  - [Security](./security.md): TLS configuration,
-  - [Testing](./testing.md): deploying test instances of Sourcegraph
-  - [PostgresSQL](./postgresql.md): Tips for working with Postgres and our deployments]
-  - [Playbooks](./playbooks.md): how-to guides for common tasks
   - [Images](#images)
   - [Renovate](#renovate)
+  - [ArgoCD](#argocd)
   - [Infrastructure](#infrastructure)
-  - [Debugging](./debugging.md)
-  - [deploy-sourcegraph](#deploy-sourcegraph)
-    - [Merging changes from deploy-sourcegraph](#merging-changes-from-deploy-sourcegraph)
-  - [Relationship between the repositories](#relationship-between-the-repositories)
-    - [Merging upstream `deploy-sourcegraph` into `deploy-sourcegraph-dot-com`](#merging-upstream-deploy-sourcegraph-into-deploy-sourcegraph-dot-com)
-  - [Azure DevOps](azure_devops.md)
-  - [RPO & RTO](./rto_rpo.md)
+- [deploy-sourcegraph](#deploy-sourcegraph)
+  - [Merging changes from deploy-sourcegraph](#merging-changes-from-deploy-sourcegraph)
+- [Relationship between deploy-sourcegraph repositories](#relationship-between-deploy-sourcegraph-repositories)
+  - [Merging upstream `deploy-sourcegraph` into `deploy-sourcegraph-dot-com`](#merging-upstream-deploy-sourcegraph-into-deploy-sourcegraph-dot-com)
 
 ## Deployment basics
 
-Changes to `sourcegraph/sourcegraph` are automatically built as [images](#images), which are then:
+Changes to [the main `sourcegraph/sourcegraph` repository](https://github.com/sourcegraph/sourcegraph) are automatically built as [images](#images).
 
-- [Automatically pushed to `deploy-sourcegraph`](#deploy-sourcegraph), which runs deployment checks on the new images and merges the changes. Updates for `deploy-sourcegraph` are performed upon CI passing in `sourcegraph/sourcegraph@main`.
-  - `sourcegraph-bot` will mention your pull request in the `deploy-sourcegraph` change - you will be able to find a link in your pull request.
-- `deploy-sourcegraph` changes are [automatically deployed in k8s.sgdev.org](instances.md#k8s-sgdev-org), our Kubernetes dogfooding environment.
-  - `sourcegraph-bot` will mention the relevant `deploy-sourcegraph` pull request in the `deploy-sourcegraph-dogfood-k8s-2` change.
 - [Sourcegraph Cloud](instances.md#sourcegraph-com) will eventually pick up the same changes on a schedule via [Renovate](#renovate)
+- [k8s.sgdev.org](instances.md#k8s-sgdev-org) will deploy the changes via [ArgoCD](#argocd)
 
 ### Images
 
@@ -47,6 +32,13 @@ For pushing custom images, refer to [building Docker images for specific branche
 ### Renovate
 
 Renovate is a tool for updating dependencies. [`deploy-sourcegraph-*`](#deploy-sourcegraph) repositories with Renovate configured check for updated Docker images about every hour. If it finds new Docker images then it opens and merges a PR ([Sourcegraph.com example](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/pulls?utf8=%E2%9C%93&q=is%3Apr+author%3Aapp%2Frenovate)) to update the image tags in the deployment configuration. This is usually accompanied by a CI job that deploys the updated images to the appropriate deployment.
+
+### ArgoCD
+
+ArgoCD is a continuous delivery tool for Kubernetes applications.
+Sourcegraph's ArgoCD instance is available at [argocd.sgdev.org](https://argocd.sgdev.org/).
+
+ArgoCD currently handles deployments for [k8s.sgdev.org](instances.md#k8s-sgdev-org).
 
 ### Infrastructure
 
@@ -83,7 +75,7 @@ and the docker images are automatically updated to the latest builds.
 
 > Note: What is said about `deploy-sourcegraph-dot-com` also applies to `deploy-sourcegraph-dogfood-k8s` unless otherwise specified.
 
-## Relationship between the repositories
+## Relationship between deploy-sourcegraph repositories
 
 1. [`deploy-sourcegraph-dot-com@master`](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/tree/master) strictly tracks the upstream https://github.com/sourcegraph/deploy-sourcegraph/tree/master.
 1. [`deploy-sourcegraph-dot-com@release`](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/tree/release) _only_ contains the customizations required to deploy/document sourcegraph.com from the base deployment of Sourcegraph.

--- a/handbook/engineering/deployments/index.md
+++ b/handbook/engineering/deployments/index.md
@@ -17,6 +17,7 @@ Additional resources:
 - [Playbooks](./playbooks.md)
 - [Azure DevOps](./azure_devops.md)
 - [RPO & RTO](./rto_rpo.md)
+- [Testing](./testing.md)
 
 ## Deployment basics
 

--- a/handbook/engineering/deployments/index.md
+++ b/handbook/engineering/deployments/index.md
@@ -1,10 +1,8 @@
 # Deployments
 
-We maintain multiple [instances](instances.md) of Sourcegraph:
+For a complete list of Sourcegraph instances we manage, see our [instances documentation](instances.md).
 
-- [Instances](./instances.md): information about our different instances
-
-Learn more about how these work in:
+For common actions related to operating our Sourcegraph deployments, see [playbooks](./playbooks.md).
 
 - [Deployment basics](#deployment-basics)
   - [Images](#images)

--- a/handbook/engineering/deployments/index.md
+++ b/handbook/engineering/deployments/index.md
@@ -2,8 +2,6 @@
 
 For a complete list of Sourcegraph instances we manage, see our [instances documentation](instances.md).
 
-For common actions related to operating our Sourcegraph deployments, see [playbooks](./playbooks.md).
-
 - [Deployment basics](#deployment-basics)
   - [Images](#images)
   - [Renovate](#renovate)
@@ -13,6 +11,12 @@ For common actions related to operating our Sourcegraph deployments, see [playbo
   - [Merging changes from deploy-sourcegraph](#merging-changes-from-deploy-sourcegraph)
 - [Relationship between deploy-sourcegraph repositories](#relationship-between-deploy-sourcegraph-repositories)
   - [Merging upstream `deploy-sourcegraph` into `deploy-sourcegraph-dot-com`](#merging-upstream-deploy-sourcegraph-into-deploy-sourcegraph-dot-com)
+
+Additional resources:
+
+- [Playbooks](./playbooks.md)
+- [Azure DevOps](./azure_devops.md)
+- [RPO & RTO](./rto_rpo.md)
 
 ## Deployment basics
 

--- a/handbook/engineering/deployments/instances.md
+++ b/handbook/engineering/deployments/instances.md
@@ -1,14 +1,17 @@
 # Instances
 
 Information about Sourcegraph's different instances.
-For deployments of Sourcegraph we manage for customers, see [managed instances](../distribution/managed/index.md).
 
-- [sourcegraph.com](instances.md#sourcegraph-com) is our production deployment for open source code.
+- [sourcegraph.com](instances.md#sourcegraph-com) is our production deployment.
 - [k8s.sgdev.org](instances.md#k8s-sgdev-org) is a dogfood deployment that replicates the scale of our largest customers.
   This deployment also contains all of our private code.
 - [Managed instances](../distribution/managed/index.md) are deployments of Sourcegraph we manage for customers.
   - [demo.sourcegraph.com](instances.md#demo-sourcegraph-com) is a managed instance used for CE demos.
   - [devmanaged.sourcegraph.com](instances.md#devmanaged-sourcegraph-com) is a managed instance used for managed instances development.
+
+For deployments of Sourcegraph we manage for customers, see [managed instances](../distribution/managed/index.md).
+
+Also see [playbooks](./playbooks.md) for common actions related to operating our Sourcegraph deployments.
 
 ## sourcegraph.com
 
@@ -41,7 +44,7 @@ It contains Sourcegraph private code, and deploys the latest [Sourcegraph images
 
 Learn more in [deployment basics](./index.md#deployment-basics).
 
-> 🚨 This deployment contains private code - for demos, use [demo.sourcegraph.com](https://demo.sourcegraph.com) instead.
+> 🚨 This deployment contains private code - for demos, use [demo.sourcegraph.com](#demo-sourcegraph-com) instead.
 
 - [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-f/dogfood?project=sourcegraph-dogfood)
   ```

--- a/handbook/engineering/deployments/instances.md
+++ b/handbook/engineering/deployments/instances.md
@@ -1,6 +1,14 @@
 # Instances
 
-Information about Sourcegraph's different instances. For deployments of Sourcegraph we manage for customers, see [managed instances](../distribution/managed/index.md).
+Information about Sourcegraph's different instances.
+For deployments of Sourcegraph we manage for customers, see [managed instances](../distribution/managed/index.md).
+
+- [sourcegraph.com](instances.md#sourcegraph-com) is our production deployment for open source code.
+- [k8s.sgdev.org](instances.md#k8s-sgdev-org) is a dogfood deployment that replicates the scale of our largest customers.
+  This deployment also contains all of our private code.
+- [Managed instances](../distribution/managed/index.md) are deployments of Sourcegraph we manage for customers.
+  - [demo.sourcegraph.com](instances.md#demo-sourcegraph-com) is a managed instance used for CE demos.
+  - [devmanaged.sourcegraph.com](instances.md#devmanaged-sourcegraph-com) is a managed instance used for managed instances development.
 
 ## sourcegraph.com
 
@@ -27,9 +35,11 @@ This deployment also includes our [documentation](https://docs.sourcegraph.com/)
 
 [![Build status](https://badge.buildkite.com/65c9b6f836db6d041ea29b05e7310ebb81fa36741c78f207ce.svg?branch=release)](https://buildkite.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2)
 
-This deployment is also colloquially referred to as "dogfood", "dogfood-k8s", or just "k8s". This is the Sourcegraph instance to use for dogfooding changes to Sourcegraph. It contains Sourcegraph private code, and generally receives the latest changes within 20 to 30 minutes.
+This deployment is also colloquially referred to as "dogfood", "dogfood-k8s", or just "k8s".
+This is the Sourcegraph instance to use for dogfooding changes to Sourcegraph.
+It contains Sourcegraph private code, and deploys the latest [Sourcegraph images](./index.md#images) via [ArgoCD](./index.md#argocd)
 
-`k8s.sgdev.org` deploys the latest changes in [`deploy-sourcegraph`](https://github.com/sourcegraph/deploy-sourcegraph), and by extension, [`sourcegraph/sourcegraph`](https://github.com/sourcegraph/sourcegraph), via automated updates - learn more in [deployment basics](./index.md#deployment-basics).
+Learn more in [deployment basics](./index.md#deployment-basics).
 
 > 🚨 This deployment contains private code - for demos, use [demo.sourcegraph.com](https://demo.sourcegraph.com) instead.
 
@@ -42,37 +52,23 @@ This deployment is also colloquially referred to as "dogfood", "dogfood-k8s", or
 - Alerts: `#alerts-dogfood-k8s`
 - [Playbooks](./playbooks.md#k8s-sgdev-org)
 
-> 🚢 Changes not deployed yet? Check if [`deploy-sourcegraph` updates](https://github.com/sourcegraph/deploy-sourcegraph/pulls?q=is%3Apr+insiders+images) or [`deploy-sourcegraph-dogfood-k8s-2` updates](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-k8s-2/pulls?q=is%3Apr) are blocked.
+## Managed instances
 
-## sourcegraph.sgdev.org
+[Managed instances](../distribution/managed/index.md) are deployments of Sourcegraph we manage for customers.
+We also maintain some internal managed instances for various use cases.
 
-[![Build status](https://badge.buildkite.com/135a00d4fba76ec97944bfb2fc28015d1565e0525853b4de06.svg)](https://buildkite.com/sourcegraph/deploy-sourcegraph-dogfood-server)
+### demo.sourcegraph.com
 
-This deployment runs the single-image version of Sourcegraph. It is deployed by the [infrastructure repository](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-server) and uses the shared `dogfood` cluster (also used by [k8s.sgdev.org](#k8s-sgdev-org)).
-
-> 🚨 This deployment contains private code - for demos, use [demo.sourcegraph.com](#demo-sourcegraph-com) instead.
-
-> 🐶 This deployment is not always up to date - for dogfooding changes, use [k8s.sgdev.org](#k8s-sgdev-org) instead.
-
-- [dogfood cluster on GCP](https://console.cloud.google.com/kubernetes/clusters/details/us-central1-f/dogfood?project=sourcegraph-dogfood)
-  ```
-  gcloud container clusters get-credentials dogfood --zone us-central1-f --project sourcegraph-dogfood
-  ```
-- [Kubernetes configuration](https://github.com/sourcegraph/deploy-sourcegraph-dogfood-server)
-- [Infrastructure configuration](https://github.com/sourcegraph/infrastructure/tree/main/dogfood)
-
-## demo.sourcegraph.com
-
-This deployment is a [managed instance](../distribution/managed/index.md) used by Sourcegraph CE for demos.
+This deployment is used by Sourcegraph CE for demos.
 
 - [GCP project](https://console.cloud.google.com/home/dashboard?project=sourcegraph-managed-demo)
-- [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/master/demo)
+- [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/main/demo)
 - [Operations](../distribution/managed/operations.md)
 
-## devmanaged.sourcegraph.com
+### devmanaged.sourcegraph.com
 
 This deployment is a [managed instance](../distribution/managed/index.md) used by Distribution for experimenting with managed instances in general.
 
 - [GCP project](https://console.cloud.google.com/home/dashboard?project=sourcegraph-managed-dev)
-- [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/master/dev)
+- [Infrastructure configuration](https://github.com/sourcegraph/deploy-sourcegraph-managed/tree/main/dev)
 - [Operations](../distribution/managed/operations.md)

--- a/handbook/engineering/deployments/playbooks.md
+++ b/handbook/engineering/deployments/playbooks.md
@@ -1,17 +1,30 @@
 # Playbooks for deployments
 
-- [Playbooks for deployments](#playbooks-for-deployments)
-    - [Sourcegraph.com](#sourcegraphcom)
-        - [Deploying to sourcegraph.com](#deploying-to-sourcegraphcom)
-        - [Rolling back sourcegraph.com](#rolling-back-sourcegraphcom)
-        - [Invalidating all user sessions](#invalidating-all-user-sessions)
-        - [Accessing sourcegraph.com database](#accessing-sourcegraphcom-database)
-            - [Via the CLI](#via-the-cli)
-            - [Via BigQuery (for read-only operations)](#via-bigquery-for-read-only-operations)
-        - [Restarting docs.sourcegraph.com](#restarting-about-sourcegraph-com-and-docs-sourcegraph-com)
-    - [k8s.sgdev.org](#k8ssgdevorg)
-        - [Manage users in k8s.sgdev.org](#manage-users-in-k8ssgdevorg)
-    - [Cloudflare Configuration](#cloudflare-configuration)
+- [General](#general)
+  - [Check what version of Sourcegraph is deployed](#check-what-version-of-sourcegraph-is-deployed)
+- [Sourcegraph.com](#sourcegraphcom)
+  - [Deploying to sourcegraph.com](#deploying-to-sourcegraphcom)
+  - [Rolling back sourcegraph.com](#rolling-back-sourcegraphcom)
+  - [Backing up & restoring a Cloud SQL instance (production databases)](#backing-up--restoring-a-cloud-sql-instance-production-databases)
+  - [Invalidating all user sessions](#invalidating-all-user-sessions)
+  - [Accessing sourcegraph.com database](#accessing-sourcegraphcom-database)
+    - [Via the CLI](#via-the-cli)
+    - [Via BigQuery (for read-only operations)](#via-bigquery-for-read-only-operations)
+  - [Restarting about.sourcegraph.com and docs.sourcegraph.com](#restarting-aboutsourcegraphcom-and-docssourcegraphcom)
+  - [Creating banners for maintenance tasks](#creating-banners-for-maintenance-tasks)
+- [k8s.sgdev.org](#k8ssgdevorg)
+  - [Manage users in k8s.sgdev.org](#manage-users-in-k8ssgdevorg)
+- [Cloudflare Configuration](#cloudflare-configuration)
+
+## General
+
+### Check what version of Sourcegraph is deployed
+
+[Install `sg`, the Sourcegraph developer tool](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md), and using the [`sg live` command](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md#sg-live---see-currently-deployed-version) you can see the version currently deployed for a specific environment:
+
+```sh
+sg live <environment>
+```
 
 ## Sourcegraph.com
 

--- a/handbook/engineering/deployments/playbooks.md
+++ b/handbook/engineering/deployments/playbooks.md
@@ -1,6 +1,7 @@
 # Playbooks for deployments
 
 - [General](#general)
+- [Debugging](#debugging)
   - [Check what version of Sourcegraph is deployed](#check-what-version-of-sourcegraph-is-deployed)
 - [Sourcegraph.com](#sourcegraphcom)
   - [Deploying to sourcegraph.com](#deploying-to-sourcegraphcom)
@@ -14,9 +15,14 @@
   - [Creating banners for maintenance tasks](#creating-banners-for-maintenance-tasks)
 - [k8s.sgdev.org](#k8ssgdevorg)
   - [Manage users in k8s.sgdev.org](#manage-users-in-k8ssgdevorg)
+- [PostgreSQL](#postgresql)
 - [Cloudflare Configuration](#cloudflare-configuration)
 
 ## General
+
+## Debugging
+
+See [debugging](./debugging/index.md).
 
 ### Check what version of Sourcegraph is deployed
 
@@ -158,6 +164,10 @@ To learn more about this deployment, see [instances](./instances.md#k8s-sgdev-or
 To create an account on [k8s.sgdev.org](https://k8s.sgdev.org), log in with your Sourcegraph Google account via OpenID Connect.
 
 To promote a user to site admin (required to make configuration changes), use the admin user credentials available in 1password (titled `k8s.sgdev.org admin user`) to log in to [k8s.sgdev.org](https://k8s.sgdev.org), and go to the [users page](https://k8s.sgdev.org/site-admin/users) to promote the desired user.
+
+## PostgreSQL
+
+See [PostgreSQL](./postgresql.md)
 
 ## Cloudflare Configuration
 

--- a/handbook/engineering/deployments/playbooks.md
+++ b/handbook/engineering/deployments/playbooks.md
@@ -23,7 +23,7 @@
 [Install `sg`, the Sourcegraph developer tool](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md), and using the [`sg live` command](https://github.com/sourcegraph/sourcegraph/blob/main/dev/sg/README.md#sg-live---see-currently-deployed-version) you can see the version currently deployed for a specific environment:
 
 ```sh
-sg live <environment>
+sg live <environment|url>
 ```
 
 ## Sourcegraph.com


### PR DESCRIPTION
Refresh based on some changes I think @daxmc99 has made. Also seems that `sourcegraph.sgdev.org` is gone, so this removes that.

Also adds mention of 'sg live', which seems like a handy tool! https://github.com/sourcegraph/sourcegraph/pull/22780 https://github.com/sourcegraph/sourcegraph/pull/22782