### PR TITLE
Add engineering career development framework

### DIFF
--- a/_resources/assets/content.css
+++ b/_resources/assets/content.css
@@ -431,7 +431,7 @@ time, abbr[title] {
   line-height: 1.25;
 }
 
-.markdown-body :is(h1, h2, h3, h4, h5, h6):hover .anchor {
+.markdown-body :is(h1, h2, h3, h4, h5, h6, th):hover .anchor {
   text-decoration: none;
   opacity: 1;
 }
@@ -515,9 +515,15 @@ time, abbr[title] {
 }
 
 .markdown-body table {
-  display: block;
   width: 100%;
   overflow: auto;
+}
+
+/* Can be applied to <th> table header cells */
+.sticky {
+  position: sticky;
+  top: calc(var(--header-height) - 1px);
+  z-index: 2;
 }
 
 .markdown-body table th {

--- a/_resources/assets/document.css
+++ b/_resources/assets/document.css
@@ -24,6 +24,11 @@
     margin-top: var(--index-margin-top);
     overflow-y: auto;
 }
+@media (min-width: 900px) {
+  #index {
+    max-width: 17rem;
+  }
+}
 #index > h3.version {
     font-weight: bold;
     font-size: 100%;
@@ -55,7 +60,6 @@
     flex: 8 4;
     background-color: white;
     padding: var(--spacing) var(--spacing) calc(3 * var(--spacing));
-    overflow: hidden;
     border-radius: 3px;
     margin-bottom: 1rem;
     border: 1px solid var(--border-color);

--- a/_resources/assets/layout.css
+++ b/_resources/assets/layout.css
@@ -56,7 +56,7 @@
     --logo-width: 120px;
     --logo-height: 1.5rem;
     --logo-padding-y: 0.25rem;
