### PR TITLE
Clarify purpose of the issue templates in the release page

### DIFF
--- a/handbook/engineering/releases/index.md
+++ b/handbook/engineering/releases/index.md
@@ -49,7 +49,7 @@ Release captain responsibilities are currently owned by the [Distribution team](
 ### Release tooling
 
 The [Sourcegraph release tool](../distribution/tools/release.md) is used to generate releases as associated materials (such as tracking issues).
-It leverages the following issue templates:
+It leverages the following issue templates, which list all individual steps that needs to be performed, for each type of release:
 
 - [Release issue template](release_issue_template.md)
 - [Patch release issue template](patch_release_issue_template.md)


### PR DESCRIPTION
I found, while scanning the release page, that it's not easy to understand
as a newcomer where exactly are the individual steps for performing a
release. This change clarifies that by making it explicit that the
issue templates are the ones filling that role.