### PR TITLE
Fix syntax highlighting

### DIFF
--- a/_resources/assets/content.css
+++ b/_resources/assets/content.css
@@ -31,128 +31,312 @@ abbr[title] {
     tab-size: 2;
 }
 
-.markdown-body .pl-c {
-    color: #6a737d;
+/* SYNTAX HIGLIGHTING */
+/* Comment */
+.markdown-body .chroma .c {
+    color: #888888;
 }
-
-.markdown-body .pl-c1,
-.markdown-body .pl-s .pl-v {
-    color: #005cc5;
+/* Error */
+.markdown-body .chroma .err {
+    color: #a61717;
+    background-color: #e3d2d2;
 }
-
-.markdown-body .pl-e,
-.markdown-body .pl-en {
-    color: #6f42c1;
-}
-
-.markdown-body .pl-smi,
-.markdown-body .pl-s .pl-s1 {
-    color: #24292e;
-}
-
-.markdown-body .pl-ent {
-    color: #22863a;
-}
-
-.markdown-body .pl-k {
-    color: #d73a49;
-}
-
-.markdown-body .pl-s,
-.markdown-body .pl-pds,
-.markdown-body .pl-s .pl-pse .pl-s1,
-.markdown-body .pl-sr,
-.markdown-body .pl-sr .pl-cce,
-.markdown-body .pl-sr .pl-sre,
-.markdown-body .pl-sr .pl-sra {
-    color: #032f62;
-}
-
-.markdown-body .pl-v,
-.markdown-body .pl-smw {
-    color: #e36209;
-}
-
-.markdown-body .pl-bu {
-    color: #b31d28;
-}
-
-.markdown-body .pl-ii {
-    color: #fafbfc;
-    background-color: #b31d28;
-}
-
-.markdown-body .pl-c2 {
-    color: #fafbfc;
-    background-color: #d73a49;
-}
-
-.markdown-body .pl-c2::before {
-    content: '^M';
-}
-
-.markdown-body .pl-sr .pl-cce {
+/* Keyword */
+.markdown-body .chroma .k {
+    color: #008800;
     font-weight: bold;
-    color: #22863a;
 }
-
-.markdown-body .pl-ml {
-    color: #735c0f;
+/* Comment.Hashbang */
+.markdown-body .chroma .ch {
+    color: #888888;
 }
-
-.markdown-body .pl-mh,
-.markdown-body .pl-mh .pl-en,
-.markdown-body .pl-ms {
+/* Comment.Multiline */
+.markdown-body .chroma .cm {
+    color: #888888;
+}
+/* Comment.Preproc */
+.markdown-body .chroma .cp {
+    color: #cc0000;
     font-weight: bold;
-    color: #005cc5;
 }
-
-.markdown-body .pl-mi {
+/* Comment.PreprocFile */
+.markdown-body .chroma .cpf {
+    color: #888888;
+}
+/* Comment.Single */
+.markdown-body .chroma .c1 {
+    color: #888888;
+}
+/* Comment.Special */
+.markdown-body .chroma .cs {
+    color: #cc0000;
+    font-weight: bold;
+    background-color: #fff0f0;
+}
+/* Generic.Deleted */
+.markdown-body .chroma .gd {
+    color: #000000;
+    background-color: #ffdddd;
+}
+/* Generic.Emph */
+.markdown-body .chroma .ge {
     font-style: italic;
-    color: #24292e;
 }
-
-.markdown-body .pl-mb {
+/* Generic.Error */
+.markdown-body .chroma .gr {
+    color: #aa0000;
+}
+/* Generic.Heading */
+.markdown-body .chroma .gh {
+    color: #333333;
+}
+/* Generic.Inserted */
+.markdown-body .chroma .gi {
+    color: #000000;
+    background-color: #ddffdd;
+}
+/* Generic.Output */
+.markdown-body .chroma .go {
+    color: #888888;
+}
+/* Generic.Prompt */
+.markdown-body .chroma .gp {
+    color: #555555;
+}
+/* Generic.Strong */
+.markdown-body .chroma .gs {
     font-weight: bold;
-    color: #24292e;
 }
-
-.markdown-body .pl-md {
-    color: #b31d28;
-    background-color: #ffeef0;
+/* Generic.Subheading */
+.markdown-body .chroma .gu {
+    color: #666666;
 }
-
-.markdown-body .pl-mi1 {
-    color: #22863a;
-    background-color: #f0fff4;
+/* Generic.Traceback */
+.markdown-body .chroma .gt {
+    color: #aa0000;
 }
-
-.markdown-body .pl-mc {
-    color: #e36209;
-    background-color: #ffebda;
-}
-
-.markdown-body .pl-mi2 {
-    color: #f6f8fa;
-    background-color: #005cc5;
-}
-
-.markdown-body .pl-mdr {
+/* Keyword.Constant */
+.markdown-body .chroma .kc {
+    color: #008800;
     font-weight: bold;
-    color: #6f42c1;
 }
-
-.markdown-body .pl-ba {
-    color: #586069;
+/* Keyword.Declaration */
+.markdown-body .chroma .kd {
+    color: #008800;
+    font-weight: bold;
 }
-
-.markdown-body .pl-sg {
-    color: #959da5;
+/* Keyword.Namespace */
+.markdown-body .chroma .kn {
+    color: #008800;
+    font-weight: bold;
 }
-
-.markdown-body .pl-corl {
-    text-decoration: underline;
-    color: #032f62;
+/* Keyword.Pseudo */
+.markdown-body .chroma .kp {
+    color: #008800;
+}
+/* Keyword.Reserved */
+.markdown-body .chroma .kr {
+    color: #008800;
+    font-weight: bold;
+}
+/* Keyword.Type */
+.markdown-body .chroma .kt {
+    color: #888888;
+    font-weight: bold;
+}
+/* Literal.Number */
+.markdown-body .chroma .m {
+    color: #0000dd;
+    font-weight: bold;
+}
+/* Literal.String */
+.markdown-body .chroma .s {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Name.Attribute */
+.markdown-body .chroma .na {
+    color: #336699;
+}
+/* Name.Builtin */
+.markdown-body .chroma .nb {
+    color: #003388;
+}
+/* Name.Class */
+.markdown-body .chroma .nc {
+    color: #bb0066;
+    font-weight: bold;
+}
+/* Name.Constant */
+.markdown-body .chroma .no {
+    color: #003366;
+    font-weight: bold;
+}
+/* Name.Decorator */
+.markdown-body .chroma .nd {
+    color: #555555;
+}
+/* Name.Exception */
+.markdown-body .chroma .ne {
+    color: #bb0066;
+    font-weight: bold;
+}
+/* Name.Function */
+.markdown-body .chroma .nf {
+    color: #0066bb;
+    font-weight: bold;
+}
+/* Name.Label */
+.markdown-body .chroma .nl {
+    color: #336699;
+    font-style: italic;
+}
+/* Name.Namespace */
+.markdown-body .chroma .nn {
+    color: #bb0066;
+    font-weight: bold;
+}
+/* Name.Property */
+.markdown-body .chroma .py {
+    color: #336699;
+    font-weight: bold;
+}
+/* Name.Tag */
+.markdown-body .chroma .nt {
+    color: #bb0066;
+    font-weight: bold;
+}
+/* Name.Variable */
+.markdown-body .chroma .nv {
+    color: #336699;
+}
+/* Operator.Word */
+.markdown-body .chroma .ow {
+    color: #008800;
+}
+/* Text.Whitespace */
+.markdown-body .chroma .w {
+    color: #bbbbbb;
+}
+/* Literal.Number.Bin */
+.markdown-body .chroma .mb {
+    color: #0000dd;
+    font-weight: bold;
+}
+/* Literal.Number.Float */
+.markdown-body .chroma .mf {
+    color: #0000dd;
+    font-weight: bold;
+}
+/* Literal.Number.Hex */
+.markdown-body .chroma .mh {
+    color: #0000dd;
+    font-weight: bold;
+}
+/* Literal.Number.Integer */
+.markdown-body .chroma .mi {
+    color: #0000dd;
+    font-weight: bold;
+}
+/* Literal.Number.Oct */
+.markdown-body .chroma .mo {
+    color: #0000dd;
+    font-weight: bold;
+}
+/* Literal.String.Affix */
+.markdown-body .chroma .sa {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Literal.String.Backtick */
+.markdown-body .chroma .sb {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Literal.String.Char */
+.markdown-body .chroma .sc {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Literal.String.Delimiter */
+.markdown-body .chroma .dl {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Literal.String.Doc */
+.markdown-body .chroma .sd {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Literal.String.Double */
+.markdown-body .chroma .s2 {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Literal.String.Escape */
+.markdown-body .chroma .se {
+    color: #0044dd;
+    background-color: #fff0f0;
+}
+/* Literal.String.Heredoc */
+.markdown-body .chroma .sh {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Literal.String.Interpol */
+.markdown-body .chroma .si {
+    color: #3333bb;
+    background-color: #fff0f0;
+}
+/* Literal.String.Other */
+.markdown-body .chroma .sx {
+    color: #22bb22;
+    background-color: #f0fff0;
+}
+/* Literal.String.Regex */
+.markdown-body .chroma .sr {
+    color: #008800;
+    background-color: #fff0ff;
+}
+/* Literal.String.Single */
+.markdown-body .chroma .s1 {
+    color: #dd2200;
+    background-color: #fff0f0;
+}
+/* Literal.String.Symbol */
+.markdown-body .chroma .ss {
+    color: #aa6600;
+    background-color: #fff0f0;
+}
+/* Name.Builtin.Pseudo */
+.markdown-body .chroma .bp {
+    color: #003388;
+}
+/* Name.Function.Magic */
+.markdown-body .chroma .fm {
+    color: #0066bb;
+    font-weight: bold;
+}
+/* Name.Variable.Class */
+.markdown-body .chroma .vc {
+    color: #336699;
+}
+/* Name.Variable.Global */
+.markdown-body .chroma .vg {
+    color: #dd7700;
+}
+/* Name.Variable.Instance */
+.markdown-body .chroma .vi {
+    color: #3333bb;
+}
+/* Name.Variable.Magic */
+.markdown-body .chroma .vm {
+    color: #336699;
+}
+/* Literal.Number.Integer.Long */
+.markdown-body .chroma .il {
+    color: #0000dd;
+    font-weight: bold;
 }
 
 .markdown-body .octicon {


### PR DESCRIPTION
Looks like we switched syntax highlighters to chroma at some point without updating the CSS. This is copied from our docs page.