### PR TITLE
Fix Typo?

### DIFF
--- a/handbook/product/roles/index.md
+++ b/handbook/product/roles/index.md
@@ -12,7 +12,7 @@ Product Managers work with engineering, sales, marketing, and design to plan, sh
 
 ### Responsibilities
 
-You will **own an area of the product**\* and:
+You will **own an area of the product**\ and:
 
 - Significantly grow usage and engagement of that area and Sourcegraph as a whole.
 - Collaborate with, support, and motivate their team to plan and build the solutions to customer problems.


### PR DESCRIPTION
Not sure if this is a typo but think it may be given the markdown bold formatting. 

If this is a typo, feel free to merge. If it's not, I'm not sure what we wanted to denote with the asterisk so Christina probably needs to make that edit. This line originally went up [in this PR](https://github.com/sourcegraph/about/commit/fb84b4897e7bc17f4bf0460e5c03fcee034a64de#diff-24de06645a9bc7ee0423d37d7f3ff5afa2ac9f062f7829d0baa264300145a607R14)
![image](https://user-images.githubusercontent.com/11967660/134442239-a2f9037c-fb8e-4e9e-95cc-20c572e8e6f7.png)
