### PR TITLE
templates: handle a document without any tree items correctly

### DIFF
--- a/_resources/templates/document.html
+++ b/_resources/templates/document.html
@@ -41,7 +41,15 @@
 {{end}}
 
 {{define "index"}}
-	{{with (or (and (eq (len .Doc.Tree) 1) (index .Doc.Tree 0).Children) .Doc.Tree)}}
+	{{/* If the tree has exactly one element, we'll go down one level to use its children for the page index. */}}
+	{{$tree := .Doc.Tree}}
+	{{if (eq (len .Doc.Tree) 1)}}
+		{{if (index .Doc.Tree 0).Children}}
+			{{$tree = .Doc.Tree}}
+		{{end}}
+	{{end}}
+
+	{{with $tree}}
 		<h4 class="visible-sm">{{$.Doc.Title}}</h4>
 		<h4 class="visible-lg">On this page:</h4>
 		<ul>{{template "doc_nav" .}}</ul>


### PR DESCRIPTION
When generating the page index (table of contents), we have a special case where a document with a single top level element will have the indexing move down a single level into that element's children, presumably to catch documents with subtly malformed element trees. This is implemented in the templating logic in `document.html`.

Unfortunately, the check that is intended to prevent this behaviour kicking in when there is _not_ one top level element dereferences `.Doc.Tree`'s first element unconditionally, because [the `and` function provided by Go templates does not short
circuit](https://pkg.go.dev/text/template) and the second branch expression calls `(index .Doc.Tree 0)`.

The fix here is to split out the logic to calculate the tree to index into a set of nested `if` statements, and use that to populate a template variable. Goodbye, nice one liner, and hello spaghetti, but it does work.