### PR TITLE
Change blog link to editorial process

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,9 +41,7 @@ yarn start
 
 ## Publishing a blog post
 
-We want and encourage everyone at Sourcegraph to contribute to the blog and publishing a blog post is as simple as merging an approved pull request with your blog content.
-
-Learn how to [create and publish a blog post](https://about.sourcegraph.com/handbook/marketing/creating_blog_posts).
+We want and encourage everyone at Sourcegraph to contribute to the blog. If you'd like to write for the blog, please check out how to [propose a blog post](editorial.md#editorial-process) in the Editorial handbook.
 
 ## Handbook
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ yarn start
 
 ## Publishing a blog post
 
-We want and encourage everyone at Sourcegraph to contribute to the blog. If you'd like to write for the blog, please check out how to [propose a blog post](editorial.md#editorial-process) in the Editorial handbook.
+We want and encourage everyone at Sourcegraph to contribute to the blog. If you'd like to write for the blog, please check out how to [propose a blog post](https://about.sourcegraph.com/handbook/marketing/content/editorial#editorial-process) in the Editorial handbook.
 
 ## Handbook
 


### PR DESCRIPTION
Changes link from readme so that we direct people first to the editorial process section.