### PR TITLE
Link to sourcegraph search to see whats new in handbook

### DIFF
--- a/handbook/index.md
+++ b/handbook/index.md
@@ -7,6 +7,7 @@ The handbook is a living document and we expect every teammate to propose improv
 - [Editing the handbook](editing.md)
 - [Handbook usage](usage.md)
 - [Handbook feedback](https://docs.google.com/forms/d/e/1FAIpQLSfb0yU9xmnvK2namuUzUEKbB9IqZlNQF2IWw0OpLsGvBiW2oQ/viewform?usp=sf_link)
+- [What's new in the handbook](https://sourcegraph.com/github.com/sourcegraph/about/-/commits)
 
 ## [Company](company/index.md)
 


### PR DESCRIPTION
https://sourcegraph.com/github.com/sourcegraph/about/-/commits is a handy way to see what's new in the handbook, almost as nice as a changelog. This links to it from the home page to make it more discoverable.