### PR TITLE
managed: no warning alerts, include abbreviations in 1pass

### DIFF
--- a/handbook/engineering/distribution/managed/creation_process.md
+++ b/handbook/engineering/distribution/managed/creation_process.md
@@ -69,14 +69,6 @@ Creating a new managed instance involves following the steps below.
 					"url": "$WEBHOOK_URL"
 				}
 			},
-			{
-				"level": "warning",
-				"notifier": {
-					"type": "slack",
-					"username": "$COMPANY",
-					"url": "$WEBHOOK_URL"
-				}
-			}
 		],
    ```
 1. Add an entry for the customer by adding their HubSpot link to the checklist in the [managed instances upgrade issue template](../../releases/upgrade_managed_issue_template.md).

--- a/handbook/engineering/distribution/managed/creation_process.md
+++ b/handbook/engineering/distribution/managed/creation_process.md
@@ -18,6 +18,7 @@ Creating a new managed instance involves following the steps below.
     - **Add** > **Login** > enter **$COMPANY sourcegraph-admin** as the title
       - **User:** `managed+$COMPANY@sourcegraph.com`
       - **Password:** Change **length** to 40 and turn on symbols and digits > **Save**
+    - Note: for all of the above, if the company name differs (i.e. via abbreviation) from the name of the folder used in `sourcegraph/customer`, please include the abbreviation in the 1password as well for easier search
 1. In GCP, enable the **Compute Engine API**:
    - Under **APIs & Services** > **Library** search for "Compute"
    - Select **Compute Engine API** and choose **Enable**


### PR DESCRIPTION
- #alerts-managed-instances is very noisy, hopefully this will make the channel more useful. I've gone ahead and disabled warning alerts for all existing managed instances
- sometimes the name of the instance differs from the name in the 1password entries, adds a step to include those abbreviations for easier search