### PR TITLE
Add initiatives page and first project

### DIFF
--- a/handbook/product/index.md
+++ b/handbook/product/index.md
@@ -10,7 +10,7 @@ Product at Sourcegraph consists of [product management](product_management/index
 ## Planning
 
 - [Product team goals](goals.md)
-- [Special Initiatives](initiatives.md)
+- [Special initiatives](initiatives.md)
 - [Roadmap](roadmap.md)
 
 ## Resources

--- a/handbook/product/index.md
+++ b/handbook/product/index.md
@@ -10,6 +10,7 @@ Product at Sourcegraph consists of [product management](product_management/index
 ## Planning
 
 - [Product team goals](goals.md)
+- [Special Initiatives](initiatives.md)
 - [Roadmap](roadmap.md)
 
 ## Resources

--- a/handbook/product/initiatives.md
+++ b/handbook/product/initiatives.md
@@ -19,7 +19,7 @@ Our current [product goals pages](goals.md) are not always up to date so can't b
 
 There are a few other initiatives we will be tracking here soon:
 
-* Public facing roadmap
-* CE / Product communication and prioritization improvements on feedback
-* Consolidation and simplification of tooling
-* Experimentation and improvements to planning
+- Public facing roadmap
+- CE / Product communication and prioritization improvements on feedback
+- Consolidation and simplification of tooling
+- Experimentation and improvements to planning

--- a/handbook/product/initiatives.md
+++ b/handbook/product/initiatives.md
@@ -1,0 +1,10 @@
+# Product Team Initiatives
+
+Occasionally the product team takes on special initiatives that are not strictly tied to product delivery. Those are tracked here.
+
+## Product Led Metrics Refinement
+
+In an effort to gain more clarity around product success and growth on Cloud, we aim to iterate and decide on the current Sourcegraph user metric definitions for On Premise. Aiming for new definition in place in FY21 Q3.
+
+- Owner: Anna (Jason covering during leave)
+- [Working Document](https://docs.google.com/document/d/1o0dLmdRRI6uWIuAg_8VQw25KnTM1CBDKKR2K91SxpAI/edit#)

--- a/handbook/product/initiatives.md
+++ b/handbook/product/initiatives.md
@@ -4,7 +4,7 @@ Occasionally the product team takes on special initiatives that are not strictly
 
 ## Product Led Metrics Refinement
 
-In an effort to gain more clarity around product success and growth on Cloud, we aim to iterate and decide on the current Sourcegraph user metric definitions for On Premise. Aiming for new definition in place in FY21 Q3.
+In an effort to gain more clarity around product success and growth on Cloud, we aim to iterate and decide on the current Sourcegraph user metric definitions for On Premise. Targeting to have the new definition in place in FY21 Q3.
 
 - Owner: Anna (Jason covering during leave)
 - [Working Document](https://docs.google.com/document/d/1o0dLmdRRI6uWIuAg_8VQw25KnTM1CBDKKR2K91SxpAI/edit#)

--- a/handbook/product/initiatives.md
+++ b/handbook/product/initiatives.md
@@ -1,10 +1,25 @@
-# Product Team Initiatives
+# Product team initiatives
 
 Occasionally the product team takes on special initiatives that are not strictly tied to product delivery. Those are tracked here.
 
-## Product Led Metrics Refinement
+## Product led metrics refinement
 
 In an effort to gain more clarity around product success and growth on Cloud, we aim to iterate and decide on the current Sourcegraph user metric definitions for On Premise. Targeting to have the new definition in place in FY21 Q3.
 
 - Owner: Anna (Jason covering during leave)
 - [Working Document](https://docs.google.com/document/d/1o0dLmdRRI6uWIuAg_8VQw25KnTM1CBDKKR2K91SxpAI/edit#)
+
+## Improve process for documentating product strategy
+
+Our current [product goals pages](goals.md) are not always up to date so can't be relied upon by the rest of the organization. They are also mixed in with other engineering team content so it can be hard to find the product direction components. We need to update and organize these pages, and then want to improve this process so that the goals pages are the always updated source of truth.
+
+- Owner: Jason
+
+## Other initiatives
+
+There are a few other initiatives we will be tracking here soon:
+
+* Public facing roadmap
+* CE / Product communication and prioritization improvements on feedback
+* Consolidation and simplification of tooling
+* Experimentation and improvements to planning


### PR DESCRIPTION
This page is intended to track major initiatives within the product area that don't have product features associated with them.

To start I've added the product led metrics refinement project, but I think there are others to add as well.