### PR TITLE
fix page rendering

### DIFF
--- a/handbook/engineering/deployments/playbooks.md
+++ b/handbook/engineering/deployments/playbooks.md
@@ -159,7 +159,8 @@ For database upgrades or other tasks that might cause some aspects of Sourcegrap
     {
 "dismissible": false,
 "location": "top",
-"message": "🚀 Sourcegraph is undergoing a scheduled upgrade ([what's changed?](https://about.sourcegraph.com/blog/)). You may be unable to perform some write actions during this time, such as updating your user settings."
+"message": "🚀 Sourcegraph is undergoing a scheduled upgrade.
+You may be unable to perform some write actions during this time, such as updating your user settings."
     },
 ]
 ```

--- a/handbook/engineering/deployments/testing.md
+++ b/handbook/engineering/deployments/testing.md
@@ -91,7 +91,8 @@ mkdir generated-cluster
 
 ./overlay-generate-cluster.sh namespaced generated-cluster
 
-gcloud container clusters create "${USER}"-testing --zone us-central1-a --num-nodes 3 --machine-type n1-standard-16 --disk-type pd-ssd --project $PROJECT
+gcloud container clusters create "${USER}"-testing --zone us-central1-a --num-nodes 3 \
+--machine-type n1-standard-16 --disk-type pd-ssd --project $PROJECT
 gcloud container clusters get-credentials "${USER}"-testing --zone us-central1-a --project $PROJECT
 
 kubectl create clusterrolebinding cluster-admin-binding --clusterrole cluster-admin --user $(gcloud config get-value account)
@@ -110,7 +111,8 @@ timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/redis-store
 timeout 5m kubectl -n ns-sourcegraph rollout status -w statefulset/gitserver
 timeout 5m kubectl -n ns-sourcegraph rollout status -w deployment/sourcegraph-frontend
 
-kubectl -n ns-sourcegraph expose deployment sourcegraph-frontend --type=NodePort --name sourcegraph --type=LoadBalancer --port=3080 --target-port=3080
+kubectl -n ns-sourcegraph expose deployment sourcegraph-frontend --type=NodePort \
+--name sourcegraph --type=LoadBalancer --port=3080 --target-port=3080
 
 kubectl -n ns-sourcegraph describe service/sourcegraph
 ```


### PR DESCRIPTION
This stops these two handbook pages being rendered incorrectly. 

I am not sure if this is a recent change that the pages wouldn't grow and accommodate long lines. I'm not familiar enough with the handbook code but this unblocks people needing to use these pages right now. 

Perhaps someone with more experience developing the handbook knows why?