### PR TITLE
Add details to editing instructions

### DIFF
--- a/handbook/editing.md
+++ b/handbook/editing.md
@@ -18,6 +18,7 @@ We don't expect everyone on the team to figure this out on their own. Other team
 
 Here's the process for getting a change published to the handbook. For detailed step-by-step instructions (intended for people who are new to Git), see the sections below.
 
+1. Make sure you've been added to [Sourcegraph's Github Org](https://github.com/sourcegraph/about). If you need access, contact Tech Ops in the #it-tech-ops Slack channel.
 1. Propose the edits you want to make by creating a [pull request](https://help.github.com/en/github/collaborating-with-issues-and-pull-requests/about-pull-requests) on the Git repository at [github.com/sourcegraph/about](https://github.com/sourcegraph/about).
    - Because the [handbook is public](usage.md#why-make-this-handbook-public), anyone in the world can see your proposed edits.
 1. Make sure the [handbook checks pass](#handbook-checks).

--- a/handbook/people-ops/onboarding/general_onboarding.md
+++ b/handbook/people-ops/onboarding/general_onboarding.md
@@ -48,10 +48,11 @@ Expensify, Rippling, and Human Interest are managed by our back office, Officeng
 ## Learn how to contribute to the handbook
 
 - [Create an account on GitHub.com](https://github.com/join) if you don't already have one.
-  - Share your username with Inés so she can add you to the Sourcegraph GitHub account and appropriate teams.
+  - Share your username with Inés so she can add you to the Sourcegraph GitHub account and appropriate teams. This step is required to make edits to the Handbook.
 - If you are not familiar with Git, complete the [Git introduction](git_intro.md).
 - Add yourself to the [team page](../../company/team/index.md).
-  - Add a link to your team page bio to your Slack profile
+  - Make sure you've been added to Sourcegraph's github org first!
+  - Add a link to your team page bio to your Slack profile.
 - Read Sourcegraph's [information security policy](https://about.sourcegraph.com/security) and acknowledge your acceptance: https://forms.gle/LUK1YtwAMJLhtRPi6.
 
 ## Learn about Sourcegraph


### PR DESCRIPTION
Born out of this thread: https://sourcegraph.slack.com/archives/CQ44Y7F4G/p1630084531013900

Adding more details/reminders about making sure you're part of Sourcegraph's github org before trying to make changes to the Handbook.