### PR TITLE
Clarify priority blog content

### DIFF
--- a/handbook/marketing/content/editorial.md
+++ b/handbook/marketing/content/editorial.md
@@ -36,9 +36,9 @@ The secondary function of the blog is to grow awareness of Sourcegraph’s brand
 
 ### Priority content
 
-The buckets outlined below are an internal reference.
+The buckets outlined below are an internal reference and guideline. Although there are three buckets here, content we may publish isn't limited to these, and we may publish more of one type of content than others.
 
-1. **Inside Sourcegraph engineering:** How we built X, scaled Y, debugged Z. These are meaty deep dives into the process of building and iterating on Sourcegraph the product and engineering org. Got code snippets? Graphs and charts? Links to PRs? We’ll take them all.
+1. **Inside Sourcegraph engineering:** How we built X, scaled Y, debugged Z. These are meaty deep dives into the process of building and iterating on Sourcegraph the product and engineering org. Got code snippets? Graphs and charts? Links to PRs? We’ll take them all. Even though we may talk about Sourcegraph as part of these stories, the focus is on the technical work behind the product rather than the product itself.
 1. **Tutorials/how tos:** These practical posts show readers how to solve a problem or improve on a skill. Better code reviews, communication and collaboration advice, and productivity tips are examples of topics we might tackle here.
 1. **Customer/user stories:** Stories highlighting cool things our customers and users are doing with or because of Sourcegraph. We’ll collaborate with customer marketing and community on these.
 


### PR DESCRIPTION
Aims to eliminate confusion around the role and execution of the priority buckets of content for the blog. 