### PR TITLE
Update marketing content team

### DIFF
--- a/handbook/marketing/index.md
+++ b/handbook/marketing/index.md
@@ -82,7 +82,8 @@ The table below breaks down the capabilities of each team within Marketing. Once
   - [Erica Lindberg](../company/team/index.md#erica-lindberg-she-her), Director of Content Strategy
     - [Rebecca Dodd](../company/team/index.md#rebecca-dodd-she-her), Senior Managing Editor
     - [Jenny Bergen](../company/team/index.md#jenny-bergen-she-her), Manager, Content Marketing
-    - We will be hiring a Content Editor and Technical Content Marketing Manager
+    - [Scott Bailey](../company/team/index.md#scott-bailey-he-him), Technical Content Marketing Manager
+    - [Nick Moore](../company/team/index.md#nick-moore-he-him-his), Content Editor
   - [Lisa Tagliaferri](../company/team/index.md#lisa-tagliaferri-flexible), Director of Developer Education
     - [Marek Zaluski](../company/team/index.md#marek-zaluski), Developer Education Engineer
     - [Oluebube Princess Egbuna](../company/team/index.md#oluebube-princess-egbuna-she-her), Education Engineer

--- a/handbook/marketing/index.md
+++ b/handbook/marketing/index.md
@@ -78,7 +78,7 @@ The table below breaks down the capabilities of each team within Marketing. Once
 - [Kacie Jenkins](../company/team/index.md#kacie-jenkins-she-her), VP of Marketing
   - [Andy Schumeister](../company/team/index.md#andy-schumeister-he-him), Director of Product Marketing
     - [Alex Isken](../company/team/index.md#alex-isken-he-him), Product Marketing Manager, Emerging Products
-    - Product Marketing Lead, Enterprise - starting in July
+    - [Victoria Yunger](../company/team/index.md#victoria-yunger-she-her), Product Marketing Lead, Enterprise
   - [Erica Lindberg](../company/team/index.md#erica-lindberg-she-her), Director of Content Strategy
     - [Rebecca Dodd](../company/team/index.md#rebecca-dodd-she-her), Senior Managing Editor
     - [Jenny Bergen](../company/team/index.md#jenny-bergen-she-her), Manager, Content Marketing


### PR DESCRIPTION
This PR replaces #4314, which will be closed w/o merge, and restricts itself to only adding new marketing team members. 

The nested spacing issue mentioned in #4314 is an existing, un-fixed issue in the markdown parser (`blackfriday`) used in our handbook. 