### PR TITLE
Deduplication of content in career dev framework pages

### DIFF
--- a/handbook/engineering/career-development/framework.md
+++ b/handbook/engineering/career-development/framework.md
@@ -2,10 +2,9 @@
 
 Our career development framework is here to help you understand the expectations of your role, and to provide a common language for you and your manager to discuss and plan your career growth. It is also an important part of our larger goal of ensuring everyone is equitably recognized for the impact they have at work, and to reduce bias in promotions and hiring.
 
-## What are these expectations?
+## What are the expectations of my role?
 
-The currently five levels for software engineers in our framework.
-A level is composed of three categories, each with a summary statement and several example behaviors. These categories are:
+There are currently five levels for software engineers described in our framework. A level is composed of three categories, each with a summary statement and several example behaviors. These categories are:
 
 - Proficiency
 - Execution
@@ -20,6 +19,10 @@ In addition to what is listed there, we expect engineers at all levels to exhibi
 
 Rather than precede each bullet point with "Consistently", we leave it as implicit.
 
+The level descriptions correspond to the start of the level, so that if an IC has a level N impact in all categories, they should then be promoted to level N (and not before). Or to put it another way, the level descriptions state the minimum expectations.
+
+These are the expectations for ICs _after they have completed their onboarding_. Some of these expectations (such as around communication) would start on day 1, but others (such as expertise in the codebase) would not be expected until they are fully ramped up.
+
 In line with our _continuously grow_ company value, we expect every engineer to eventually reach at least level 3.
 It is the responsibility of your manager to track this, and to ensure that you are given the support and opportunities needed for career growth.
 
@@ -29,6 +32,8 @@ When your manager can make the case that you’ve had at least one quarter of hi
 
 Promotions from one level to another are considered in our quarterly [talent review](talent-review-process.md).
 An in-band compensation increase (while staying at the same level) can happen at any time, in recognition of exceeding expectations in your current level without having yet met the expectations of the next level.
+
+You can learn more [here](talent-review-process#considerations-for-promotion).
 
 <style>
   .container {

--- a/handbook/engineering/career-development/framework.md
+++ b/handbook/engineering/career-development/framework.md
@@ -33,7 +33,7 @@ When your manager can make the case that you’ve had at least one quarter of hi
 Promotions from one level to another are considered in our quarterly [talent review](talent-review-process.md).
 An in-band compensation increase (while staying at the same level) can happen at any time, in recognition of exceeding expectations in your current level without having yet met the expectations of the next level.
 
-You can learn more [here](talent-review-process#considerations-for-promotion).
+You can learn more [here](talent-review-process.md#considerations-for-promotion).
 
 <style>
   .container {

--- a/handbook/engineering/career-development/talent-review-process.md
+++ b/handbook/engineering/career-development/talent-review-process.md
@@ -50,41 +50,11 @@ Finally, we should have a [retrospective](../../retrospectives/index.md) after e
 
 ## Levels
 
-#### Structure of the levels
+We have seven levels for software engineers at Sourcegraph, derived from Option Impact, a startup compensation tool that Sourcegraph and many other companies use to determine their compensation bands.
 
-We have 7 levels for software engineers at Sourcegraph, derived from Option Impact, a startup compensation tool that Sourcegraph and many other companies use to determine their compensation bands. For each of these, we have a corresponding level description.
+Levels 1-5 are [described in our career development framework](framework.md).
 
-The structure of a level description is in three parts, for each of our evaluation categories (listed below). For each category, we include a summary statement and several _examples_ of the kinds of behaviors we expect of someone at that level. (Note that these are neither necessary nor sufficient for promotion: these are not checkboxes. Rather, they serve to illustrate the magnitude of impact that we are looking for in each of the categories.)
-
-The level descriptions correspond to the start of the level, so that if an IC has a level N impact in all categories, they should then be promoted to level N (and not before). Or to put it another way, the level descriptions state the minimum expectations.
-
-#### Research
-
-We consulted a variety of sources to determine our levels, and [summarized our findings here](https://docs.google.com/document/d/1Vqpks_iZLalGwbcTFHQcQs3xnjZtGxX_azH063aulOg/edit#).
-
-#### Evaluation categories
-
-Each level definition is composed of three categories, each with a summary statement and several example behaviors.
-
-The categories we use are:
-
-- Proficiency
-- Execution
-- Teamwork
-
-#### Level descriptions
-
-The levels are [defined in our career development framework](framework.md). In most cases, a level builds on the criteria from the preceding level: someone at level 2 must also meet the criteria for level 1.
-
-In addition to what is listed there, we expect engineers at all levels to exhibit [our values](../../company/values.md).
-
-These are the expectations for ICs _after they have completed their onboarding_. Some of these expectations (such as around communication) would start on day 1, but others (such as expertise in the codebase) would not be expected until they are fully ramped up.
-
-Rather than precede each bullet point in the level descriptions with “Consistently”, we leave it as implicit.
-
-In line with our ["Continuously grow" company value](../../company/values.md), we expect every engineer to eventually reach at least level 3, spending no more than 2 years at any previous level. It is the responsibility of the EM to track this, and to ensure that ICs are given the support and opportunities needed for career growth.
-
-#### Considerations for promotion
+## Considerations for promotion
 
 Teammates are considered for promotion to a new level when their manager can make the case that they have had at least one quarter of high performance at their current level, and one quarter performing at the next level. We want to avoid situations where someone is promoted to a level in which they struggle to meet expectations.
 


### PR DESCRIPTION
This removes some of the duplication of content between the career dev framework page and the talent review page.