### PR TITLE
Add details and process for compensation for user research participants

### DIFF
--- a/handbook/product/design/research/index.md
+++ b/handbook/product/design/research/index.md
@@ -20,3 +20,7 @@ We've found that moderated user research goes more smoothly, and is more approac
 
 - [So you’re about to participate in user testing](../../user_research/user_research_participant.md)
 - [So you’re about to help us with user testing](../../user_research/user_research_observer.md)
+
+## Compensation for user research participants
+
+When it's the right choice to provide compensation for user research participants, we have an [established process you can bring into your research activity](../../user_research/user_research_compensation.md).

--- a/handbook/product/user_research/index.md
+++ b/handbook/product/user_research/index.md
@@ -2,3 +2,4 @@
 
 - [So you’re about to participate in user testing](user_research_participant.md)
 - [So you’re about to help us with user testing](user_research_observer.md)
+- [Compensation for user research participants](user_research_compensation.md)

--- a/handbook/product/user_research/user_research_compensation.md
+++ b/handbook/product/user_research/user_research_compensation.md
@@ -1,0 +1,34 @@
+# Compensation for user research participants
+
+We use a [variety of research methods](../design/research/index.md) to help us learn about our customers, test our ideas, and improve our products.
+
+Often, our customers or users are happy to help us out to make their experience with Sourcegraph better. Other times, we do research through usertesting.com, which recruits and compensates participants automatically without our involvement.
+
+However, there are times when it makes sense to compensate research participants for their time and involvement in our research activities. We have three ways of providing compensation to user research participants:
+
+1. **Monetary compensation.** We can provide this option when participants are located in a region where we can pay out through PayPal.
+1. **A voucher for an online store.** We pre-approve vendors before offering it as an option. Note that not all vendors are available in all regions, and it's important that we manage participant's expectations accordingly.
+1. **A donation to a registered non-profit of the participant's choosing.**
+
+## Compensation rate
+
+We have a flat hourly rate of **$60 USD / hour** for compensation in user research. We will always compensate for at least one full hour, even if the research session takes less than the full hour. This simplifies communication, expectations, and our own accounting.
+
+## Process
+
+While planning user research, if you feel it's the right choice to offer compensation for participants, the process is as follows:
+
+1. Identify: How long will each session be? Will the compensation be monetary, voucher-based, or a donation?
+  - It's okay to offer more than one form of compensation as a choice for participants.
+  - In screener surveys, it's a good idea to ask where the participant is based and what form of compensation they prefer.
+1. Share your research plan and expected cost with [Tommy O Donnell](../../company/team/index.md#tommy-o-donnell-he-him) to make sure the research budget is available and approved.
+1. Conduct your research!
+1. After the session, add the session information to the [Sourcegraph User Research Compensation spreadsheet (internal only)](https://docs.google.com/spreadsheets/d/1lQDF8_1XX372FhSE8gsE_XstpGPXrJl5ZhkBanc8dgQ/edit#gid=1160735453). Then, message [Tommy O Donnell](../../company/team/index.md#tommy-o-donnell-he-him) to let him know that new sessions are ready to be compensated.
+  - When the chosen compensation is a donation on the participant's behalf, forward the donation confirmation to the participant when available.
+
+Whoever is the DRI for the research initiative is accountable for making sure the end-to-end compensation process is followed and that the research participants are ultimately compensated.
+
+## Links & resources
+
+- [Sourcegraph User Research Compensation spreadsheet (internal only)](https://docs.google.com/spreadsheets/d/1lQDF8_1XX372FhSE8gsE_XstpGPXrJl5ZhkBanc8dgQ/edit#gid=1160735453)
+- [One-Page Research Plan Template](https://docs.google.com/document/d/1frKMZIT3rPjsvT5w5rkUahR7KiZA8KWTOjAlqIWKnP0/edit#)

--- a/handbook/product/user_research/user_research_compensation.md
+++ b/handbook/product/user_research/user_research_compensation.md
@@ -32,3 +32,4 @@ Whoever is the DRI for the research initiative is accountable for making sure th
 
 - [Sourcegraph User Research Compensation spreadsheet (internal only)](https://docs.google.com/spreadsheets/d/1lQDF8_1XX372FhSE8gsE_XstpGPXrJl5ZhkBanc8dgQ/edit#gid=1160735453)
 - [One-Page Research Plan Template](https://docs.google.com/document/d/1frKMZIT3rPjsvT5w5rkUahR7KiZA8KWTOjAlqIWKnP0/edit#)
+- [RFC 334: Compensation for user research participation](https://docs.google.com/document/d/1-2Mw2rE53Tb9bLaSui9CLMW6IIPaVp5Kt8zXdeVcjrE/edit)

--- a/handbook/product/user_research/user_research_compensation.md
+++ b/handbook/product/user_research/user_research_compensation.md
@@ -21,9 +21,9 @@ While planning user research, if you feel it's the right choice to offer compens
 1. Identify: How long will each session be? Will the compensation be monetary, voucher-based, or a donation?
   - It's okay to offer more than one form of compensation as a choice for participants.
   - In screener surveys, it's a good idea to ask where the participant is based and what form of compensation they prefer.
-1. Share your research plan and expected cost with [Tommy O Donnell](../../company/team/index.md#tommy-o-donnell-he-him) to make sure the research budget is available and approved.
+1. Share your research plan and expected cost with Finance ([finance@sourcegraph.com](mailto:finance@sourcegraph.com)) to make sure the research budget is available and approved.
 1. Conduct your research!
-1. After the session, add the session information to the [Sourcegraph User Research Compensation spreadsheet (internal only)](https://docs.google.com/spreadsheets/d/1lQDF8_1XX372FhSE8gsE_XstpGPXrJl5ZhkBanc8dgQ/edit#gid=1160735453). Then, message [Tommy O Donnell](../../company/team/index.md#tommy-o-donnell-he-him) to let him know that new sessions are ready to be compensated.
+1. After the session, add the session information to the [Sourcegraph User Research Compensation spreadsheet (internal only)](https://docs.google.com/spreadsheets/d/1lQDF8_1XX372FhSE8gsE_XstpGPXrJl5ZhkBanc8dgQ/edit#gid=1160735453). Then, contact Finance ([finance@sourcegraph.com](mailto:finance@sourcegraph.com)) to let him know that new sessions are ready to be compensated.
   - When the chosen compensation is a donation on the participant's behalf, forward the donation confirmation to the participant when available.
 
 Whoever is the DRI for the research initiative is accountable for making sure the end-to-end compensation process is followed and that the research participants are ultimately compensated.


### PR DESCRIPTION
We have an approved and tested process for providing compensation for user research participants in [RFC 334: Compensation for user research participation](https://docs.google.com/document/d/1-2Mw2rE53Tb9bLaSui9CLMW6IIPaVp5Kt8zXdeVcjrE/edit). This new handbook page documents the process for everyone in our source of truth.