### PR TITLE
Add meta tag specific title and description for blog posts

### DIFF
--- a/blogposts/2021/dev-tool-time-seth-vargo.md
+++ b/blogposts/2021/dev-tool-time-seth-vargo.md
@@ -1,6 +1,8 @@
 ---
 title: 'Dev Tool Time with Seth Vargo: Productivity hacks and .gitconfig tips'
 description: Check out the recording of our first episode of Dev Tool Time, in which Google Cloud Engineer Seth Vargo shares his tips for a productivity-optimized desk setup, efficient window management, and keyboard shortcuts.
+seoTitle: Productivity Hacks & .gitconfig Tips – Dev Tool Time
+seoDescription: We’re talking about setting up a new computer in record time on Dev Tool Time. Seth Vargo shares .gitconfig tips, favorite Mac window manager, and more.
 author: Vanesa Ortiz
 authorUrl: https://twitter.com/vanesacodes
 publishDate: 2021-04-28T10:00-07:00

--- a/blogposts/2021/dev-tool-time-seth-vargo.md
+++ b/blogposts/2021/dev-tool-time-seth-vargo.md
@@ -1,8 +1,8 @@
 ---
 title: 'Dev Tool Time with Seth Vargo: Productivity hacks and .gitconfig tips'
 description: Check out the recording of our first episode of Dev Tool Time, in which Google Cloud Engineer Seth Vargo shares his tips for a productivity-optimized desk setup, efficient window management, and keyboard shortcuts.
-seoTitle: Productivity Hacks & .gitconfig Tips – Dev Tool Time
-seoDescription: We’re talking about setting up a new computer in record time on Dev Tool Time. Seth Vargo shares .gitconfig tips, favorite Mac window manager, and more.
+externalTitle: Productivity Hacks & .gitconfig Tips – Dev Tool Time
+externalDescription: We’re talking about setting up a new computer in record time on Dev Tool Time. Seth Vargo shares .gitconfig tips, favorite Mac window manager, and more.
 author: Vanesa Ortiz
 authorUrl: https://twitter.com/vanesacodes
 publishDate: 2021-04-28T10:00-07:00

--- a/website/README.md
+++ b/website/README.md
@@ -36,11 +36,11 @@ published: boolean
 ---
 ```
 
-There are two optional frontmatter fields used to specify meta-specific title and description:
+There are two optional frontmatter fields used to specify meta-specific title and description for external consumers, such as search engines:
 
 ```
-seoTitle: Example title
-seoDescription: Example description
+externalTitle: Example title
+externalDescription: Example description
 ```
 
 If these are not present, the `title` and `description` are used for these meta tags.

--- a/website/README.md
+++ b/website/README.md
@@ -36,6 +36,15 @@ published: boolean
 ---
 ```
 
