### PR TITLE
Add prettier-ignore to deep-nested lists

### DIFF
--- a/handbook/company/goals/2022_q3.md
+++ b/handbook/company/goals/2022_q3.md
@@ -4,87 +4,93 @@
 
 ## Company
 
+<!-- Our markdown renderer is not spec-compliant and needs 4 spaces of indentation for nested lists, therefor we need to prettier-ignore. -->
+<!-- prettier-ignore -->
 1. **Bring code search to the largest enterprises (5k+ user, multi-business unit, global)**
 
-   **WHY:** Moving this to the top because it needs more priority than it has gotten in the past. Otherwise, this is the same as last quarter.
+    **WHY:** Moving this to the top because it needs more priority than it has gotten in the past. Otherwise, this is the same as last quarter.
 
-   - KR: [_N<sub>0</sub>_][n0] IARR ([_N<sub>1</sub>_][n1] Stretch)
-   - KR: Land [_N<sub>2</sub>_][n2] Large Enterprise Logos ([_N<sub>3</sub>_][n3])
-   - KR: Advance [_N<sub>4</sub>_][n4] Large Enterprise Opportunities to Stage 4+ with FY22 Close Date (including prepping [_N<sub>5</sub>_][n5] to close in Q4)
-   - KR: Generate [_N<sub>6</sub>_][n6] new business Sales Accepted Opportunities among our target accounts
+    - KR: [_N<sub>0</sub>_][n0] IARR ([_N<sub>1</sub>_][n1] Stretch)
+    - KR: Land [_N<sub>2</sub>_][n2] Large Enterprise Logos ([_N<sub>3</sub>_][n3])
+    - KR: Advance [_N<sub>4</sub>_][n4] Large Enterprise Opportunities to Stage 4+ with FY22 Close Date (including prepping [_N<sub>5</sub>_][n5] to close in Q4)
+    - KR: Generate [_N<sub>6</sub>_][n6] new business Sales Accepted Opportunities among our target accounts
 
 1. **Get on a path of regular growth of new devs using Sourcegraph**
 
-   **WHY:** Instead of the overly broad "win every dev" wording from last quarter, this focuses on what we can do this quarter. We want to see regular growth of usage (both Sourcegraph.com usage and new self-hosted instances), because right now it's stagnant, and (in hindsight) we're too heavily invested in big, long-term projects to improve that and not enough in shorter iteration cycle projects that we can learn from and see results from sooner.
+    **WHY:** Instead of the overly broad "win every dev" wording from last quarter, this focuses on what we can do this quarter. We want to see regular growth of usage (both Sourcegraph.com usage and new self-hosted instances), because right now it's stagnant, and (in hindsight) we're too heavily invested in big, long-term projects to improve that and not enough in shorter iteration cycle projects that we can learn from and see results from sooner.
 
-   - KR: Maximize overall monthly unique visitors to sourcegraph.com and about.sourcegraph.com
-   - KR: Maximize monthly community engagement and reach
-   - KR: Maximize monthly /search visits
-   - KR: 2x cloud weekly activation rate to [_N<sub>7</sub>_][n7]
-   - KR: 2x cloud weekly retention rate to [_N<sub>8</sub>_][n8]
+    - KR: Maximize overall monthly unique visitors to sourcegraph.com and about.sourcegraph.com
+    - KR: Maximize monthly community engagement and reach
+    - KR: Maximize monthly /search visits
+    - KR: 2x cloud weekly activation rate to [_N<sub>7</sub>_][n7]
+    - KR: 2x cloud weekly retention rate to [_N<sub>8</sub>_][n8]
 
 1. **Promote an async company culture**
 
