### PR TITLE
Replace screenshots of Slack messages with accessible SVGs

### DIFF
--- a/blogposts/2021/show-us-your-calendar.md
+++ b/blogposts/2021/show-us-your-calendar.md
@@ -51,11 +51,10 @@ The workplace can get noisy. For Gutekanst, it comes in waves.
 
 Over the course of two months, he says, half of his time might go toward helping other people: “It’s a weird conundrum because it’s a completely useful way to spend my time. On the other hand, it’s completely unrelated to what my focus area actually is, which is working on a product feature or something like that.”
 
-![Slack message from Stephen regarding his workation](https://storage.googleapis.com/sourcegraph-assets/blog/Show%20Us%20Your%20Calendar%20Images/Screen%20Shot%202021-09-13%20at%201.19.29%20PM.png)
-
-<p class="font-italic text-center">
-Stephen’s message to the team about his workation.
-</p>
+<figure>
+  <object role="image" data="https://sourcegraphstatic.com/blog/Show%20Us%20Your%20Calendar%20Images/stephen-gutekanst-workation.svg" width="791" height="426"></object>
+  <figcaption>Stephen’s message to the team about his workation.</figcaption>
+</figure>
 
 Part of the reason for that comes from working at a [high-growth startup](https://about.sourcegraph.com/blog/announcing-sourcegraphs-series-d-round/): “A lot of the time, we don’t have an owner for an area and I’m the person with the most context, so it’s useful for me to help out there.”
 
@@ -87,11 +86,12 @@ Vanesa recommends the four-day work week to everyone, but especially to primary 
 
 TJ jokingly acknowledges it’s not his _ideal_ schedule. “My preferred hours would be working in the middle of the night but that doesn’t work with a family,” he says, laughing. TJ has an 11-month-old baby boy, a wife, and responsibilities at church: all of which make weeknights busy. Working four tens allows him to handle those responsibilities at night and have Fridays free for streaming his [live coding sessions](https://www.twitch.tv/teej_dv).
 
+<figure>
+
 ![TJ coding live on Twitch](https://storage.googleapis.com/sourcegraph-assets/blog/Show%20Us%20Your%20Calendar%20Images/Screen%20Shot%202021-09-13%20at%202.03.37%20PM.png)
 
-<p class="font-italic text-center">
-TJ coding live on Twitch.
-</p>
+  <figcaption>TJ coding live on Twitch.</figcaption>
+</figure>
 
 Many would rightfully worry that lopping off one day a week wouldn’t sit well with a manager. TJ had the opposite experience: "No one minds how you’re working as long as you’re getting done what you say you’re going to get done and staying healthy." As long as his new schedule wasn’t a detriment to his team, TJ says, then he had his manager’s full support.
 
@@ -133,11 +133,10 @@ For Jean, this means using the morning to take care of the chores that most woul
 
 In the afternoon, Jean is frank: he might just nap. After, around 3 pm (his time), is when most people in the east coast of the United States start to wake up, so the next three hours have some of the best overlap for meetings. From 6:00 pm to 8:30 pm is family time: “We have supper together, kids get bathed, and I put them to bed.” And from 8:30 pm to 10:00 pm, he handles any stray follow-up meetings and completes some light work.
 
-![Slack message from Jean regarding his schedule](https://storage.googleapis.com/sourcegraph-assets/blog/Show%20Us%20Your%20Calendar%20Images/Screen%20Shot%202021-09-13%20at%201.20.11%20PM.png)
-
-<p class="font-italic text-center">
-Jean's message to the team about his work schedule.
-</p>
+<figure>
+  <object role="image" data="https://sourcegraphstatic.com/blog/Show%20Us%20Your%20Calendar%20Images/jean-du-plessis-slack.svg" width="859" height="480"></object>
+  <figcaption>Jean's message to the team about his work schedule.</figcaption>
+</figure>
 
 For Jean, the nonlinear work day isn’t merely a traditional workday, fragmented: “I’m picky about what I do in the evenings.” He tends to schedule meetings that he doesn’t have to lead during his evening sessions–meetings where he only has to listen or provide input. He optimizes his entire day based on what he does best when.
 

--- a/website/src/css/components/blog/_BlogPost.scss
+++ b/website/src/css/components/blog/_BlogPost.scss
@@ -18,7 +18,8 @@
     }
 
     &__html {
-        img {
+        img,
+        object {
             max-width: 75%;
             max-height: 100vh;
             box-shadow: 0 2px 18px 0 #0000001a, 0 6px 20px 0 #00000017;
@@ -31,6 +32,20 @@
         video-embed,
         .gatsby-highlight {
             margin: 3rem auto;
+        }
+
+        figcaption {
+            margin-top: 2rem;
+            text-align: center;
+            font-style: italic;
+        }
+
+        // Make sure margin for figures with caption is applied after the caption, not before.
+        figure > :is(img, object, video) {
+            margin-bottom: 0;
+        }
+        figure {
+            margin-bottom: 3rem;
         }
     }
 }


### PR DESCRIPTION
Replaces the screenshots of Slack messages in the remote work calendars blog post with accessible SVGs so that the message can be read by screen reader users too. Notice how you can select the text inside now with your mouse :)

This is the "premium" solution that required some advanced techniques to generate the SVG ([SVG Screenshot](https://chrome.google.com/webstore/detail/svg-screenshot/nfakpcpmhhilkdpphcjgnokknpbpdllg?hl=en) and some manual editing of the SVG). I say "premium" because not only is it accessible, it also gives **everyone** a super crisp vector graphic, where text can even be selected and links are still clickable (e.g. Jean's link to non-linear workdays).

The _easier_ solution to make screenshots of text accessible is to have a screenshot in PNG, then include the text of the screenshot in a `<div class="sr-only">` that is only visible to screen readers.

Also changed the captions to use `<figure>`+`<figcaption>`.