### PR TITLE
Update creating a community search context page

### DIFF
--- a/handbook/direction/code-graph/code-intelligence/index.md
+++ b/handbook/direction/code-graph/code-intelligence/index.md
@@ -42,7 +42,7 @@ Code intelligence lies at the very center of the product as a whole, providing t
 
 At the moment maturity varies depending on the area of ownership:
 
-- **Language indexers:** Maturity varies widely per language See [LSIF indexers documentation](https://docs.sourcegraph.com/code_intelligence/references/indexers).
+- **Language indexers:** Maturity varies widely per language. See [LSIF indexers documentation](https://docs.sourcegraph.com/code_intelligence/references/indexers).
 
 - **Code intelligence platform:** Viable with a solid foundation, we're currently working on scaling and improving performance to push the limits of precise indexing and build the Global Code Graph.
 
@@ -85,19 +85,22 @@ Recent key learnings:
 These tie back to [FY22 Q3 Product/Engineering OKRs](../../../company/goals/2022_q3.md#product-engineering)
 
 **Objective: Make cloud and enterprise successful at massive scale**
-**KR:** Increase the amount of LSIF indexed repos and dependencies on Cloud by 5x (Target: 50k).
-**KR:** 1 customer successfully enables auto-indexing and dependency navigation on their instance.
-**KR:** Add Scala and Kotlin support to increase JVM ecosystem coverage.
+
+- **KR:** Increase the amount of LSIF indexed repos and dependencies on Cloud by 5x (Target: 50k).
+- **KR:** 1 customer successfully enables auto-indexing and dependency navigation on their instance.
+- **KR:** Add Scala and Kotlin support to increase JVM ecosystem coverage.
 
 **Why?** During Q2 we validated our approach for cross-dependency navigation and slowly started building towards the Global Code Graph. For Q3, we want to double down on scaling the number of repositories and dependencies we index on Cloud while making sure we optimize the way we handle LSIF data and uploads. We also want to make sure we’re able to deliver the same top-notch navigation experience to our enterprise customers and will invest in making our approach scalable and performant for on-prem instances.
 
 **Objective: Build a delightful personalized product that devs love**
-**KR:** Solve at least 3 long-standing code navigation UX issues from our papercuts backlog.
+
+- **KR:** Solve at least 3 long-standing code navigation UX issues from our papercuts backlog.
 
 **Why?** Code navigation is a key part of a developer’s workflow, we want that experience to feel smooth and snappy, similar to the one you’d get in your favorite IDE. While we build up our code navigation team, we want to take a first stab at improving the current code navigation experience by tackling some long-standing UX papercuts.
 
 **Objective: Happy, effective, async team**
-**KR:** Hire and successfully onboard 3 engineers.
+
+- **KR:** Hire and successfully onboard 3 engineers.
 
 **Why?** Our goal is to own the end-to-end code navigation experience, which will result in clear ownership in some historically grey areas and faster iteration in code navigation-related issues and features. We want to build out the team skillset to own the vertical product slice.
 
@@ -105,12 +108,12 @@ These tie back to [FY22 Q3 Product/Engineering OKRs](../../../company/goals/2022
 
 #### Top level theme: Build and scale the Global Code Graph
 
-- Cross repository and dependency navigation
+- **Cross repository and dependency navigation**
   - We believe this is the global code graph’s killer feature. It elevates the code navigation experience to a new level of cross-project analysis. It includes enabling precise cross-repository navigation and the ability to navigate to any third party dependency a repository references. We're solving this initially on Sourcegraph Cloud and plan to replicate the same functionality for on-premise usage.
-- Auto-indexing and scaling the code graph
+- **Auto-indexing and scaling the code graph**
   - The current set up experience is not scalable for customers with a large amount of repositories. Enabling auto-indexing would mean a lower barrier for entry, a seamless experience and more engineers using precise code intelligence.
   - Building the code graph also means we need to generate and store increased amounts of LSIF data that will require scaling our infrastructure in an order of one to two magnitudes. We hypothesize that we'll reach scaling concerns, we want to be proactive in identifying and removing bottlenecks.
-- Ship precise language support
+- **Ship precise language support**
   - We’ve historically invested in broadening our span of supported languages. This is an ongoing effort that ties directly back to the Global Code Graph vision.
 
 ### What's next and why

--- a/handbook/marketing/oss_community_pages.md
+++ b/handbook/marketing/oss_community_pages.md
@@ -5,6 +5,7 @@ Sourcegraph hosts community landing pages to help open source community members 
 ## How to create a community landing page on Sourcegraph Cloud
 
 First, create the search context:
+
 - Make sure you are a site-admin on Cloud
 - Identify the requirements for the community search contexts page. What repos should be included in the search context? What examples would be worth highlighting?
 - Create a new search context: [Create page](https://sourcegraph.com/contexts/new)
@@ -18,6 +19,7 @@ First, create the search context:
 
 Second, create the corresponding community search context page in the main sourcegraph repository. This is a temporary measure and will be automated in the future.
 Steps:
+
 - Copy an existing page config (e.g. [Stanford](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/communitySearchContexts/Stanford.tsx)) and adjust the necessary data
   - **Important**: The `spec` property should match the search context name you created in the first step
 - Add the corresponding route [to the client router](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/communitySearchContexts/routes.tsx?L31)

--- a/handbook/marketing/oss_community_pages.md
+++ b/handbook/marketing/oss_community_pages.md
@@ -4,17 +4,22 @@ Sourcegraph hosts community landing pages to help open source community members 
 
 ## How to create a community landing page on Sourcegraph Cloud
 
+First, create the search context:
 - Make sure you are a site-admin on Cloud
 - Identify the requirements for the community search contexts page. What repos should be included in the search context? What examples would be worth highlighting?
-- Create a new search context: https://sourcegraph.com/contexts/new
+- Create a new search context: [Create page](https://sourcegraph.com/contexts/new)
   - Select the "Global owner" option from the Owner dropdown (this will make the context available to all users on Cloud)
   - Enter the context name (e.g. `stanford`, `cncf`)
   - Enter a description (Markdown is supported)
   - Select the "Public" visiblity
-  - Enter the repositories as a JSON config (see https://sourcegraph.com/contexts/stanford/edit for example configuration)
+  - Enter the repositories as a JSON config (see [Stanford edit page](https://sourcegraph.com/contexts/stanford/edit) for example configuration)
   - Click "Test configuration" to check if the configuration is in the correct format and that all of the entered repositories exist
   - Finally, you can create the search context
 
-<!-- - Create the page ([example](https://github.com/sourcegraph/sourcegraph/commit/576318e4dff2a3ecc8002ebea2b490b8ee99fc31)) and open a PR. Tag the search-product team for review. -->
-- TODO: Creating a page
-
+Second, create the corresponding community search context page in the main sourcegraph repository. This is a temporary measure and will be automated in the future.
+Steps:
+- Copy an existing page config (e.g. [Stanford](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/communitySearchContexts/Stanford.tsx)) and adjust the necessary data
+  - **Important**: The `spec` property should match the search context name you created in the first step
+- Add the corresponding route [to the client router](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/communitySearchContexts/routes.tsx?L31)
+- Add the same route [to the backend router as well](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/app/ui/router.go?L173)
+- Tag the search-product team to review & approve the changes (or if you need help adding the page)

--- a/handbook/marketing/oss_community_pages.md
+++ b/handbook/marketing/oss_community_pages.md
@@ -1,12 +1,20 @@
 # Adding a community landing page
 
-Sourcegraph hosts community landing pages to help open source community members discover, onboard, and search their code. Good examples include the [kubernetes](https://sourcegraph.com/kubernetes) and [stanford](https://sourcegraph.com/stanford) landing pages.
-
-For now, those pages are based on repogroups (a named group of repositories defined by a site admin on Sourcegraph.com).
+Sourcegraph hosts community landing pages to help open source community members discover, onboard, and search their code. Good examples include the [kubernetes](https://sourcegraph.com/kubernetes) and [stanford](https://sourcegraph.com/stanford) landing pages. The pages are based on search contexts (a named collection of repositories and revisions).
 
 ## How to create a community landing page on Sourcegraph Cloud
 
-- Identify the requirements for the repogroup page. What repos should be included in the repogroup? What examples would be worth highlighting?
-- Create the repogroup by opening a PR adding a repogroup definition to `search.repositoryGroups` [here](https://github.com/sourcegraph/deploy-sourcegraph-dot-com/blob/release/base/frontend/sourcegraph-frontend.ConfigMap.yaml#L47). Tag search-product for review.
-- Create the page ([example](https://github.com/sourcegraph/sourcegraph/commit/576318e4dff2a3ecc8002ebea2b490b8ee99fc31)) and open a PR. Tag search-product for review.
-- Run a few tests to check that repositories are all indexed and the repo group returns expected results.
+- Make sure you are a site-admin on Cloud
+- Identify the requirements for the community search contexts page. What repos should be included in the search context? What examples would be worth highlighting?
+- Create a new search context: https://sourcegraph.com/contexts/new
+  - Select the "Global owner" option from the Owner dropdown (this will make the context available to all users on Cloud)
+  - Enter the context name (e.g. `stanford`, `cncf`)
+  - Enter a description (Markdown is supported)
+  - Select the "Public" visiblity
+  - Enter the repositories as a JSON config (see https://sourcegraph.com/contexts/stanford/edit for example configuration)
+  - Click "Test configuration" to check if the configuration is in the correct format and that all of the entered repositories exist
+  - Finally, you can create the search context
+
+<!-- - Create the page ([example](https://github.com/sourcegraph/sourcegraph/commit/576318e4dff2a3ecc8002ebea2b490b8ee99fc31)) and open a PR. Tag the search-product team for review. -->
+- TODO: Creating a page
+

--- a/handbook/marketing/oss_community_pages.md
+++ b/handbook/marketing/oss_community_pages.md
@@ -20,8 +20,8 @@ First, create the search context:
 Second, create the corresponding community search context page in the main sourcegraph repository. This is a temporary measure and will be automated in the future.
 Steps:
 
-- Copy an existing page config (e.g. [Stanford](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/communitySearchContexts/Stanford.tsx)) and adjust the necessary data
+- Copy an existing page config (e.g. [Stanford](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@675e5129031b75998ffa2823782f5e354390edfb/-/blob/client/web/src/communitySearchContexts/Stanford.tsx)) and adjust the necessary data
   - **Important**: The `spec` property should match the search context name you created in the first step
-- Add the corresponding route [to the client router](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/client/web/src/communitySearchContexts/routes.tsx?L31)
-- Add the same route [to the backend router as well](https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/cmd/frontend/internal/app/ui/router.go?L173)
+- Add the corresponding route [to the client router](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@675e5129031b75998ffa2823782f5e354390edfb/-/blob/client/web/src/communitySearchContexts/routes.tsx?L31)
+- Add the same route [to the backend router as well](https://sourcegraph.com/github.com/sourcegraph/sourcegraph@675e5129031b75998ffa2823782f5e354390edfb/-/blob/cmd/frontend/internal/app/ui/router.go?L173)
 - Tag the search-product team to review & approve the changes (or if you need help adding the page)


### PR DESCRIPTION
We are migrating from repogroup pages to community search context pages as a part of the repogroup deprecation process.