### PR TITLE
Gently remind authors of stale PRs

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,30 @@
+name: 'Close stale PRs'
+on:
+  schedule:
+    - cron: '30 1 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v4
+        with:
+          days-before-pr-stale: 14
+          days-before-pr-close: 7
+          days-before-issue-close: -1
+          days-before-issue-stale: -1
+          stale-pr-label: stale
+          exempt-pr-labels: bot,blog,pinned
+          stale-pr-message: |
+            Hey there! It looks like this pull request has been sitting for a long time. Keep in mind that when you make a pull request, the change doesn't actually go live until you **merge** the pull request. This needs to be done by you (the pull request author) as soon as you feel like you got the appropriate amount of review/approvals that make you confident with the change. For example: adding yourself to the team page doesn't require anyone's review and you can merge directly, while when proposing a change to your team's processes you'll probably want to get your team's review (and need to request review from your team explicitly, so they get notified).
+
+            Please see whether you want to **merge** this pull request, **close** it and discard the change, or **remind** the people you would like review from.
+
+            You can find more help on our [Editing the handbook](https://about.sourcegraph.com/handbook/editing) handbook page.
+
+            Thank you! \(^-^)/
+          close-pr-message: |
+            Since there were no updates in the past 7 days, this pull request is being automatically closed.
+            If this is a mistake, you can simply click the **Reopen** button to reopen the pull request.
+
+            Thank you! \(^-^)/


### PR DESCRIPTION
So I am normally NOT a fan of stale bot and I would NEVER introduce it to our main code repository for issues.
But hear me out: I think for our handbook repo, it would help a lot of folks.

We have many people joining every month that may have never used a pull request flow before or are not fluent with GitHub's UI and might completely forget to merge their PRs, never noticing their changes never went live. At the moment, we have over 125 pull requests that have been open for over a month.

I think the _perfect_ thing to do about this is whenever a PR has been open for 2 weeks without any review, comment, new commit pushed, etc, to post a friendly comment that reminds the author, which should then be delivered to their email inbox.
If the PR still sits still for another 7 days (no comment, review request, etc) it will be auto-closed. However, it can be easily brought back by reopening the PR if that was a mistake, nothing is _deleted_.

This is applied only to PRs, not issues.