### PR TITLE
fix codeblock by removing list formating

### DIFF
--- a/handbook/support/p4-enablement.md
+++ b/handbook/support/p4-enablement.md
@@ -3,16 +3,19 @@
 Perforce is a version control system like Git, subversion, or mercurial. While git is based on a distributed, decentralised model, Perforce is centralised. For testing purposes, you may use our [Perforce dogfood server](https://k8s.sgdev.org/github.com/sourcegraph/infrastructure/-/tree/dogfood/kubernetes/tooling/perforce).
 
 ## Setting up
-- To connect to the Perforce server, you'll need the Perforce cli installed locally. Use the command: `brew install --cask perforce`
-- The following environment variables configure your shell to point at the Perforce server. Set them to your `env` with the `export` command, or add them to your `.bashrc` or `.zshrc` file.
+  To connect to the Perforce server, you'll need the Perforce cli installed locally. Use the command: `brew install --cask perforce`
+  
+  The following environment variables configure your shell to point at the Perforce server. Set them to your `env` with the `export` command, or add them to your `.bashrc` or `.zshrc` file. <br>
+
 
 ```
-# .zshrc or .bashrc
+    # .zshrc or .bashrc
 
-P4PORT=perforce.sgdev.org:1666 # This points the p4 cli at the dogfood server
-P4USER=admin                   # sets your user
-P4PASSWD=<session ticket>      # see details below, doesn't require string quotes
-P4EDITOR=/usr/bin/vim          # specifies the editor opened by some p4 commands
+    P4PORT=perforce.sgdev.org:1666 # This points the p4 cli at the dogfood server
+    P4USER=admin                   # sets your user
+    P4PASSWD=<session ticket>      # optional, see details below, doesn't require string quotes
+    P4EDITOR=/usr/bin/vim          # specifies the editor opened by some p4 commands
+
 ```
 
 Perforce dogfood is a service on our Sourcegraph dogfood cluster, for more info see its GCP [service details](https://console.cloud.google.com/kubernetes/service/us-central1-f/dogfood/tooling/perforce-server/overview?authuser=1&project=sourcegraph-dogfood).


### PR DESCRIPTION
I have no idea why this was causing the weird code block issue on our site, but removing the bullet list prior to the first codeblock has fixed the formatting of the codeblock