### PR TITLE
Change grooming to refinement

### DIFF
--- a/handbook/engineering/developer-insights/extensibility/index.md
+++ b/handbook/engineering/developer-insights/extensibility/index.md
@@ -103,7 +103,7 @@ This column represents issues that we’ve acknowledged but are currently not pl
 This column exists for our design partners to track their issues.
 sorted by priority (descending)
 Items should be assigned to alicja & eng
-Our kanplan methodology gives us the ability to backlog groom while continuously delivering quality software. We benefit from flexible planning, clearer focus, and total transparency because our board represents our priorities. We also communicate our team updates with the broader engineering org [every two weeks](https://about.sourcegraph.com/handbook/engineering/engineering-management#status-updates).
+Our kanplan methodology gives us the ability to refine the backlog while continuously delivering quality software. We benefit from flexible planning, clearer focus, and total transparency because our board represents our priorities. We also communicate our team updates with the broader engineering org [every two weeks](https://about.sourcegraph.com/handbook/engineering/engineering-management#status-updates).
 
 ### Tracking Issues
 

--- a/handbook/engineering/developer-insights/frontend-platform/index.md
+++ b/handbook/engineering/developer-insights/frontend-platform/index.md
@@ -90,7 +90,7 @@ We plan and track our day-to-day work on our [Kanban board](https://github.com/o
 
 ### Triage
 
-We have a weekly rotation for triaging and grooming issues. During their week on rotation, the on-duty teammate is responsible for triaging and clarifying any new issues that have been reported. We aim to do the following on a daily basis:
+We have a weekly rotation for triaging and refining issues. During their week on rotation, the on-duty teammate is responsible for triaging and clarifying any new issues that have been reported. We aim to do the following on a daily basis:
 
 1. Click the "+ Add cards" button and search for `is:issue is:open label:team/frontend-platform` to find all open issues for the Frontend Platform team that are not yet on our board. For each issue that is found, drag the card into the _Inbox_ column on our board.
 2. For each issue in the _Inbox_ column, consider the following:

--- a/handbook/engineering/distribution/recurring_processes.md
+++ b/handbook/engineering/distribution/recurring_processes.md
@@ -42,7 +42,7 @@ At the beginning of each cycle, [we determine what work we plan to do](#planning
 1. Revisit the goals. Are they still the right goals?
 1. If there are any remaining uncertainties following the meeting, the owners of each theme or task should follow up before the start of the cycle.
 
-**Backlog grooming:** The distribution team runs a backlog grooming session every two weeks to ensure that backlog is correctly prioritized for the upcoming sprint. We use the backlogs for tracking bugs, small features, and unplanned work. We don’t use the backlog for tracking work that is expressly planned in our roadmap. To add an issue, tag it `team/distribution` to notify the distribution team.
+**Backlog refinement:** The distribution team runs a backlog refinement session every two weeks to ensure that backlog is correctly prioritized for the upcoming sprint. We use the backlogs for tracking bugs, small features, and unplanned work. We don’t use the backlog for tracking work that is expressly planned in our roadmap. To add an issue, tag it `team/distribution` to notify the distribution team.
 
 **Note on pairing:** Pairing is a great way to share knowledge about the different projects that team is working on and pays dividends down the road. Teammates are encouraged to spend time on each cycle pairing with someone on all projects that you are _not_ working on. You are also encouraged to take own fewer tasks in order to accommodate this. As a rule of thumb estimate around **2 hours** for pairing and remember that people with be pairing with you as well.
 


### PR DESCRIPTION
Scrum started using the keyword "refinement" instead of "grooming". Making changes in our documents to reflect that change.

Ref: https://scrumguides.org/revisions.html