### PR TITLE
Updated references to roadmap, OKRs, & One pagers

### DIFF
--- a/handbook/product/product_management/planning.md
+++ b/handbook/product/product_management/planning.md
@@ -1,6 +1,6 @@
 # Planning
 
-Planning is a continuous process of negotiation between product and engineering. Teams should review the [roadmap](../index.md#roadmap) weekly with the [Product Manager](../roles/index.md#product-manager) and update it regularly.  The roadmap will become less specific and focus more on the problems we are looking to solve the further out it gets.  We expect to learn a lot between defining the problem and implementation. As implementation details change and we learn more about the solution to the problem we are aiming to solve, the product manager is responsible for communicating impacts to the overall coherency of a release. 
+Planning is a continuous process of negotiation between product and engineering. Teams should review the [roadmap](../index.md#roadmap) weekly with the [Product Manager](../roles/index.md#product-manager) and update it regularly. The roadmap will become less specific and focus more on the problems we are looking to solve the further out it gets. We expect to learn a lot between defining the problem and implementation. As implementation details change and we learn more about the solution to the problem we are aiming to solve, the product manager is responsible for communicating impacts to the overall coherency of a release.
 
 ## Product / eng team backlogs
 
@@ -39,7 +39,7 @@ We ask that teams leverage the [Direction page template](direction_template.md) 
 
 ### OKRs and One-pagers
 
-To ensure our team objectives are aligned with the company objectives at each fiscal quarter boundary the product and engineering organization collaborate with leadership on team [one pagers](https://docs.google.com/document/d/1iX7ytN8FztLXjl830XtNlI0KxfxFYFSOUUjtgSnmOPA/edit#heading=h.4nkrzeavd0fi).  Once the objectives in the one pagers are agreed on the content of the one pages should be reflect on the [roadmap](../index.md#roadmap).  This generally happens in the first week of the fiscal quarter.  As the quarter progresses the product manager is responsible for communicating progress towards our objectives in the [OKR tracker](https://docs.google.com/spreadsheets/d/1M7xgQuKTkxhAlOU2bZgnp5EjJgptwxNJXBkOJaomm5w/edit#gid=628032573) so that we can stay aligned.
+To ensure our team objectives are aligned with the company objectives at each fiscal quarter boundary the product and engineering organization collaborate with leadership on team [one pagers](https://docs.google.com/document/d/1iX7ytN8FztLXjl830XtNlI0KxfxFYFSOUUjtgSnmOPA/edit#heading=h.4nkrzeavd0fi). Once the objectives in the one pagers are agreed on the content of the one pages should be reflect on the [roadmap](../index.md#roadmap). This generally happens in the first week of the fiscal quarter. As the quarter progresses the product manager is responsible for communicating progress towards our objectives in the [OKR tracker](https://docs.google.com/spreadsheets/d/1M7xgQuKTkxhAlOU2bZgnp5EjJgptwxNJXBkOJaomm5w/edit#gid=628032573) so that we can stay aligned.
 
 ### RFCs
 

--- a/handbook/product/product_management/planning.md
+++ b/handbook/product/product_management/planning.md
@@ -1,10 +1,10 @@
 # Planning
 
-Planning is a continuous process of negotiation between product and engineering. Teams should review the project roadmap weekly with the [Product Manager](../roles/index.md#product-manager) during their team meetings, and update it regularly as new information comes in. The product manager should also review the plans for all projects in the next release for overall coherency. This ensures that projects can work on the schedules that make the most sense for them (subject to the constraint of needing to ship some kind of milestone monthly). A particularly long-term project can have many months of visibility into requirements and plans, and shorter or more experimental projects can be planned with shorter time horizons.
+Planning is a continuous process of negotiation between product and engineering. Teams should review the [roadmap](../index.md#roadmap) weekly with the [Product Manager](../roles/index.md#product-manager) and update it regularly.  The roadmap will become less specific and focus more on the problems we are looking to solve the further out it gets.  We expect to learn a lot between defining the problem and implementation. As implementation details change and we learn more about the solution to the problem we are aiming to solve, the product manager is responsible for communicating impacts to the overall coherency of a release. 
 
 ## Product / eng team backlogs
 
-You can find the backlogs for the product teams by visiting their [individual direction pages](../index.md#roadmap), which will contain a link. Different teams are using different tools and processes to plan their sprints, such as Jira, Productboard, or GitHub issues.
+You can find the backlogs for the product teams by visiting their [individual direction pages](../index.md#roadmap). For tracking implementation teams are using different tools and processes to plan their work, such as Jira, Productboard, or GitHub issues.
 
 ## Planning artifacts
 
@@ -20,13 +20,13 @@ Planning requires several artifacts for communicating. This section clarifies ho
 
 Engineering should feel empowered to add items to the roadmap that they feel strongly about, which will start conversations with product. [We want to push decisions down to people closest to those problems](../../communication/decisions.md#what-makes-an-effective-decision). It is product's responsibility to help give insight into customer pains and feedback, strategic priorities, and to ensure consistency across the product.
 
-The project roadmap is NOT:
+The roadmap is NOT:
 
 - a comprehensive backlog of everything we want to do
 - a list of every bug or customer issue in our issue tracker
 - permanent or mandated
 
-The project roadmap is:
+The roadmap is:
 
 - a prioritized list of the most important things we intend to do
 - an indicator of relative priority to teams, customers, and users
@@ -34,6 +34,12 @@ The project roadmap is:
 - where engineering and product negotiate the next most important thing to work on
 
 Teams should work on the next thing at the top of the roadmap and should not jump around. If there is a desire to work on something lower on the roadmap, that should be elevated during team meetings and the change in priority should be discussed. That item should be moved in the roadmap based on the outcome of the discussion.
+
+We ask that teams leverage the [Direction page template](direction_template.md) when creating and updating their team's page in [the roadmap](../index.md#roadmap).
+
+### OKRs and One-pagers
+
+To ensure our team objectives are aligned with the company objectives at each fiscal quarter boundary the product and engineering organization collaborate with leadership on team [one pagers](https://docs.google.com/document/d/1iX7ytN8FztLXjl830XtNlI0KxfxFYFSOUUjtgSnmOPA/edit#heading=h.4nkrzeavd0fi).  Once the objectives in the one pagers are agreed on the content of the one pages should be reflect on the [roadmap](../index.md#roadmap).  This generally happens in the first week of the fiscal quarter.  As the quarter progresses the product manager is responsible for communicating progress towards our objectives in the [OKR tracker](https://docs.google.com/spreadsheets/d/1M7xgQuKTkxhAlOU2bZgnp5EjJgptwxNJXBkOJaomm5w/edit#gid=628032573) so that we can stay aligned.
 
 ### RFCs
 


### PR DESCRIPTION
Added a section to the document to include references to the OKR tracking process as well as the one pagers.  Updated the references to the roadmap to point back to team pages and also pointed team to use the direction page template when updating their individual team goals pages.