### PR TITLE
Add differentiators from workflow page here

### DIFF
--- a/handbook/marketing/messaging.md
+++ b/handbook/marketing/messaging.md
@@ -80,6 +80,23 @@ Universal code search meets these requirements, and all users have to do is sear
 
 By solving some of the most pressing challenges in today’s fast-moving, intricately connected software organizations, universal code search is the right technology for the era of Big Code.
 
+## How is Sourcegraph different?
+
+See how Sourcegraph compares with and integrates to other solutions:
+
+- [Atlassian Fisheye](tools/atlassian_fisheye_vs_sourcegraph.md)
+- [Bitbucket Cloud](tools/bitbucket_cloud_vs_sourcegraph.md)
+- [Bitbucket Server](tools/bitbucket_server_vs_sourcegraph.md)
+- [GitHub](tools/github_vs_sourcegraph.md)
+- [GitLab](tools/gitlab_vs_sourcegraph.md)
+- [Google Cloud Source Repositories](tools/google_cloud_source_repositories_vs_sourcegraph.md)
+- [Hound](tools/hound_vs_sourcegraph.md)
+- [Livegrep](tools/livegrep_vs_sourcegraph.md)
+- [OpenGrok](tools/opengrok_vs_sourcegraph.md)
+- [Phabricator](tools/phabricator_vs_sourcegraph.md)
+
+([File an issue](https://github.com/sourcegraph/about/issues) if you want us to add a page about another product.)
+
 ## Company overview
 
 Sourcegraph is a company that creates software to help every organization build software with the quality and efficiency of today's elite technology companies.

--- a/handbook/marketing/messaging.md
+++ b/handbook/marketing/messaging.md
@@ -84,18 +84,16 @@ By solving some of the most pressing challenges in today’s fast-moving, intric
 
 See how Sourcegraph compares with and integrates to other solutions:
 
-- [Atlassian Fisheye](tools/atlassian_fisheye_vs_sourcegraph.md)
-- [Bitbucket Cloud](tools/bitbucket_cloud_vs_sourcegraph.md)
-- [Bitbucket Server](tools/bitbucket_server_vs_sourcegraph.md)
-- [GitHub](tools/github_vs_sourcegraph.md)
-- [GitLab](tools/gitlab_vs_sourcegraph.md)
-- [Google Cloud Source Repositories](tools/google_cloud_source_repositories_vs_sourcegraph.md)
-- [Hound](tools/hound_vs_sourcegraph.md)
-- [Livegrep](tools/livegrep_vs_sourcegraph.md)
-- [OpenGrok](tools/opengrok_vs_sourcegraph.md)
-- [Phabricator](tools/phabricator_vs_sourcegraph.md)
-
-([File an issue](https://github.com/sourcegraph/about/issues) if you want us to add a page about another product.)
+- [Atlassian Fisheye](../workflow/tools/atlassian_fisheye_vs_sourcegraph.md)
+- [Bitbucket Cloud](../workflow/tools/bitbucket_cloud_vs_sourcegraph.md)
+- [Bitbucket Server](../workflow/tools/bitbucket_server_vs_sourcegraph.md)
+- [GitHub](../workflow/tools/github_vs_sourcegraph.md)
+- [GitLab](../workflow/tools/gitlab_vs_sourcegraph.md)
+- [Google Cloud Source Repositories](../workflow/tools/google_cloud_source_repositories_vs_sourcegraph.md)
+- [Hound](../workflow/tools/hound_vs_sourcegraph.md)
+- [Livegrep](../workflow/tools/livegrep_vs_sourcegraph.md)
+- [OpenGrok](../workflow/tools/opengrok_vs_sourcegraph.md)
+- [Phabricator](../workflow/tools/phabricator_vs_sourcegraph.md)
 
 ## Company overview
 


### PR DESCRIPTION
Victoria,  I also sent you a slack message related to this topic.  I am trying to delete the [workflow page](https://about.sourcegraph.com/handbook/workflow) as it is out of date.  The links to the sub pages appear to be up to date so I am suggesting we move that content to our messaging page.  Let me know what you think.