-    --header-height: calc(var(--logo-height) + 2 * var(--logo-padding-y) + 1px);
+    --header-height: calc(3rem + 1px);
 }
 body {
     margin: 0;
@@ -83,30 +83,23 @@ a:hover {
 }
 
 /* Scroll slightly beyond in-page anchor so that the fixed header doesn't obscure it. */
-:target::before {
-    content: '';
-    display: block;
-    position: relative;
-    pointer-events: none;
-}
-:not(.anchor-inline):target::before {
+:not(.anchor-inline):target {
     /* Scroll so that header anchors are at the top of the viewport. */
-    height: var(--header-height);
-    margin-top: calc(-1 * var(--header-height));
+    scroll-margin-top: var(--header-height);
 }
-.anchor-inline:target::before {
+.anchor-inline:target {
     /* Scroll so that inline anchors are at the center (vertically) of the viewport. */
-    height: 50vh;
-    margin-top: -50vh;
+    scroll-margin-top: 50vh;
 }
 .anchor-inline + .anchor-inline-link::before {
     content: '🔗';
     width: 1rem;
     height: 1rem;
+    padding-left: 0.2em;
 }
 .anchor-inline:target + .anchor-inline-link {
-    background-color: yellow;
-    border: solid 1px #eecc11;
+    background-color: var(--sg-yellow-2);
+    border: solid 1px var(--sg-yellow-3);
     display: inline-block;
     padding: 0.1rem;
     margin: -0.1rem;
@@ -115,6 +108,7 @@ a:hover {
 /* HEADER */
 #header {
     position: sticky;
+    height: var(--header-height);
     top: 0;
     z-index: 1;
     background-color: var(--header-bg);
@@ -219,6 +213,18 @@ footer a {
 
   #header nav div {
     margin-top: 1rem;
+  }
+}
+
+/* Account for wrapping nav */
+@media (max-width: 1029px) {
+  :root {
+    --header-height: 4.5rem;
+  }
+}
+@media (max-width: 754px) {
+  :root {
+    --header-height: 6.5rem;
   }
 }
 

--- a/handbook/engineering/career-development/CODENOTIFY
+++ b/handbook/engineering/career-development/CODENOTIFY
@@ -2,3 +2,5 @@
 
 # Members of the Careers WG
 **/* @chrispine @felixfbecker @pdubroy
+
+**/* @jeanduplessis

--- a/handbook/engineering/career-development/CODENOTIFY
+++ b/handbook/engineering/career-development/CODENOTIFY
@@ -1,0 +1,4 @@
+# See https://github.com/sourcegraph/codenotify for documentation
+
+# Members of the Careers WG
+**/* @chrispine @felixfbecker @pdubroy

--- a/handbook/engineering/career-development/framework.md
+++ b/handbook/engineering/career-development/framework.md
@@ -447,7 +447,7 @@ An in-band compensation increase (while staying at the same level) can happen at
       <td colspan="3" rowspan="2" class="tbd">
         <p>
           We haven't defined these levels at Sourcegraph yet, which would be equivalent in impact to a <a href="../roles#director-of-engineering">Director of Engineering</a> and <a href="../roles#vp-engineering">VP of Engineering</a>, respectively.
-          Like <a href="#ic5">IC5</a>, these are different <strong>roles</strong> than the levels preceding it based not only on performance, but also company need, and (like <a href="#ic5">IC5</a>) what impact at this level looks like may wary more from person to person than at preceding levels.
+          Like <a href="#ic5">IC5</a>, these are different <strong>roles</strong> than the levels preceding it based not only on performance, but also company need, and (like <a href="#ic5">IC5</a>) what impact at this level looks like may vary more from person to person than at preceding levels.
         </p>
         <p>
           We will define these no later than if any of the following become true:

--- a/handbook/engineering/career-development/framework.md
+++ b/handbook/engineering/career-development/framework.md
@@ -1,0 +1,466 @@
+# Sourcegraph engineering career development framework
+
+Our career development framework is here to help you understand the expectations of your role, and to provide a common language for you and your manager to discuss and plan your career growth. It is also an important part of our larger goal of ensuring everyone is equitably recognized for the impact they have at work, and to reduce bias in promotions and hiring.
+
+## What are these expectations?
+
+The currently five levels for software engineers in our framework.
+A level is composed of three categories, each with a summary statement and several example behaviors. These categories are:
+
+- Proficiency
+- Execution
+- Teamwork
+
+It's important to understand that what is listed in the level descriptions are example behaviors, and not checkboxes for promotion. Doing everything listed there is neither necessary nor sufficient for a promotion.
+The expectation is that you demonstrate a _level of impact_ consistent with each of the category descriptions for your level.
+The [magnitude of your impact](https://about.sourcegraph.com/blog/software-engineer-career-paths/) is ultimately the measure of your career growth.
+
+In most cases, a level builds on the expectations from the preceding levels: someone at level 2 must also meet the level 1 expectations.
+In addition to what is listed there, we expect engineers at all levels to exhibit [our values](../../company/values.md).
+
+Rather than precede each bullet point with "Consistently", we leave it as implicit.
+
+In line with our _continuously grow_ company value, we expect every engineer to eventually reach at least level 3.
+It is the responsibility of your manager to track this, and to ensure that you are given the support and opportunities needed for career growth.
+
+## When do I get promoted?
+
+When your manager can make the case that you’ve had at least one quarter of high performance at your current level, and one quarter performing at the next level, in all three of the categories. It takes time to demonstrate the “consistently” implicit in the expectations, and we don’t want to promote anyone to a level in which they will struggle.
+
+Promotions from one level to another are considered in our quarterly [talent review](talent-review-process.md).
+An in-band compensation increase (while staying at the same level) can happen at any time, in recognition of exceeding expectations in your current level without having yet met the expectations of the next level.
+
+<style>
+  .container {
+    --width: 1300px;
+  }
+  .levels-table {
+    --proficiency-color: var(--sg-vivid-violet);
+    --execution-color: var(--sg-sky-blue);
+    --teamwork-color: var(--sg-vermillion);
+
+    table-layout: fixed;
+  }
+  .proficiency {
+    --category-color: var(--proficiency-color);
+  }
+  .execution {
+    --category-color: var(--execution-color);
+  }
+  .teamwork {
+    --category-color: var(--teamwork-color);
+  }
+  .levels-table :is(td, th) {
+    vertical-align: top;
+    background: white;
+  }
+  .levels-table [id] {
+    /* Account for sticky table header */
+    scroll-margin-top: calc(var(--header-height) + 2.25rem);
+  }
+  thead th:first-child {
+    width: 8ch;
+  }
+  thead th.category-title {
+    text-align: center;
+    border-color: white;
+    background: var(--category-color);
+  }
+  thead th:is(.proficiency, .teamwork) {
+    color: white;
+  }
+  /*
+  Repeat the category color as a border color after each category summary.
+  Safari doesn't respect different border colors below a cell spanning multiple columns,
+  so we need to draw borders on wrapper elements instead.
+  */
+  .levels-table .category-summaries-row {
+    border-top: none;
+  }
+  .levels-table .category-summary {
+    border-top: none;
+    padding: 0;
+  }
+  .category-summary > .wrapper {
+    /* Note that absolute positioning wouldn't work here because <td>s can't be position: relative in Firefox. */
+    width: 100%;
+    height: 100%;
+    padding: 6px 13px;
+    display: block;
+    border-top: 1px solid var(--category-color);
+  }
+  .level {
+    white-space: nowrap;
+  }
+  .levels-table td[colspan] {
+    text-align: center;
+  }
+  .level-summary, .category-summaries-row {
+    font-style: italic;
+  }
+  .level-summary {
+    border-bottom: none !important;
+  }
+  .levels-table td.tbd {
+    vertical-align: middle;
+    text-align: left;
+    padding: 2.5rem;
+  }
+  /*
+  Safari doesn't make the two IC6/IC7 rows equal size automatically, so give them explicit heights
+  Note that min-height also doesn't work.
+  */
+  th#ic6, th#ic7 {
+    height: 11rem;
+  }
+</style>
+
+## Levels
+
+<table class="levels-table">
+
+  <thead>
+    <tr>
+      <th scope="col" class="sticky">Level</th>
+      <th scope="col" class="category-title proficiency sticky">Proficiency</th>
+      <th scope="col" class="category-title execution sticky">Execution</th>
+      <th scope="col" class="category-title teamwork sticky">Teamwork</th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <!-- IC1 -->
+    <tr>
+      <th id="ic1" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic1"></a><abbr title="Individual Contributor">IC</abbr>1</th>
+      <td colspan="3" class="level-summary">An engineer focused on learning, growth, and establishing themselves as a contributing teammate.</td>
+    </tr>
+    <tr class="category-summaries-row">
+      <td class="category-summary proficiency">
+        <div class="wrapper">
+          Possesses and demonstrates core technical skills, while focusing on learning and improving in everything they do.
+        </div>
+      </td>
+      <td class="category-summary execution">
+        <div class="wrapper">
+          Able to achieve positive outcomes on small well defined problems.
+        </div>
+      </td>
+      <td class="category-summary teamwork">
+        <div class="wrapper">
+          An engaged member of their team.
+        </div>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors proficiency">
+        <ul>
+          <li>Contributes technical solutions to well-scoped tasks, with guidance.</li>
+          <li>Demonstrates the essentials needed to do work in their domain.</li>
+          <li>Reviews code for their teammates by asking questions and applying what they learned.</li>
+          <li>Integrates feedback from teammates to deliver high-quality solutions.</li>
+          <li>Increases their technical knowledge through reading, observing, and doing.</li>
+        </ul>
+      </td>
+      <td class="behaviors execution">
+        <ul>
+          <li>Manages their own time and wellbeing, meeting commitments while finding balance and creating rest.</li>
+          <li>Asks for guidance in unfamiliar areas or for underspecified tasks. Speaks up if not comfortable with the scopes or timelines.</li>
+          <li>Exercises user empathy, whether their users are internal or external.</li>
+          <li>Recognizes when they’re blocked and asks for support.</li>
+        </ul>
+      </td>
+      <td class="behaviors teamwork">
+        <ul>
+          <li>Actively asks teammates questions to seek feedback and clarify, including cross-functionally (e.g. Design and Product).</li>
+          <li>Participates and demonstrates curiosity in team meetings.</li>
+          <li>Follows documented team processes and helps keep the handbook up-to-date.</li>
+          <li>Communicates empathetically.</li>
+          <li>Is flexible to change.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC2 -->
+    <tr>
+      <th id="ic2" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic2"></a><abbr title="Individual Contributor">IC</abbr>2</th>
+      <td colspan="3" class="level-summary">A solid and autonomous contributor, executor, and collaborator.</td>
+    </tr>
+    <tr class="category-summaries-row">
+      <td class="category-summary proficiency">
+        <div class="wrapper">
+          A solid technical contributor who produces high-quality code.
+        </div>
+      </td>
+      <td class="category-summary execution">
+        <div class="wrapper">
+          Autonomously executes on the team’s short-term goals and actively contributes to project planning.
+        </div>
+      </td>
+      <td class="category-summary teamwork">
+        <div class="wrapper">
+          A solid communicator and proactive collaborator.
+        </div>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors proficiency">
+        <ul>
+          <li>
+            Proficient in core technical skills of their primary focus area, while
+            continuing to develop proficiency in some aspects.
+          </li>
+          <li>Writes maintainable, well-tested code that aligns with the style and practices of the team/codebase.</li>
+          <li>Can explain the reasoning and trade-offs behind their technical decisions.</li>
+          <li>Provides helpful, timely code reviews.</li>
+          <li>Invests in their own productivity; willingly explores new tools, skills, and areas of the codebase.</li>
+        </ul>
+      </td>
+      <td class="behaviors execution">
+        <ul>
+          <li>Breaks down tasks, plans, estimates and cuts scope as appropriate to deliver reliably.</li>
+          <li>Prioritizes their own work in alignment with team goals.</li>
+          <li>Detects problems in requirements and actively engages to resolve them.</li>
+          <li>Has understanding of how users interact with their product/infrastructure.</li>
+          <li>Reliably delivers results on time.</li>
+        </ul>
+      </td>
+      <td class="behaviors teamwork">
+        <ul>
+          <li>
+            Communicates clearly (in meetings and asynchronously), escalating blockers
+            quickly, clarifying requirements and sharing assumptions and context.
+          </li>
+          <li>
+            Exemplifies team processes; participates in identifying problems, suggesting
+            improvements, and helping with solutions.
+          </li>
+          <li>
+            Proactively adds documentation to help others; is learning to present
+            internally and externally.
+          </li>
+          <li>
+            Gives timely, helpful feedback to others and trusts them to decide to what
+            extent to incorporate it.
+          </li>
+          <li>
+            Helps onboarding and orienting new team members; mentors more junior team
+            members where possible.
+          </li>
+          <li>
+            Participates in the hiring process where possible, conducting interviews
+            (with training) and writing helpful feedback.
+          </li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC3 -->
+    <tr>
+      <th id="ic3" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic3"></a><abbr title="Individual Contributor">IC</abbr>3</th>
+      <td colspan="3" class="level-summary">An experienced, strong individual contributor (<q>Senior</q> equivalent).</td>
+    </tr>
+    <tr class="category-summaries-row">
+      <td class="category-summary proficiency">
+        <div class="wrapper">
+          An experienced, versatile technical contributor who demonstrates foresight in technical decision making.
+        </div>
+      </td>
+      <td class="category-summary execution">
+        <div class="wrapper">
+          Independently scopes and implements solutions to complex, loosely-defined problems.
+        </div>
+      </td>
+      <td class="category-summary teamwork">
+        <div class="wrapper">
+          A strong, clear communicator, making collaboration happen where it should to move their team forward and a particularly valuable contributor to discussions.
+        </div>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors proficiency">
+        <ul>
+          <li>
+            Expert in their domain: deep understanding of their team’s code, debugs
+            their team’s code expertly, and has mastered their tools (Git, $EDITOR,
+            profiler, etc).
+          </li>
+          <li>Willingly dives into unfamiliar areas of the codebase.</li>
+          <li>
+            Finds technical solutions to open-ended, potentially ambiguously defined
+            problems.
+          </li>
+          <li>
+            When finding solutions, identifies the core problems that need to be solved,
+            as well as goals, risks, trade-offs, customer impact, technical debt,
+            non-technical factors, etc.
+          </li>
+          <li>
+            Gives feedback on higher-level aspects (architecture, scalability,
+            customer-focus, etc.) in code reviews and RFCs, holding teammates to the
+            same high standard they set for themselves.
+          </li>
+          <li>
+            Maintains awareness of approaches outside of Sourcegraph that we're not
+            using, and uses this to help define best practices for the team/domain.
+          </li>
+        </ul>
+      </td>
+      <td class="behaviors execution">
+        <ul>
+          <li>Independently scopes and implements solutions to complex, loosely-defined problems.</li>
+          <li>
+            Estimates methodically, based on iterative learning. Sets realistic
+            deadlines that drive effort but support healthy work habits. Cuts scope as
+            needed, mitigating risk by shipping frequently.
+          </li>
+          <li>
+            When faced with roadblocks, identifies appropriate courses of action,
+            engaging others or unblocking themselves as appropriate.
+          </li>
+          <li>
+            Accountable end-to-end, through planning, shipping, cleanup, and
+            maintenance. Proactive about potential issues without overengineering.
+          </li>
+          <li>
+            Proactively identifies areas for improvement and improves common code,
+            balancing new feature development with refactoring, upgrades, cleanups, etc.
+          </li>
+        </ul>
+      </td>
+      <td class="behaviors teamwork">
+        <ul>
+          <li>Communicates technical issues and decisions clearly, brings clarity to discussions and helps drive them forward.</li>
+          <li>Routinely drives improvements in team/company processes (retros, testing, on-call, planning, etc.)</li>
+          <li>Considers effects of their work and words on other teams and represents the team well in discussions with other teams, customers, and stakeholders.</li>
+          <li>Shares their experience and expertise to help others grow, through mentoring and coaching more junior engineers where possible, insightful code/design/RFC reviews, etc.</li>
+          <li>Proactively proposes additions and changes to the team’s roadmap.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC4 -->
+    <tr>
+      <th id="ic4" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic4"></a><abbr title="Individual Contributor">IC</abbr>4</th>
+      <td colspan="3" class="level-summary">A particularly experienced, impactful contributor.</td>
+    </tr>
+    <tr class="category-summaries-row">
+      <td class="category-summary proficiency">
+        <div class="wrapper">
+          An engineer whose technical expertise benefits their entire team.
+        </div>
+      </td>
+      <td class="category-summary execution">
+        <div class="wrapper">
+          Supports the EM and PM in ensuring that the team is always working on the right problems with the right scope given higher level goals, and that the team is reliably delivering on time.
+        </div>
+      </td>
+      <td class="category-summary teamwork">
+        <div class="wrapper">
+          A very strong communicator who drives cross-functional collaboration efforts and the long-term direction of their team.
+        </div>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors proficiency">
+        <ul>
+          <li>High-quality technical decision making, leading team-sized tasks that affect one or more complex systems or mission-critical areas.</li>
+          <li>Consistently incorporates non-technical factors into technical decisions and weights them appropriately.</li>
+          <li>
+            Proficiency beyond their domain: broad understanding of our architecture,
+            debugs expertly across the broader codebase, advises on broader technical
+            issues, etc.
+          </li>
+          <li>
+            Invests in technology, tools, and processes that benefit their entire team,
+            and lifts teammates through feedback, mentorship, and sharing reusable
+            patterns.
+          </li>
+        </ul>
+      </td>
+      <td class="behaviors execution">
+        <ul>
+          <li>Independently scopes and implements solutions to extremely complex problems, and identifies the problems to be solved.</li>
+          <li>Remains composed in: ambiguous situations, challenging situations, situations involving multiple stakeholders, etc.</li>
+          <li>Intentionally and proactively aligns their work around a deep understanding of how people use the products/services they build.</li>
+          <li>Proactively identifies areas for improvement beyond the scope of their team, and contributes meaningfully to solutions while continuing to deliver on their team’s goals.</li>
+          <li>Works closely with EM/PM to validate technical feasibility of team roadmap.</li>
+        </ul>
+      </td>
+      <td class="behaviors teamwork">
+        <ul>
+          <li>Effectively able to convince and challenge teammates and cross-functional stakeholders using valid expertise and respectful communication.</li>
+          <li>Actively seeks dissenting opinions, disconfirming evidence, etc.</li>
+          <li>Shares a long-term vision that influences the team’s roadmap.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC5 -->
+    <tr>
+      <th id="ic5" scope="row" rowspan="3" class="level"><a class="anchor" href="#ic5"></a><abbr title="Individual Contributor">IC</abbr>5</th>
+      <td colspan="3" class="level-summary">
+        A different IC role from levels 1-4, with a focus on technical leadership.<br>
+        This level is equivalent in impact to an <a href="../roles#engineering-manager">Engineering Manager</a>.
+      </td>
+    </tr>
+    <tr class="category-summaries-row">
+      <td class="category-summary proficiency">
+        <div class="wrapper">
+          A respected technical leader, on and off their team.
+        </div>
+      </td>
+      <td class="category-summary execution">
+        <div class="wrapper">
+          Defines cross-team goals that align with top level company goals, and ensures delivery to meet business needs.
+        </div>
+      </td>
+      <td class="category-summary teamwork">
+        <div class="wrapper">
+          An extremely strong communicator doing outstanding stakeholder management.
+        </div>
+      </td>
+    </tr>
+    <tr class="behaviors-row">
+      <td class="behaviors proficiency">
+        <ul>
+          <li>Sets the technical vision for their team, and influences the broader technical vision.</li>
+          <li>Initiates and drives cross-team projects that enable higher quality work.</li>
+          <li>Provides oversight, coaching, and guidance through code and design reviews, both on and off the team.</li>
+          <li>Acts as a trusted advisor, drawing on functional expertise to inform customer-driven strategy.</li>
+        </ul>
+      </td>
+      <td class="behaviors execution">
+        <ul>
+          <li>Proactively identifies areas for improvement at the org level. Suggests process and methodology improvements.</li>
+          <li>Works closely with Engineering/Product leadership to validate alignment of team roadmaps within their org.</li>
+          <li>Independently scopes, designs, and delivers solutions for large, complex challenges.</li>
+        </ul>
+      </td>
+      <td class="behaviors teamwork">
+        <ul>
+          <li>Provides technical expertise internally and externally, informing what can be achieved.</li>
+          <li>Guides others on effective collaboration, conflict resolution and improved communication.</li>
+          <li>Regularly shares knowledge and willingly presents to large and/or senior audiences.</li>
+          <li>Persuades and challenges clients and internal stakeholders, using valid expertise and respectful communication.</li>
+        </ul>
+      </td>
+    </tr>
+    <!-- IC6 -->
+    <tr>
+      <th id="ic6" scope="row" class="level"><a class="anchor" href="#ic6"></a><abbr title="Individual Contributor">IC</abbr>6</th>
+      <td colspan="3" rowspan="2" class="tbd">
+        <p>
+          We haven't defined these levels at Sourcegraph yet, which would be equivalent in impact to a <a href="../roles#director-of-engineering">Director of Engineering</a> and <a href="../roles#vp-engineering">VP of Engineering</a>, respectively.
+          Like <a href="#ic5">IC5</a>, these are different <strong>roles</strong> than the levels preceding it based not only on performance, but also company need, and (like <a href="#ic5">IC5</a>) what impact at this level looks like may wary more from person to person than at preceding levels.
+        </p>
+        <p>
+          We will define these no later than if any of the following become true:
+        </p>
+        <ul>
+          <li>We agree that we have a company need to have someone in this role.</li>
+          <li>At least one IC on our engineering team doesn't only <em>exceed expectations</em> for <a href="#ic5">IC5</a>, but clearly operates at a higher <em>level</em> than <a href="#ic5">IC5</a> (a distinct role, with the aforementioned impact). The existence of an IC operating and bringing value at this level naturally implies the company need.</li>
+        </ul>
+      </td>
+    </tr>
+    <tr>
+      <th id="ic7" scope="row" class="level"><a class="anchor" href="#ic7"></a><abbr title="Individual Contributor">IC</abbr>7</th>
+    </tr>
+  </tbody>
+
+</table>

--- a/handbook/engineering/career-development/index.md
+++ b/handbook/engineering/career-development/index.md
@@ -1,0 +1,4 @@
+# Engineering career development
+
+- [Career development framework](framework.md)
+- [Talent review process](talent-review-process.md)

--- a/handbook/engineering/career-development/talent-review-process.md
+++ b/handbook/engineering/career-development/talent-review-process.md
@@ -1,0 +1,93 @@
+# Engineering talent review process
+
+## Definitions
+
+<dl>
+  <dt>Group</dt>
+  <dd>The set of ICs under consideration, plus their managers and directors (at first, this will be all of engineering; as we grow, we will eventually need to split this up at the director-org level).</dd>
+
+  <dt>Talent review</dt>
+  <dd>This entire process.</dd>
+
+  <dt>Calibration meeting</dt>
+  <dd>Meeting with EMs and directors of a group to evaluate each IC for the purposes of determining promotions and ensuring we are all well-calibrated to the engineering levels.</dd>
+</dl>
+
+## Cadence
+
+**Talent review is performed once per quarter.** More frequent than quarterly is not enough time for significant growth to occur for most ICs, and is thus not a good use of <a href="../roles#engineering-manager"><abbr title="Engineering Manager">EM</abbr></a> effort: too much cost for not enough benefit.
+Less frequent than quarterly raises the stakes too high: “I just started this new role right before Talent Review. If it’s not enough time for me to demonstrate my increased impact, I’ll have to wait another 6 months before I’m considered again!”
+
+## Pre-work
+
+Prior to the calibration meeting, each <a href="../roles#engineering-manager"><abbr title="Engineering Manager">EM</abbr></a> should evaluate each <a href="../roles#software-engineer"><abbr title="Individual Contributor">IC</abbr></a> reporting to them using the [level descriptions](framework.md#levels) and determine if they are meeting/exceeding/struggling-to-meet the expectations of their given level. EMs should prepare a _short_ statement to justify this, which they will share during the calibration meeting. If they believe the IC to be performing at a higher level, they should also ensure that the IC is meeting the expectations for that higher level, as well as write up a brief promotion pitch. (Note that compensation increases within a level, such as from the start of the compensation band to the midpoint, do not need to go through this process; those can happen any time and are between the EM and their <a href="../roles#director-of-engineering">director</a> to decide.)
+
+This pre-work is greatly aided by [360º feedback](../../people-ops/review-cycles/index.md), so we schedule the talent review accordingly. (Since we do 360º feedback every 6 months, it would only be available for every other talent review.)
+
+Because of the quarterly cadence, it’s important that this be as light-weight as possible. The pre-work should take an EM less than an hour per IC not being pitched for a promotion. (For ICs being pitched, the cadence isn’t a consideration: an EM will have the same number of promotion pitches to make regardless of cadence. More frequent evaluations means fewer pitches per talent review.)
+
+Prior to the calibration meeting, EMs in a Group will share their evaluations and any promotion pitches for async review/commenting, and for supporting or challenging promotions.
+
+## Calibration meeting
+
+The calibration meeting is a several-hour meeting (possibly spread out over two days, depending on logistics) with all of the EMs and directors of the Group, plus an observer from [People Ops](../../people-ops/index.md) for the purpose of reducing unconscious bias. (If the Group is not all of engineering, then at least one other director is invited as well, to help ensure that all Groups are well-calibrated with each other.) Upper management may be invited, but are not required and have no official role.
+
+All ICs at a given level are reviewed together, starting with level 1. Every EM with an IC at level 1 places their ICs into one of these categories: struggling/meeting/exceeding expectations. Then, one at a time, each IC’s placement is explained by their EM. (Note that in the interests of time, the Group might decide to focus conversation on ICs who are under- or over-performing, especially given the async prework described above.) If they are being pitched for a promotion, that is also shared. Other EMs then provide additional feedback/insight they might have, either to challenge or to further justify the IC’s placement. _This is not adversarial:_ the EMs are working together to best establish where each IC is, and to help prepare the EM to provide meaningful feedback to the IC.
+
+During the discussion, there is a rotating _moderator_ whose job it is to ensure that a fair, balanced, and productive conversation is happening. This can include asking questions of the other participants, calling out potential biases, and calling “time” when things are going in circles.
+
+After all level 1 ICs have been discussed, we move on to level 2 ICs. For any IC being pitched for a promotion to level 2, they are evaluated along with their prospective cohort. (They are not discussed again in the same way, but after discussing other ICs with the same meeting/exceeding evaluation, a quick check is done to validate that they are performing similarly to those folks at level 2.)
+
+This is done for each of our engineering levels.
+
+## After the meeting
+
+Decisions regarding promotions are prioritized by the relevant decision-makers (EM, Director, VP), and made quickly. Promotions are communicated back to the ICs in a timely manner. Regardless of promotions, any qualitative feedback for an IC that came out of talent review is shared with them in their next one-on-one (if not sooner).
+
+It’s important that this process moves quickly! If we leave people wondering for a month or more if they will be getting a promotion, we’re creating needless anxiety and uncertainty.
+
+Finally, we should have a [retrospective](../../retrospectives/index.md) after each of these, so we can continue iterating and improving upon this process. We should also consider changes/clarifications to the [level descriptions](framework.md#levels) at this time, in case any of the existing definitions were cause for confusion.
+
+## Levels
+
+#### Structure of the levels
+
+We have 7 levels for software engineers at Sourcegraph, derived from Option Impact, a startup compensation tool that Sourcegraph and many other companies use to determine their compensation bands. For each of these, we have a corresponding level description.
+
+The structure of a level description is in three parts, for each of our evaluation categories (listed below). For each category, we include a summary statement and several _examples_ of the kinds of behaviors we expect of someone at that level. (Note that these are neither necessary nor sufficient for promotion: these are not checkboxes. Rather, they serve to illustrate the magnitude of impact that we are looking for in each of the categories.)
+
+The level descriptions correspond to the start of the level, so that if an IC has a level N impact in all categories, they should then be promoted to level N (and not before). Or to put it another way, the level descriptions state the minimum expectations.
+
+#### Research
+
+We consulted a variety of sources to determine our levels, and [summarized our findings here](https://docs.google.com/document/d/1Vqpks_iZLalGwbcTFHQcQs3xnjZtGxX_azH063aulOg/edit#).
+
+#### Evaluation categories
+
+Each level definition is composed of three categories, each with a summary statement and several example behaviors.
+
+The categories we use are:
+
+- Proficiency
+- Execution
+- Teamwork
+
+#### Level descriptions
+
+The levels are [defined in our career development framework](framework.md). In most cases, a level builds on the criteria from the preceding level: someone at level 2 must also meet the criteria for level 1.
+
+In addition to what is listed there, we expect engineers at all levels to exhibit [our values](../../company/values.md).
+
+These are the expectations for ICs _after they have completed their onboarding_. Some of these expectations (such as around communication) would start on day 1, but others (such as expertise in the codebase) would not be expected until they are fully ramped up.
+
+Rather than precede each bullet point in the level descriptions with “Consistently”, we leave it as implicit.
+
+In line with our ["Continuously grow" company value](../../company/values.md), we expect every engineer to eventually reach at least level 3, spending no more than 2 years at any previous level. It is the responsibility of the EM to track this, and to ensure that ICs are given the support and opportunities needed for career growth.
+
+#### Considerations for promotion
+
+Teammates are considered for promotion to a new level when their manager can make the case that they have had at least one quarter of high performance at their current level, and one quarter performing at the next level. We want to avoid situations where someone is promoted to a level in which they struggle to meet expectations.
+
+The engineering levels describe performance expectations in 3 categories. It will be extremely rare for an engineer to be exactly at the same level in all of these categories. Since the levels describe the minimum expectations for each level, an engineer must meet the expectations for all categories before they can be considered for promotion.
+
+This does imply a distinction between _high performance at current level_ vs. _ready for promotion_. A level N engineer who is consistently exceeding level N expectations in some areas, but whom we do not feel would be able to meet level N+1 expectations, should not be promoted (despite their high performance in some areas).

--- a/handbook/engineering/index.md
+++ b/handbook/engineering/index.md
@@ -25,6 +25,9 @@
 - [Hiring](hiring/index.md)
   - [Open positions](hiring/index.md#open-positions)
   - [Early-career engineers](hiring/early-career-engineers.md)
+- [Career development](career-development/index.md)
+  - [Career development framework](career-development/framework.md)
+  - [Talent review process](career-development/talent-review-process.md)
 
 ## Org chart
 

--- a/handbook/engineering/roles.md
+++ b/handbook/engineering/roles.md
@@ -23,8 +23,9 @@ Engineering managers lead, grow, and develop teams of software engineers.
 - Facilitate and sustain a healthy, inclusive team culture where everyone is set up to do their best work (examples: [retrospectives](../retrospectives/index.md), [team events](../people-ops/travel.md#team-events), [compensation](../people-ops/compensation/index.md)).
 - Model, teach, and apply [our values](../company/values.md) and [our guiding engineering principles](../index.md#guiding-principles).
 - Ensure the team has clear incremental goals that are documented and are always up-to-date (example: [PM – EM partnership responsibilities](../product/roles/product_manager_engineering_manager_responsibilities.md)).
-- Regularly communicate the team's progress toward their goals as well as changes in team goals to appropriate stakeholders (examples: presenting a slide at [company meeting](../communication/company_meeting.md), [weekly updates](engineering-management.md#status-updates))
-- Support and coach teammates to grow in their careers and fulfill their responsibilities (examples: [1-1s](../leadership/1-1.md), [retrospectives](), [review cycles](https://about.sourcegraph.com/handbook/people-ops/review-cycles/index.md), [compensation](../people-ops/compensation/index.md))
+- Regularly communicate the team's progress toward their goals as well as changes in team goals to appropriate stakeholders (examples: presenting a slide at [company meeting](../communication/company_meeting.md), sending [status updates](engineering-management.md#status-updates))
+- Support and coach teammates to grow in their careers and fulfill their responsibilities (examples: [1-1s](../leadership/1-1.md), [career levels](./career-development/framework.md), [retrospectives](../retrospectives/index.md), [review cycles](../people-ops/review-cycles/index.md), [compensation](../people-ops/compensation/index.md))
+- Participate in our [talent review](career-development/talent-review-process.md) sessions.
 - Grow the team in a sustainable way so that the team can accomplish more over time (examples: define open roles, maintain a hiring plan over time, source candidates with help from our talent org, define efficient and effective interview process, make hiring decisions).
 
 ## Director of Engineering


### PR DESCRIPTION
This adds our career development framework proposal (the [talent review process](https://docs.google.com/document/d/1HUY_2cYSsRTEx7JFBPXwQNc-e3qRWJ5Vv7n2rkQYSkw/edit), and the [level descriptions](https://docs.google.com/document/d/1Zb7zCZUFkxP6vS_H5Y24wPK7MajA51DqV6gpsvDMMnU/edit#heading=h.5y4045rjaabr)) to the handbook (see those documents for more context on our approach and the feedback that went into this). I added cross-links in the places I could think of. This was extensively reviewed in Google Docs so there should be no surprising content here :)

I experimented with a few different layouts and chose to go with a **table** to lay out the separate categories and visualize how they are _axes_ all equally important for each level, but with bullet points within each cell, as not every bullet point "maps" to another bullet point in another category or level. I made the page a bit wider for this purpose, so that text doesn't wrap too much. There's a trade-off here in that this doesn't look good on mobile, but I think that's the right trade-off.

Other features:
- Individual levels can be linked to like headings on other pages.
- I used our brand colors for color-coding the categories and making the page visually appealing.
- Added sticky table headers so they are visible even when looking at higher levels.

The intro text is part of the levels page so the context on how to interpret them can't be missed. The second page about the talent review process is more for an EM audience (and hence there is some slight redundancy in content, but that's intentional).

We settled on the name "Career development framework" because the primary goal of this is to help ICs develop their careers and because it's, well, a _framework_ to help with that.