### PR TITLE
Removing Jira (not used in this way anymore)

### DIFF
--- a/handbook/communication/index.md
+++ b/handbook/communication/index.md
@@ -19,7 +19,6 @@ These places are the source of truth for information at Sourcegraph. Information
 - [productboard](https://sourcegraph.productboard.com/)
 - [HubSpot](https://app.hubspot.com) (only contacts, not companies and deals)
 - [Salesforce](https://sourcegraph2020.lightning.force.com/)
-- [JIRA Service Desk](https://sourcegraph.atlassian.net/jira/servicedesk/projects/SG)
 - [Looker](http://sourcegraph.looker.com/)
 - [Customer legal contracts](https://drive.google.com/drive/folders/1ePvVWcZYdd1_3ZlCP5A0lvMbBhBCVfSm)
 


### PR DESCRIPTION
Removing Jira Service Desk since it is not used for support issues like this. Since we link Zendesk to Salesforce, also not listing Zendesk since it's mirrored in Salesforce and this is an opportunity to simplify