+There are two optional frontmatter fields used to specify meta-specific title and description:
+
+```
+seoTitle: Example title
+seoDescription: Example description
+```
+
+If these are not present, the `title` and `description` are used for these meta tags.
+
 Blog posts are visible on if published is set to `true`.
 
 **Important:** when creating hyperlinks to pages within https://about.sourcegraph.com, never link with the base URL https://about.sourcegraph.com.

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -42,11 +42,7 @@ export default class Layout extends React.PureComponent<LayoutProps> {
         return (
             <div className={`flex flex-column fill-height ${this.props.className || ''}`}>
                 <Helmet>
-                    {metaProps.seoTitle ? (
-                        <title>{metaProps.seoTitle}</title>
-                    ) : (
-                        <title>{metaProps.title}</title>
-                    )}
+                    {metaProps.seoTitle ? <title>{metaProps.seoTitle}</title> : <title>{metaProps.title}</title>}
 
                     <meta name="twitter:title" content={metaProps.title} />
                     <meta name="twitter:site" content="@sourcegraph" />

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -8,6 +8,8 @@ interface LayoutProps {
     meta?: {
         title?: string
         description?: string
+        seoTitle?: string
+        seoDescription?: string
         image?: string
         icon?: string
     }
@@ -40,7 +42,12 @@ export default class Layout extends React.PureComponent<LayoutProps> {
         return (
             <div className={`flex flex-column fill-height ${this.props.className || ''}`}>
                 <Helmet>
-                    <title>{metaProps.title}</title>
+                    {metaProps.seoTitle ? (
+                        <title>{metaProps.seoTitle}</title>
+                    ) : (
+                        <title>{metaProps.title}</title>
+                    )}
+
                     <meta name="twitter:title" content={metaProps.title} />
                     <meta name="twitter:site" content="@sourcegraph" />
                     <meta name="twitter:image" content={metaProps.image} />
@@ -52,7 +59,12 @@ export default class Layout extends React.PureComponent<LayoutProps> {
                     <meta property="og:image" content={metaProps.image} />
                     <meta property="og:description" content={metaProps.description} />
 
-                    <meta name="description" content={metaProps.description} />
+                    {metaProps.seoDescription ? (
+                        <meta name="description" content={metaProps.seoDescription} />
+                    ) : (
+                        <meta name="description" content={metaProps.description} />
+                    )}
+
                     <link rel="icon" type="image/png" href={metaProps.icon} />
                     <link rel="icon" type="image/png" href={metaProps.image} />
                     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -42,7 +42,7 @@ export default class Layout extends React.PureComponent<LayoutProps> {
         return (
             <div className={`flex flex-column fill-height ${this.props.className || ''}`}>
                 <Helmet>
-                    {metaProps.seoTitle ? <title>{metaProps.seoTitle}</title> : <title>{metaProps.title}</title>}
+                    <title>{metaProps.seoTitle || metaProps.title}</title>
 
                     <meta name="twitter:title" content={metaProps.title} />
                     <meta name="twitter:site" content="@sourcegraph" />
@@ -55,11 +55,7 @@ export default class Layout extends React.PureComponent<LayoutProps> {
                     <meta property="og:image" content={metaProps.image} />
                     <meta property="og:description" content={metaProps.description} />
 
-                    {metaProps.seoDescription ? (
-                        <meta name="description" content={metaProps.seoDescription} />
-                    ) : (
-                        <meta name="description" content={metaProps.description} />
-                    )}
+                    <meta name="description" content={metaProps.seoDescription || metaProps.description} />
 
                     <link rel="icon" type="image/png" href={metaProps.icon} />
                     <link rel="icon" type="image/png" href={metaProps.image} />

--- a/website/src/components/Layout.tsx
+++ b/website/src/components/Layout.tsx
@@ -8,8 +8,8 @@ interface LayoutProps {
     meta?: {
         title?: string
         description?: string
-        seoTitle?: string
-        seoDescription?: string
+        externalTitle?: string
+        externalDescription?: string
         image?: string
         icon?: string
     }
@@ -42,7 +42,7 @@ export default class Layout extends React.PureComponent<LayoutProps> {
         return (
             <div className={`flex flex-column fill-height ${this.props.className || ''}`}>
                 <Helmet>
-                    <title>{metaProps.seoTitle || metaProps.title}</title>
+                    <title>{metaProps.externalTitle || metaProps.title}</title>
 
                     <meta name="twitter:title" content={metaProps.title} />
                     <meta name="twitter:site" content="@sourcegraph" />
@@ -55,7 +55,7 @@ export default class Layout extends React.PureComponent<LayoutProps> {
                     <meta property="og:image" content={metaProps.image} />
                     <meta property="og:description" content={metaProps.description} />
 
-                    <meta name="description" content={metaProps.seoDescription || metaProps.description} />
+                    <meta name="description" content={metaProps.externalDescription || metaProps.description} />
 
                     <link rel="icon" type="image/png" href={metaProps.icon} />
                     <link rel="icon" type="image/png" href={metaProps.image} />

--- a/website/src/components/blog/postTypes.tsx
+++ b/website/src/components/blog/postTypes.tsx
@@ -18,6 +18,8 @@ export interface Post {
     frontmatter: {
         title: string
         description: string
+        seoTitle: string
+        seoDescription: string
         slug: string
         canonical: string
         publishDate: string

--- a/website/src/components/blog/postTypes.tsx
+++ b/website/src/components/blog/postTypes.tsx
@@ -18,8 +18,10 @@ export interface Post {
     frontmatter: {
         title: string
         description: string
-        seoTitle: string
-        seoDescription: string
+        /** Controls the page's `<title>` for SEO and the browser tab label. Defaults to {@link title}. */
+        seoTitle?: string
+        /** Controls the page's `<meta name="description">` for SEO. Defaults to {@link description}. */
+        seoDescription?: string
         slug: string
         canonical: string
         publishDate: string

--- a/website/src/components/blog/postTypes.tsx
+++ b/website/src/components/blog/postTypes.tsx
@@ -19,9 +19,9 @@ export interface Post {
         title: string
         description: string
         /** Controls the page's `<title>` for SEO and the browser tab label. Defaults to {@link title}. */
-        seoTitle?: string
+        externalTitle?: string
         /** Controls the page's `<meta name="description">` for SEO. Defaults to {@link description}. */
-        seoDescription?: string
+        externalDescription?: string
         slug: string
         canonical: string
         publishDate: string

--- a/website/src/templates/PodcastEpisodeTemplate.tsx
+++ b/website/src/templates/PodcastEpisodeTemplate.tsx
@@ -27,9 +27,11 @@ export default class PodcastEpisodeTemplate extends React.Component<any, any> {
     public render(): JSX.Element | null {
         const md = this.props.data.markdownRemark
         const title = md.frontmatter.title
+        const seoTitle = md.frontmatter.seoTitle
         const publishDate = md.frontmatter.publishDate
         let slug = md.frontmatter.slug
         const description = md.frontmatter.description ? md.frontmatter.description : md.excerpt
+        const seoDescription = md.frontmatter.seoDescription
         const content = md.html
         const image = md.frontmatter.heroImage
             ? `${md.frontmatter.heroImage}`
@@ -38,6 +40,8 @@ export default class PodcastEpisodeTemplate extends React.Component<any, any> {
             title,
             image,
             description,
+            seoTitle,
+            seoDescription
         }
 
         const { guestsHTML, audioHTML, summaryHTML, transcriptHTML, showNotesHTML } = getHTMLParts(content)
@@ -137,6 +141,8 @@ export const pageQuery = graphql`
                 tags
                 publishDate(formatString: "MMMM D, YYYY")
                 slug
+                seoTitle
+                seoDescription
             }
             html
             excerpt

--- a/website/src/templates/PodcastEpisodeTemplate.tsx
+++ b/website/src/templates/PodcastEpisodeTemplate.tsx
@@ -27,11 +27,11 @@ export default class PodcastEpisodeTemplate extends React.Component<any, any> {
     public render(): JSX.Element | null {
         const md = this.props.data.markdownRemark
         const title = md.frontmatter.title
-        const seoTitle = md.frontmatter.seoTitle
+        const externalTitle = md.frontmatter.externalTitle
         const publishDate = md.frontmatter.publishDate
         let slug = md.frontmatter.slug
         const description = md.frontmatter.description ? md.frontmatter.description : md.excerpt
-        const seoDescription = md.frontmatter.seoDescription
+        const externalDescription = md.frontmatter.externalDescription
         const content = md.html
         const image = md.frontmatter.heroImage
             ? `${md.frontmatter.heroImage}`
@@ -40,8 +40,8 @@ export default class PodcastEpisodeTemplate extends React.Component<any, any> {
             title,
             image,
             description,
-            seoTitle,
-            seoDescription,
+            externalTitle,
+            externalDescription,
         }
 
         const { guestsHTML, audioHTML, summaryHTML, transcriptHTML, showNotesHTML } = getHTMLParts(content)
@@ -141,8 +141,8 @@ export const pageQuery = graphql`
                 tags
                 publishDate(formatString: "MMMM D, YYYY")
                 slug
-                seoTitle
-                seoDescription
+                externalTitle
+                externalDescription
             }
             html
             excerpt

--- a/website/src/templates/PodcastEpisodeTemplate.tsx
+++ b/website/src/templates/PodcastEpisodeTemplate.tsx
@@ -41,7 +41,7 @@ export default class PodcastEpisodeTemplate extends React.Component<any, any> {
             image,
             description,
             seoTitle,
-            seoDescription
+            seoDescription,
         }
 
         const { guestsHTML, audioHTML, summaryHTML, transcriptHTML, showNotesHTML } = getHTMLParts(content)

--- a/website/src/templates/PostTemplate.tsx
+++ b/website/src/templates/PostTemplate.tsx
@@ -21,7 +21,7 @@ export const PostTemplate: React.FunctionComponent<Props> = ({ data, location })
         image,
         description,
         seoTitle,
-        seoDescription
+        seoDescription,
     }
 
     const C = POST_TYPE_TO_COMPONENT[postType(post)]

--- a/website/src/templates/PostTemplate.tsx
+++ b/website/src/templates/PostTemplate.tsx
@@ -14,10 +14,14 @@ export const PostTemplate: React.FunctionComponent<Props> = ({ data, location })
     const image = 'https://about.sourcegraph.com/sourcegraph-mark.png'
     const socialImage = post.frontmatter.socialImage
     const canonical = post.frontmatter.canonical
+    const seoTitle = post.frontmatter.seoTitle
+    const seoDescription = post.frontmatter.seoDescription
     const meta = {
         title,
         image,
         description,
+        seoTitle,
+        seoDescription
     }
 
     const C = POST_TYPE_TO_COMPONENT[postType(post)]
@@ -69,6 +73,8 @@ export const pageQuery = graphql`
             frontmatter {
                 title
                 description
+                seoTitle
+                seoDescription
                 heroImage
                 socialImage
                 author

--- a/website/src/templates/PostTemplate.tsx
+++ b/website/src/templates/PostTemplate.tsx
@@ -14,14 +14,14 @@ export const PostTemplate: React.FunctionComponent<Props> = ({ data, location })
     const image = 'https://about.sourcegraph.com/sourcegraph-mark.png'
     const socialImage = post.frontmatter.socialImage
     const canonical = post.frontmatter.canonical
-    const seoTitle = post.frontmatter.seoTitle
-    const seoDescription = post.frontmatter.seoDescription
+    const externalTitle = post.frontmatter.externalTitle
+    const externalDescription = post.frontmatter.externalDescription
     const meta = {
         title,
         image,
         description,
-        seoTitle,
-        seoDescription,
+        externalTitle,
+        externalDescription,
     }
 
     const C = POST_TYPE_TO_COMPONENT[postType(post)]
@@ -73,8 +73,8 @@ export const pageQuery = graphql`
             frontmatter {
                 title
                 description
-                seoTitle
-                seoDescription
+                externalTitle
+                externalDescription
                 heroImage
                 socialImage
                 author


### PR DESCRIPTION
This PR adds optional fields to the frontmatter for blog posts: `seoTitle` and `seoDescription`. 

When present, these are used to set `<title>` and `<meta name="description" />`. When they aren't present, the values for `title` and `description` are used. 