### PR TITLE
Fix wrong JSX syntax in podcast Markdown

### DIFF
--- a/podcast/0.md
+++ b/podcast/0.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/3991271-introducing-the-sourcegraph-podcast.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/3991271-introducing-the-sourcegraph-podcast.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/1.md
+++ b/podcast/1.md
@@ -8,7 +8,9 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/4078679-david-cramer-creator-of-sentry.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/4078679-david-cramer-creator-of-sentry.mp3" controls preload="none"></audio>
+
+<!-- END AUDIO -->
 
 <!-- END AUDIO -->
 

--- a/podcast/10.md
+++ b/podcast/10.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/5162593-matt-holt-creator-of-caddy.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/5162593-matt-holt-creator-of-caddy.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/11.md
+++ b/podcast/11.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/5151244-michael-stapelberg-creator-of-i3-debian-code-search-and-distri.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/5151244-michael-stapelberg-creator-of-i3-debian-code-search-and-distri.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/12.md
+++ b/podcast/12.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/5701504-syrus-akbary.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/5701504-syrus-akbary.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/13.md
+++ b/podcast/13.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/6078358-andrew-gallant-creator-of-ripgrep.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/6078358-andrew-gallant-creator-of-ripgrep.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/14.md
+++ b/podcast/14.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/6096724-jonathan-carter.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/6096724-jonathan-carter.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/15.md
+++ b/podcast/15.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/6266917-peter-pezaris-ceo-of-codestream.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/6266917-peter-pezaris-ceo-of-codestream.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/16.md
+++ b/podcast/16.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/6755608-kelsey-hightower.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/6755608-kelsey-hightower.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/2.1.md
+++ b/podcast/2.1.md
@@ -8,7 +8,7 @@ published: false
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/8674016-developer-onboarding-part-1-ryan-djurovich-devops-manager-xero.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/8674016-developer-onboarding-part-1-ryan-djurovich-devops-manager-xero.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/2.2.md
+++ b/podcast/2.2.md
@@ -8,7 +8,7 @@ published: false
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/8674045-developer-onboarding-part-2-limor-bergman-powertofly-and-digital-ocean.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/8674045-developer-onboarding-part-2-limor-bergman-powertofly-and-digital-ocean.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/2.3.md
+++ b/podcast/2.3.md
@@ -8,7 +8,7 @@ published: false
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/8674049-developer-onboarding-part-3-jean-du-plessis-director-of-engineering-sourcegraph.mp3?download=true" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/8674049-developer-onboarding-part-3-jean-du-plessis-director-of-engineering-sourcegraph.mp3?download=true" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/2.4.md
+++ b/podcast/2.4.md
@@ -8,7 +8,9 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/8953032-devon-zuegel.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/8953032-devon-zuegel.mp3" controls preload="none"></audio>
+
+<!-- END AUDIO -->
 
 <!-- END AUDIO -->
 

--- a/podcast/2.md
+++ b/podcast/2.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/3849032-ryan-djurovich.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/3849032-ryan-djurovich.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/3.1.md
+++ b/podcast/3.1.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/9020726-kirsten-westeinde-shopify.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/9020726-kirsten-westeinde-shopify.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/3.md
+++ b/podcast/3.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/4261673-charity-majors.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/4261673-charity-majors.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/4.md
+++ b/podcast/4.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/4354517-evan-culver-of-segment.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/4354517-evan-culver-of-segment.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/5.md
+++ b/podcast/5.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/4466138-luke-hoban-cto-of-pulumi-co-founder-of-typescript.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/4466138-luke-hoban-cto-of-pulumi-co-founder-of-typescript.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/6.md
+++ b/podcast/6.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/4557812-yves-junqueira-and-john-ewart.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/4557812-yves-junqueira-and-john-ewart.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/7.md
+++ b/podcast/7.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/4648337-dan-bentley-ceo-and-co-founder-of-tilt.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/4648337-dan-bentley-ceo-and-co-founder-of-tilt.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/8.md
+++ b/podcast/8.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/4755524-rijnard-van-tonder-creator-of-comby.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/4755524-rijnard-van-tonder-creator-of-comby.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 

--- a/podcast/9.md
+++ b/podcast/9.md
@@ -8,7 +8,7 @@ published: true
 
 <!-- START AUDIO -->
 
-<audio className="object-center" src="https://www.buzzsprout.com/1097978/5129665-thorsten-klein-creator-of-k3d.mp3" controls={true} preload="none"></audio>
+<audio className="object-center" src="https://www.buzzsprout.com/1097978/5129665-thorsten-klein-creator-of-k3d.mp3" controls preload="none"></audio>
 
 <!-- END AUDIO -->
 


### PR DESCRIPTION
I noticed the `<audio>` elements had an invalid `{true}` syntax for the `controls` attribute. This is the correct syntax for JSX, but the blog posts are Markdown with embedded raw HTML, where the curly braces are invalid (omitting the value sets it to true).

![image](https://user-images.githubusercontent.com/10532611/130216748-96860a78-7639-4d12-a83a-4ac1a5ed891b.png)
