### PR TITLE
Update engineering organization in the handbook

### DIFF
--- a/handbook/engineering/eng_org.md
+++ b/handbook/engineering/eng_org.md
@@ -42,88 +42,24 @@ If you are already at Sourcegraph and see a current or future opportunity that y
 
 ## Current organization
 
+_As of 2021-09-13 [we reorganized the product and engineering teams](https://docs.google.com/document/d/1d8Z8zN6DjKHfXGaCQerKDeJo5qEVxBTku8RcZtw7Di4/edit#) (internal document) so some team pages are missing and need to be created. Until the handbook is updated, the source of truth for team assignments and hiring plans are in [this spreadsheet](https://docs.google.com/spreadsheets/d/1CIQYQDN2KFyHMmPEx3FqubapyXyapFp0B_DoDJtWvm8/edit#gid=0)._
+
 - [Nick Snyder](index.md#nick-snyder-he-him), [VP Engineering](../../handbook/engineering/roles.md#vp-engineering) (reports to [Beyang Liu](index.md#beyang-liu), CTO)
-  - Global code graph
+  - Code graph
     - [Search core](../../handbook/engineering/search/core.md)
     - [Search product](../../handbook/engineering/search/product.md)
     - [Code intelligence](../../handbook/engineering/code-intelligence/index.md)
     - [Batch Changes](../../handbook/engineering/batch-changes/index.md)
-  - [Developer Insights](../../handbook/engineering/developer-insights/index.md)
-    - [Frontend platform](../../handbook/engineering/developer-insights/frontend-platform/index.md)
-    - [Extensibility](../../handbook/engineering/developer-insights/extensibility/index.md)
     - [Code insights](../../handbook/engineering/developer-insights/code-insights/index.md)
-    - [API docs](../../handbook/engineering/developer-insights/api-docs/index.md)
-  - Platform and infrastructure
+  - Enablement
+    - Repository management
+    - Delivery
+    - Developer experience
+    - [Frontend platform](../../handbook/engineering/developer-insights/frontend-platform/index.md)
+  - Cloud
+    - Growth (includes [API docs](../../handbook/engineering/developer-insights/api-docs/index.md)
     - [Security](../../handbook/engineering/security/index.md)
-    - [Distribution](../../handbook/engineering/distribution/index.md)
-    - [Core application](../../handbook/engineering/core-application/index.md)
-
-## Planned organization
-
-This is the current plan for our engineering organization and growth.
-
-Plans can change given new information!
-
-- [Nick Snyder](../company/team/index.md#nick-snyder-he-him), [VP Engineering](roles.md#vp-engineering) (reports to [Beyang Liu](index.md#beyang-liu), CTO)
-  - Global code graph {#global-code-graph}
-    - [Yink Teo](../company/team/index.md#yink-teo-he-him) ([Director of Engineering](roles.md#director-of-engineering))
-    - [Search core](search/core.md)
-      - [Team: Search core](search/core.md#search-core-eng)
-    - [Search product](search/product.md)
-      - [Team: Search product](search/product.md#search-product-eng)
-    - [Code intelligence](code-intelligence/index.md)
-      - [Team: Code intelligence](code-intelligence/index.md#code-intelligence-eng)
-    - [Batch Changes](batch-changes/index.md)
-      - [Team: Batch Changes](batch-changes/index.md#batch-changes-eng)
-  - Developer Insights {#developer-insights}
-    - [Jean du Plessis](../company/team/index.md#jean-du-plessis-he-him) ([Director of Engineering](roles.md#director-of-engineering))
-    - [Code insights](developer-insights/code-insights/index.md)
-      - [Team: Code insights](developer-insights/code-insights/index.md#code-insights-eng)
-    - [Extensibility](developer-insights/extensibility/index.md)
-      - [Team: Extensibility](developer-insights/extensibility/index.md#extensibility-eng)
-    - [Frontend platform](developer-insights/frontend-platform/index.md)
-      - [Team: Frontend platform](developer-insights/frontend-platform/index.md#frontend-platform-eng)
-    - [API docs](developer-insights/api-docs/index.md)
-      - [Team: API docs](developer-insights/api-docs/index.md#api-docs-eng)
-  - Platform and infrastructure {#platform-and-infrastructure}
-    - [Bill Creager](../company/team/index.md#bill-creager) ([Director of Engineering](roles.md#director-of-engineering))
-    - [Security](security/index.md)
-      - [Team: Security](security/index.md#security-eng)
-    - [Distribution](distribution/index.md)
-      - [Team: Distribution](distribution/index.md#distribution-eng)
-    - [Core application](core-application/index.md)
-      - [Team: Core application](core-application/index.md#core-application-eng)
+    - DevOps
+    - Cloud SaaS
 
 [VP Eng team docs](vpe/index.md).
-
-<script>
-// This script injects the org chart content into each section of this page that links to a team page.
-// It is similar to the script used to compile the goals in ../goals/index.md.
-
-async function getPageOrgList(pageUrl) {
-	const sectionId = pageUrl.replace(/^.*#/, '')
-
-	const resp = await fetch(pageUrl)
-	const doc = new DOMParser().parseFromString(await resp.text(), "text/html")
-	const section = doc.getElementById(sectionId)
-	if (!section) {
-		const error = document.createElement('p')
-		error.innerText = `Error generating org chart: page at ${pageUrl} has no section with ID ${sectionId}.`
-		return error
-	}
-    return section.parentNode
-}
-
-const teamAnchors = Array.from(document.querySelectorAll('a')).filter(a => a.innerText.startsWith('Team: '))
-Promise.all(
-	teamAnchors.map(async a => ({
-		anchor: a,
-		content: await getPageOrgList(a.href),
-	}))
-).then(data => {
-	for (const {anchor, content} of data) {
-        // Replace the parent node list item
-        anchor.parentNode.replaceWith(content)
-	}
-})
-</script>


### PR DESCRIPTION
As of 2021-09-13 [we reorganized the product and engineering teams](https://docs.google.com/document/d/1d8Z8zN6DjKHfXGaCQerKDeJo5qEVxBTku8RcZtw7Di4/edit#) (internal document) so some team pages are missing and need to be created. Until the handbook is updated, the source of truth for team assignments and hiring plans are in [this spreadsheet](https://docs.google.com/spreadsheets/d/1CIQYQDN2KFyHMmPEx3FqubapyXyapFp0B_DoDJtWvm8/edit#gid=0) (internal document).

This removes the autogenerated chart because:
1. There is no way to make that accurate without me changing all the team pages (I want to distribute this work)
2. It was annoying that it was frequently slow to load
3. It was brittle because anchors it depended on kept getting removed
4. Current SoT is the spreadsheet, so want to delete inaccurate info.

We can decide to add it back after the handbook is updated if we want, or we can consider other solutions moving forward.