-   **WHY:** See [Raising a tension: Balancing asynchronous and synchronous communication](https://docs.google.com/document/d/1kdrLECKYuDoLUnnbEN3bin3TX8MqgYVRtFxMHahVBqU/edit)
+    **WHY:** See [Raising a tension: Balancing asynchronous and synchronous communication](https://docs.google.com/document/d/1kdrLECKYuDoLUnnbEN3bin3TX8MqgYVRtFxMHahVBqU/edit)
 
-   - KR: Average score of 4+ ("Strongly agree" = 5, "Agree" = 4) on team survey at end of quarter, with targeted questions for async culture. (Do mid-quarter survey as well to get the pulse.)
+    - KR: Average score of 4+ ("Strongly agree" = 5, "Agree" = 4) on team survey at end of quarter, with targeted questions for async culture. (Do mid-quarter survey as well to get the pulse.)
 
 ## Talent
 
 **WHY:** Our teammates are our greatest asset, and to achieve our company goals, we need to continue to attract and hire incredible people. The Talent team’s focus in Q3 will be all about recruitment efficiency, while never losing sight on providing the best interview experience our candidates have ever had.
 
+<!-- Our markdown renderer is not spec-compliant and needs 4 spaces of indentation for nested lists, therefor we need to prettier-ignore. -->
+<!-- prettier-ignore -->
 1. **Enhance recruitment branding efforts to attract talent globally.**
 
-   **WHY:** We can’t achieve our company goals without continuing to attract and hire great people. We need to increase our recruitment branding efforts to ensure we’re a known entity to incredible talent who will help us achieve our mission.
+    **WHY:** We can’t achieve our company goals without continuing to attract and hire great people. We need to increase our recruitment branding efforts to ensure we’re a known entity to incredible talent who will help us achieve our mission.
 
-   - KR: Enhance partnerships with Blind, LinkedIn, Glassdoor, Hacker News, AngelList, Women Who Code, and Great Place to Work to increase brand awareness, resulting in increased candidate pipeline.
-   - KR: Publish 2 articles focused on talent/culture at Sourcegraph (in partnership with Marketing).
-   - KR: Design and roll out new careers page (in partnership with Marketing).
-   - KR: Establish a referral program: for every referred candidate hired, we will sponsor a scholarship (school/organization TBD) to help make a world in which everyone can code.
+    - KR: Enhance partnerships with Blind, LinkedIn, Glassdoor, Hacker News, AngelList, Women Who Code, and Great Place to Work to increase brand awareness, resulting in increased candidate pipeline.
+    - KR: Publish 2 articles focused on talent/culture at Sourcegraph (in partnership with Marketing).
+    - KR: Design and roll out new careers page (in partnership with Marketing).
+    - KR: Establish a referral program: for every referred candidate hired, we will sponsor a scholarship (school/organization TBD) to help make a world in which everyone can code.
 
 1. **Build the operational foundation to help our team scale.**
 
-   **WHY:** Hiring is a company-wide effort, and we need to ensure that every teammate has the training, tools, and structure in place to help make strong hiring decisions.
+    **WHY:** Hiring is a company-wide effort, and we need to ensure that every teammate has the training, tools, and structure in place to help make strong hiring decisions.
 
-   - KR: Identify & roll out automated headcount tracking software/tool that reflects real-time staffed-to-plan % and is adjustable as needs to business change (in partnership with Finance/BizOps/TechOps).
-   - KR: 100% of roles have a structured interview plan that is built out in Greenhouse.
-   - KR: Automate interview training and ensure that 100% of teammates have gone through interview training by the end of Q3.
+    - KR: Identify & roll out automated headcount tracking software/tool that reflects real-time staffed-to-plan % and is adjustable as needs to business change (in partnership with Finance/BizOps/TechOps).
+    - KR: 100% of roles have a structured interview plan that is built out in Greenhouse.
+    - KR: Automate interview training and ensure that 100% of teammates have gone through interview training by the end of Q3.
 
 1. **Execute on hiring plans that are responsive to teams' needs, while providing an excellent candidate experience.**
 
-   **WHY:** Simply put, we need to meet the hiring needs of the business, all while providing a great candidate experience. This means that candidates move quickly through our process, and they walk away saying that this was the best interview experience they’ve ever had, regardless of outcome.
+    **WHY:** Simply put, we need to meet the hiring needs of the business, all while providing a great candidate experience. This means that candidates move quickly through our process, and they walk away saying that this was the best interview experience they’ve ever had, regardless of outcome.
 
-   - KR: Final Q3 hiring is 85%+ of the plan.
-   - KR: Average time-to-fill (from date the job is opened to date the offer is accepted) is ≤45 days.
-   - KR: Provide a strong candidate experience, as indicated by an average score of 4+ ("Strongly agree" =5, "Agree" = 4) in our candidate experience survey.
+    - KR: Final Q3 hiring is 85%+ of the plan.
+    - KR: Average time-to-fill (from date the job is opened to date the offer is accepted) is ≤45 days.
+    - KR: Provide a strong candidate experience, as indicated by an average score of 4+ ("Strongly agree" =5, "Agree" = 4) in our candidate experience survey.
 
 ## Sales
 
+<!-- Our markdown renderer is not spec-compliant and needs 4 spaces of indentation for nested lists, therefor we need to prettier-ignore. -->
+<!-- prettier-ignore -->
 1. **Make Sourcegraph valuable and accessible to every company**
 
-   **WHY:** [_N<sub>11</sub>_][n11]
+    **WHY:** [_N<sub>11</sub>_][n11]
 
-   - KR: [_N<sub>0</sub>_][n0] IARR ([_N<sub>1</sub>_][n1] Stretch)
-   - KR: Secure 100% of Logos for Q3 Renewals (including [_N<sub>9</sub>_][n9])
+    - KR: [_N<sub>0</sub>_][n0] IARR ([_N<sub>1</sub>_][n1] Stretch)
+    - KR: Secure 100% of Logos for Q3 Renewals (including [_N<sub>9</sub>_][n9])
 
 1. **Solve Big Code problems for the largest enterprises (5k+ user, multi-business unit, global)**
 
-   **WHY:** [_N<sub>12</sub>_][n12]
+    **WHY:** [_N<sub>12</sub>_][n12]
 
-   - KR: Land [_N<sub>2</sub>_][n2] Large Enterprise Logos ([_N<sub>3</sub>_][n3])
-   - KR: Advance [_N<sub>4</sub>_][n4] Large Enterprise Opportunities to Stage 4+ with FY22 Close Date (including prepping [_N<sub>5</sub>_][n5] to close in Q4)
+    - KR: Land [_N<sub>2</sub>_][n2] Large Enterprise Logos ([_N<sub>3</sub>_][n3])
+    - KR: Advance [_N<sub>4</sub>_][n4] Large Enterprise Opportunities to Stage 4+ with FY22 Close Date (including prepping [_N<sub>5</sub>_][n5] to close in Q4)
 
 1. **Build a company that thrives amid rapid growth**
 
-   **WHY:** Creating a new category is hard. It requires you to convince someone that they need a solution that they didn’t know existed to a problem they’ve long accepted as a cost of doing business. Our Know Thy Dev program aims to provide the education, training, and resources needed to truly understand our customers and effectively communicate the value of Sourcegraph to them.
+    **WHY:** Creating a new category is hard. It requires you to convince someone that they need a solution that they didn’t know existed to a problem they’ve long accepted as a cost of doing business. Our Know Thy Dev program aims to provide the education, training, and resources needed to truly understand our customers and effectively communicate the value of Sourcegraph to them.
 
-   - KR: Our sales team is actively putting into practice learnings from our Know Thy Dev enablement program
+    - KR: Our sales team is actively putting into practice learnings from our Know Thy Dev enablement program
 
 1. **Establish a repeatable, scalable pipeline generation motion**
 
-   **WHY:** Our past pipeline KRs have been too broad and our plan for Q3 is to set a more focused KR for our sales and marketing teams. As such, we’ve established a shared KR that puts the focus of our outbound efforts on a specific list of [_N<sub>13</sub>_][n13] Target Accounts.
+    **WHY:** Our past pipeline KRs have been too broad and our plan for Q3 is to set a more focused KR for our sales and marketing teams. As such, we’ve established a shared KR that puts the focus of our outbound efforts on a specific list of [_N<sub>13</sub>_][n13] Target Accounts.
 
-   - KR: Generate [_N<sub>6</sub>_][n6] New Business SAOs among our target accounts
+    - KR: Generate [_N<sub>6</sub>_][n6] New Business SAOs among our target accounts
 
 ## Customer Engineering
 
@@ -104,31 +110,33 @@
 
 [FY22 Q3: Product / Engineering 1 pager](https://docs.google.com/document/d/1iX7ytN8FztLXjl830XtNlI0KxfxFYFSOUUjtgSnmOPA/edit#) contains full context of our planning and links to each product/eng team’s individual 1 pagers.
 
+<!-- Our markdown renderer is not spec-compliant and needs 4 spaces of indentation for nested lists, therefor we need to prettier-ignore. -->
+<!-- prettier-ignore -->
 1. **OBJECTIVE: Make cloud and enterprise successful at a massive scale**
 
-   **WHY:** To build code search that is valuable to every developer, we need Sourcegraph to work well at the largest enterprises, and we need Sourcegraph to work well over all of the open source code on GitHub.com and GitLab.com (5.5M repos). Scaling to both of these use cases is complementary because Sourcegraph Cloud is simply the largest deployment of Sourcegraph and it helps us validate our ability to scale to future large enterprises. We’re measuring our enterprise success based on our ability to satisfy the needs of a small number of strategic accounts in Q3. These strategic accounts are both essential to achieve our revenue goals this year, and also these customers have needs that are representative of large enterprises that we want to be able to win in the future.
+    **WHY:** To build code search that is valuable to every developer, we need Sourcegraph to work well at the largest enterprises, and we need Sourcegraph to work well over all of the open source code on GitHub.com and GitLab.com (5.5M repos). Scaling to both of these use cases is complementary because Sourcegraph Cloud is simply the largest deployment of Sourcegraph and it helps us validate our ability to scale to future large enterprises. We’re measuring our enterprise success based on our ability to satisfy the needs of a small number of strategic accounts in Q3. These strategic accounts are both essential to achieve our revenue goals this year, and also these customers have needs that are representative of large enterprises that we want to be able to win in the future.
 
-   - KR: Sourcegraph Cloud provides fast and relevant search results over 5.5M repos.
-   - KR: Resolve technical deal blockers with [_N<sub>10</sub>_][n10].
-   - KR: Maintain 100% support issue resolution within 7 days while only requiring help (filing a #rfh GitHub issue) on 10% (measured weekly looking at last 30 days). Plan details can be found [here](https://about.sourcegraph.com/handbook/support/FY22Q3-OKR-Plan)
+    - KR: Sourcegraph Cloud provides fast and relevant search results over 5.5M repos.
+    - KR: Resolve technical deal blockers with [_N<sub>10</sub>_][n10].
+    - KR: Maintain 100% support issue resolution within 7 days while only requiring help (filing a #rfh GitHub issue) on 10% (measured weekly looking at last 30 days). Plan details can be found [here](https://about.sourcegraph.com/handbook/support/FY22Q3-OKR-Plan)
 
 1. **OBJECTIVE: Build a delightful personalized product that devs love**
 
-   **WHY:** Fundamentally, we need to build a product that developers love to use, and that uniquely improves their development workflows. As we begin to understand the customer journey and usage funnel, product and engineering need to ensure that we don’t have a leaky funnel as more folks come to Sourcegraph Cloud. Marketing will be responsible for new visitors (acquisition), and Product and Engineering need to make sure we’re successfully pulling those visitors into the product. New users who come to Sourcegraph should understand the value of code search (activation) and learn how to integrate it into their workflows (retention). These two metrics help us more effectively focus on growth and awareness of Sourcegraph.
+    **WHY:** Fundamentally, we need to build a product that developers love to use, and that uniquely improves their development workflows. As we begin to understand the customer journey and usage funnel, product and engineering need to ensure that we don’t have a leaky funnel as more folks come to Sourcegraph Cloud. Marketing will be responsible for new visitors (acquisition), and Product and Engineering need to make sure we’re successfully pulling those visitors into the product. New users who come to Sourcegraph should understand the value of code search (activation) and learn how to integrate it into their workflows (retention). These two metrics help us more effectively focus on growth and awareness of Sourcegraph.
 
-   In addition, we want to build a group of small and medium sized organizations or teams who are using and loving Sourcegraph Cloud. This is the next step in the journey towards having self-service customers on Sourcegraph Cloud, and we need to continue the momentum we have built with private code for individuals.
+    In addition, we want to build a group of small and medium sized organizations or teams who are using and loving Sourcegraph Cloud. This is the next step in the journey towards having self-service customers on Sourcegraph Cloud, and we need to continue the momentum we have built with private code for individuals.
 
-   - KR: 2x [cloud weekly activation rate](https://analytics.amplitude.com/sourcegraph/chart/cpc9d6i/edit/wcnnorp) to [_N<sub>7</sub>_][n7]
-   - KR: 2x [cloud weekly retention rate](https://analytics.amplitude.com/sourcegraph/chart/f3uzrwi/edit/tgsk1bq) to [_N<sub>8</sub>_][n8]
+    - KR: 2x [cloud weekly activation rate](https://analytics.amplitude.com/sourcegraph/chart/cpc9d6i/edit/wcnnorp) to [_N<sub>7</sub>_][n7]
+    - KR: 2x [cloud weekly retention rate](https://analytics.amplitude.com/sourcegraph/chart/f3uzrwi/edit/tgsk1bq) to [_N<sub>8</sub>_][n8]
 
 1. **OBJECTIVE: Happy, effective, async team**
 
-   **WHY:** Our ability to succeed and grow as a business is dependent on having teams that are happy, effective, and thriving. We don’t believe there is one succinct way to measure success on this dimension, but we do expect to be able to point to a range of both quantitative and qualitative evidence to evaluate whether we’re on the right track.
+    **WHY:** Our ability to succeed and grow as a business is dependent on having teams that are happy, effective, and thriving. We don’t believe there is one succinct way to measure success on this dimension, but we do expect to be able to point to a range of both quantitative and qualitative evidence to evaluate whether we’re on the right track.
 
-   The specific areas we think are important to focus on are improving teammate onboarding, establishing KPIs to enable teams to be more async/autonomous, and investing in our technical architecture + operational infrastructure so we are able to sustainably support Sourcegraph Cloud.
+    The specific areas we think are important to focus on are improving teammate onboarding, establishing KPIs to enable teams to be more async/autonomous, and investing in our technical architecture + operational infrastructure so we are able to sustainably support Sourcegraph Cloud.
 
-   - KR: Evidence that the team is happy and thriving, such as successfully onboarding new teammates, happiness survey, low attrition, experimentation (examples: sg tool, fuzzy file finding, search notebooks). [Dev happiness log](https://docs.google.com/document/u/0/d/1mEn35gCQfKTf9T5QcIYtw1urqvyW1O9AzGty2ct1v20/edit)
-   - KR: Each team has documented KPIs in the handbook, and a metrics dashboard that tracks those KPIs.
+    - KR: Evidence that the team is happy and thriving, such as successfully onboarding new teammates, happiness survey, low attrition, experimentation (examples: sg tool, fuzzy file finding, search notebooks). [Dev happiness log](https://docs.google.com/document/u/0/d/1mEn35gCQfKTf9T5QcIYtw1urqvyW1O9AzGty2ct1v20/edit)
+    - KR: Each team has documented KPIs in the handbook, and a metrics dashboard that tracks those KPIs.
 
 ## Marketing
 
@@ -200,6 +208,8 @@ Lastly, to support the unconscious bias training launched by the Talent team in 
 
 - Be providing training to managers on how to build and maintain inclusive teams in Q3
 - Updating our handbook with more initiatives aimed at enhancing inclusivity and diversity in our teams, which will include the career leveling OKR (which aims to promote equity around how the impact of all team members is assessed) and Modern Health (which provides access to various support groups (COVID-19, LQBTQ+, Black Lives Matter, Asian communities, Latinx communities) plus guidance on how Sourcegraph teammates can support each other and escalate insights and ideas that are aligned with our values and will have a positive impact on the bigger company, to us for consideration.
+
+<!-- prettier-ignore-end -->
 
 [n0]: https://docs.google.com/document/d/1CTU1f1miFDhzdQOGMicK243dokePzVGiXR5TEynLyc8/edit#bookmark=id.jn5pj7wn62uo
 [n1]: https://docs.google.com/document/d/1CTU1f1miFDhzdQOGMicK243dokePzVGiXR5TEynLyc8/edit#bookmark=id.v0yxg7tx4azm

--- a/handbook/engineering/eng_org.md
+++ b/handbook/engineering/eng_org.md
@@ -6,6 +6,7 @@ This page documents our current/planned engineering org structure. Plans can cha
 
 As of 2021-09-13 [we reorganized the product and engineering teams](https://docs.google.com/document/d/1d8Z8zN6DjKHfXGaCQerKDeJo5qEVxBTku8RcZtw7Di4/edit#) (internal document) so some team pages are missing and need to be created. Until the handbook is updated, the source of truth for team assignments and hiring plans are in [this spreadsheet](https://docs.google.com/spreadsheets/d/1CIQYQDN2KFyHMmPEx3FqubapyXyapFp0B_DoDJtWvm8/edit#gid=0).
 
+<!-- Our markdown renderer is not spec-compliant and needs 4 spaces of indentation for nested lists, therefor we need to prettier-ignore. -->
 <!-- prettier-ignore -->
 - [Nick Snyder](index.md#nick-snyder-he-him), [VP Engineering](../../handbook/engineering/roles.md#vp-engineering) (reports to [Beyang Liu](index.md#beyang-liu), CTO)
   - [Code graph](./code-graph/index.md)

--- a/handbook/index.md
+++ b/handbook/index.md
@@ -43,23 +43,25 @@ The handbook is a living document and we expect every teammate to propose improv
 
 <!-- When updating the engineering team list below, please also update engineering/eng_org.md -->
 
+<!-- Our markdown renderer is not spec-compliant and needs 4 spaces of indentation for nested lists, therefor we need to prettier-ignore. -->
+<!-- prettier-ignore -->
 - [Engineering](./engineering/index.md)
-  - [Code graph](./engineering/code-graph/index.md)
-    - [Search core](./engineering/code-graph/search/core.md)
-    - [Search product](./engineering/code-graph/search/product.md)
-    - [Code intelligence](./engineering/code-graph/code-intelligence/index.md)
-    - [Batch Changes](./engineering/code-graph/batch-changes/index.md)
-    - [Code insights](./engineering/code-graph/code-insights/index.md)
-  - Enablement
-    - Repository management
-    - Delivery
-    - Developer experience
-    - [Frontend platform](./engineering/enablement/frontend-platform/index.md)
-  - Cloud
-    - [Growth](./engineering/cloud/growth/index.md) (includes API docs)
-    - [Security](./engineering/cloud/security/index.md)
-    - [DevOps](./engineering/cloud/devops/index.md)
-    - [SaaS](./engineering/cloud/saas/index.md)
+    - [Code graph](./engineering/code-graph/index.md)
+      - [Search core](./engineering/code-graph/search/core.md)
+      - [Search product](./engineering/code-graph/search/product.md)
+      - [Code intelligence](./engineering/code-graph/code-intelligence/index.md)
+      - [Batch Changes](./engineering/code-graph/batch-changes/index.md)
+      - [Code insights](./engineering/code-graph/code-insights/index.md)
+    - Enablement
+      - Repository management
+      - Delivery
+      - Developer experience
+      - [Frontend platform](./engineering/enablement/frontend-platform/index.md)
+    - Cloud
+      - [Growth](./engineering/cloud/growth/index.md) (includes API docs)
+      - [Security](./engineering/cloud/security/index.md)
+      - [DevOps](./engineering/cloud/devops/index.md)
+      - [SaaS](./engineering/cloud/saas/index.md)
 
 ### [Customer Support](support/index.md)
 

--- a/handbook/marketing/index.md
+++ b/handbook/marketing/index.md
@@ -76,6 +76,7 @@ The table below breaks down the capabilities of each team within Marketing. Once
 
 ## Members
 
+<!-- Our markdown renderer is not spec-compliant and needs 4 spaces of indentation for nested lists, therefor we need to prettier-ignore. -->
 <!-- prettier-ignore -->
 - [Kacie Jenkins](../company/team/index.md#kacie-jenkins-she-her), VP of Marketing
     - [Andy Schumeister](../company/team/index.md#andy-schumeister-he-him), Director of Product Marketing

--- a/handbook/sales/sdrteam.md
+++ b/handbook/sales/sdrteam.md
@@ -4,18 +4,20 @@ The SDR Team (TBA)
 
 ## Members
 
+<!-- Our markdown renderer is not spec-compliant and needs 4 spaces of indentation for nested lists, therefor we need to prettier-ignore. -->
+<!-- prettier-ignore -->
 - [Nicholas Gage](../company/team/index.md#nicholas-gage-he-him), Head of Sales Development
-  - West Outbound SDRs
-    - [Quin "Q" Keough](../company/team/index.md#quin-keough)
-    - [Kevin "Quigs" Quiqley](../company/team/index.md#kevin-quigley-he-him)
-    - [Zach Naidu](https://about.sourcegraph.com/handbook/company/team#zach-naidu)
-    - [Brannon Rouse](https://about.sourcegraph.com/handbook/company/team#brannon-rouse)
-  - East Outbound SDRs
-    - [Sam Cregg](../company/team/index.md#sam-cregg)
-    - [Jenna Pierre](https://about.sourcegraph.com/handbook/company/team#jenna-pierre-she-her)
-    - [Zach Naidu](https://about.sourcegraph.com/handbook/company/team#zach-naidu)
-  - Inbound SDR
-    - [Mark "Markie" Muldez](../company/team/index.md#mark-muldez-he-him)
+    - West Outbound SDRs
+      - [Quin "Q" Keough](../company/team/index.md#quin-keough)
+      - [Kevin "Quigs" Quiqley](../company/team/index.md#kevin-quigley-he-him)
+      - [Zach Naidu](https://about.sourcegraph.com/handbook/company/team#zach-naidu)
+      - [Brannon Rouse](https://about.sourcegraph.com/handbook/company/team#brannon-rouse)
+    - East Outbound SDRs
+      - [Sam Cregg](../company/team/index.md#sam-cregg)
+      - [Jenna Pierre](https://about.sourcegraph.com/handbook/company/team#jenna-pierre-she-her)
+      - [Zach Naidu](https://about.sourcegraph.com/handbook/company/team#zach-naidu)
+    - Inbound SDR
+      - [Mark "Markie" Muldez](../company/team/index.md#mark-muldez-he-him)
 
 More SDRs coming soon...
 


### PR DESCRIPTION
Adds `prettier-ignore` to all deep-nested lists (at least 3 layers) I found that were broken and an explanatory comment to those that already had it.

It turned out there are actually not that many instances – usually only for the department org charts, which obviously there are not that many of.

Now that they have the `prettier-ignore` comment editing those org charts will also not cause issues, while other content still gets to enjoy pretty formatting.