### PR TITLE
Add Frontend Platform meeting guidelines

### DIFF
--- a/handbook/engineering/developer-insights/frontend-platform/index.md
+++ b/handbook/engineering/developer-insights/frontend-platform/index.md
@@ -118,22 +118,6 @@ The team makes use of [tracking issues](../../tracking_issues.md) for tracking p
 
 Specific product feedback about well-defined, small features can be found directly in the backlog boards. More general product feedback that applies to larger features, or that needs more research and planning to be actionable, is kept in [Productboard](https://sourcegraph.productboard.com/feature-board/2330177-web-frontend-platform)
 
-### Retrospectives
-
-Every two weeks, we hold a review/retrospective meeting to reflect on the past two weeks. We use this meeting to:
-
-- Review the previous retro’s action items to ensure they get completed
-- Give _Shoutouts!_ to teammates to show appreciation for something they did that we appreciated
-- Discuss things that went well in the past two weeks and that we should do more of / invest more into it
-- Discuss the things that could have gone better and what we can learn from it to improve
-- Talk about processes that we should revisit/refine/propose to improve our efficiency.
-
-We capture and assign actions to individual teammates. Teammates should consider actions coming out of the retrospective as a very high priority.
-
-Teammates contribute to the retrospective asynchronously during the iteration by adding their thoughts to our [retrospective document](https://docs.google.com/document/d/1SRhrTRJFGAEtTyhOqaO7TxsMQeBgIhUXRCDOEcv1EB8/edit). Teammates are highly encouraged to comment on points raised before the sync meeting in the document.
-
-We rotate who leads the retrospective to allow all teammates an opportunity to lead the session. Teammates can find the rotation schedule at the top of the [retrospective document](https://docs.google.com/document/d/1SRhrTRJFGAEtTyhOqaO7TxsMQeBgIhUXRCDOEcv1EB8/edit).
-
 ### Code reviews
 
 The team follows the [default code review guidelines](https://docs.sourcegraph.com/dev/background-information/code_reviews) with the following addition:
@@ -141,6 +125,39 @@ The team follows the [default code review guidelines](https://docs.sourcegraph.c
 1. If the author would like any of the requested reviewers to merge the PR after approval they add the label `merge-on-any-approve`
 2. If the author would like their PR to be merged once all of the requested reviewers have approved it they add the label `merge-on-all-approve`
 3. When there are only minor issues, reviewers are encouraged to give "approval with comments" and trust their teammates to address the comments without requiring a follow-up review.
+
+### Meetings
+
+We inherit Sourcegraph's [meeting principles](https://about.sourcegraph.com/handbook/communication#internal-meetings) and [asynchronous communication guidelines](https://about.sourcegraph.com/handbook/company/asynchronous-communication#how-to-choose-sync-vs-async) with some modifications that help us run effective meetings:
+
+- Meeting agenda:
+  - The meeting leader prepares the agenda at least 24 hours in advance in a shared Google document.
+  - Participants write down their items at least 12 hours before the meeting. There can always be last-minute additions, but early preparation is encouraged.
+  - If the discussion point is expected to take a considerable amount of time, an estimate in minutes should be added.
+  - Participants ensure that each topic includes important details and relevant references.
+  - Participants review agenda details before the meeting starts.
+  - During the meeting, we follow the agenda and fill in notes along the way.
+- Timing:
+  - The meeting leader always starts discussion on time, even if some participants are late. (And try not to be late.)
+  - The meeting leader ensures that the meeting ends on time (or early).
+- Action items:
+  - We capture and assign action items to individual teammates.
+  - We review action items from the previous meeting to make sure they get completed.
+
+### Retrospectives
+
+Every two weeks, we hold a review/retrospective meeting to reflect on the past two weeks. We use this meeting to:
+
+- Give _Shoutouts!_ to teammates to show appreciation for something they did that we appreciated
+- Discuss things that went well in the past two weeks and that we should do more of / invest more into it
+- Discuss the things that could have gone better and what we can learn from it to improve
+- Talk about processes that we should revisit/refine/propose to improve our efficiency.
+
+Teammates should consider action items coming out of the retrospective as a very high priority.
+
+Teammates contribute to the retrospective asynchronously during the iteration by adding their thoughts to our [retrospective document](https://docs.google.com/document/d/1SRhrTRJFGAEtTyhOqaO7TxsMQeBgIhUXRCDOEcv1EB8/edit).
+
+We rotate who leads the retrospective to allow all teammates an opportunity to lead the session. Teammates can find the rotation schedule at the top of the [retrospective document](https://docs.google.com/document/d/1SRhrTRJFGAEtTyhOqaO7TxsMQeBgIhUXRCDOEcv1EB8/edit).
 
 ### Weekly Sync
 


### PR DESCRIPTION
This PR adds Frontend Platform team meeting guidelines based on our discussion on the last [Frontend Platform sync](https://docs.google.com/document/d/1_wptyMfAjLagJKPjIhPt_miXoEpYuyo_64PBCTTr5h0/edit#heading=h.amx432xet56u).