### PR TITLE
Add link to the security policy to customer data policy

### DIFF
--- a/handbook/ops/bizops/customer_data_policy.md
+++ b/handbook/ops/bizops/customer_data_policy.md
@@ -47,16 +47,13 @@ No. Only you can see or edit your private settings and Sourcegraph configuration
 
 ### Is my data encrypted?
 
-Yes, our dedicated security team follows best-practices for data encryption. We know that source code is one of your most sensitive assets. Every component of Sourcegraph was designed with security in mind. We've detailed our strict security guidelines for different deployment types below:
+Yes, our dedicated security team follows best-practices for data encryption, both at-rest and in-transit. The following documents outline our practices in details:
 
-- User credentials are encrypted in our database using 256-bit Advanced Encryption Standard (AES-256) keys in Galois Counter Mode (GCM). The keys are automatically rotated every 90 days.
-- All storage volumes are encrypted at rest, and data is encrypted in-cloud during transport.
-- We leverage IAM groups and rules to enforce the principle of least access across our cloud infrastructure.
-- The domain sourcegraph.com is managed through Cloudflare and uses its security capabilities, like Web Application Firewall and Rate Limiting.
-- We only log information crucial for security and support. Only restricted personnel have access to user data. Logs are stored in GCP and the information is retained for 180 days.
-- Our Incident Response plan is currently under review. It will be publicly available when finalized.
+- [Security Policy](https://about.sourcegraph.com/security/)
+- [Privacy Policy](https://about.sourcegraph.com/privacy/)
+- [Terms of Service](https://about.sourcegraph.com/terms-dotcom)
 
-Our full data policy is outlined in our [Terms of Service](https://about.sourcegraph.com/terms-dotcom) and our [Privacy Policy](https://about.sourcegraph.com/privacy/). If you have further questions, reach out to us at Security@sourcegraph.com.
+If you have further questions, reach out to us at [security@sourcegraph.com](mailto:security@sourcegraph.com).
 
 ### What is my private data used for?
 


### PR DESCRIPTION
Hey Eric, minor update to the doc you shared. Linking to the Security policy works best here IMO because we are much more likely to keep sourcegraph.com/security updated regularly. I added a `both at-rest and in-transit` bit that may be sufficient for most folks.