### PR TITLE
Indent teams goals and roadmap per product org

### DIFF
--- a/handbook/product/index.md
+++ b/handbook/product/index.md
@@ -25,16 +25,23 @@ You can reach us at the #product channel or @product-team on Slack. If you have 
 
 Within the product organization, individual product engineering teams set their own goals.
 
-- [Search core and Search product](../engineering/search/goals.md)
-- [Code Intelligence](../engineering/code-intelligence/goals.md)
-- [Batch Changes](../engineering/batch-changes/goals.md)
-- [Frontend Platform](../engineering/developer-insights/frontend-platform/goals.md)
-- [Extensibility](../engineering/developer-insights/extensibility/goals.md)
-- [Code Insights](../engineering/developer-insights/code-insights/goals.md)
-- [API docs](../engineering/developer-insights/api-docs/goals.md)
-- [Security](../engineering/security/goals.md)
-- [Distribution](../engineering/distribution/goals.md)
-- [Core application](../engineering/core-application/goals.md)
+- Code Graph
+  - [Search core and Search product](../engineering/search/goals.md)
+  - [Batch Changes](../engineering/batch-changes/goals.md)
+  - [Code Intelligence](../engineering/code-intelligence/goals.md)
+  - [Code Insights](../engineering/developer-insights/code-insights/goals.md)
+- Enablement
+  - Repository Management
+  - [Distribution](../engineering/distribution/goals.md)
+  - [Frontend Platform](../engineering/developer-insights/frontend-platform/goals.md)
+- Cloud
+  - [Core application](../engineering/core-application/goals.md)
+  - Cloud SaaS
+  - Growth
+    - [API docs](../engineering/developer-insights/api-docs/goals.md)
+  - [Security](../engineering/security/goals.md)
+  - DevOps/SRE
+  - [Extensibility](../engineering/developer-insights/extensibility/goals.md)
 
 ## Product team initiatives
 

--- a/handbook/product/roadmap.md
+++ b/handbook/product/roadmap.md
@@ -12,25 +12,31 @@ NOTE: Dates and timelines below are not considered commitments, these roadmaps a
 	<small>If the roadmaps do not appear, please <a href="https://github.com/sourcegraph/about/issues">report this issue</a> and include the output from your browser's devtools JavaScript console.</small>
 </div>
 
-## [Batch Changes roadmap](../engineering/batch-changes/goals.md#roadmap)
+## Code Graph
 
-## [Core application roadmap](../engineering/core-application/goals.md#roadmap)
+### [Search roadmap](../engineering/search/goals.md#roadmap)
 
-## [Code intel roadmap](../engineering/code-intelligence/goals.md#roadmap)
+### [Batch Changes roadmap](../engineering/batch-changes/goals.md#roadmap)
 
-## [Distribution roadmap](../engineering/distribution/goals.md#roadmap)
+### [Code intel roadmap](../engineering/code-intelligence/goals.md#roadmap)
 
-## [Search roadmap](../engineering/search/goals.md#roadmap)
+### [Code Insights roadmap](../engineering/developer-insights/code-insights/goals.md#roadmap)
 
-## [Security roadmap](../engineering/security/goals.md#roadmap)
+## Enablement
 
-## [Frontend platform roadmap](../engineering/developer-insights/frontend-platform/goals.md#roadmap)
+### [Distribution roadmap](../engineering/distribution/goals.md#roadmap)
 
-## [Extensibility roadmap](../engineering/developer-insights/extensibility/goals.md#roadmap)
+### [Frontend platform roadmap](../engineering/developer-insights/frontend-platform/goals.md#roadmap)
 
-## [Code Insights roadmap](../engineering/developer-insights/code-insights/goals.md#roadmap)
+## Cloud
 
-## [API docs roadmap](../engineering/developer-insights/api-docs/goals.md#roadmap)
+### [Core application roadmap](../engineering/core-application/goals.md#roadmap)
+
+### [API docs roadmap](../engineering/developer-insights/api-docs/goals.md#roadmap)
+
+### [Security roadmap](../engineering/security/goals.md#roadmap)
+
+### [Extensibility roadmap](../engineering/developer-insights/extensibility/goals.md#roadmap)
 
 ---
 


### PR DESCRIPTION
This adds a level of indent per each of the product orgs, helping organize things a bit more logically. It also places them in the same order as listed in the image at https://docs.google.com/document/d/1d8Z8zN6DjKHfXGaCQerKDeJo5qEVxBTku8RcZtw7Di4/edit#heading=h.7ca6yk77z8d6.

Note that some product org were missing on the goals and/or roadmap sections, this does not attempt to address that (I'll mention in the team Slack channel).