### PR TITLE
Remove link from blog titles

### DIFF
--- a/website/src/components/blog/BlogPost.tsx
+++ b/website/src/components/blog/BlogPost.tsx
@@ -37,9 +37,7 @@ export const BlogPost: React.FunctionComponent<Props> = ({
         <Tag className={`blog-post ${className}`}>
             <header className={headerClassName}>
                 <h1 className={titleClassName}>
-                    <Link to={url} className={`d-block ${titleLinkClassName}`}>
                         {post.frontmatter.title}
-                    </Link>
                 </h1>
                 <p className="blog-post__byline mb-0">
                     {post.frontmatter.author} on {post.frontmatter.publishDate}

--- a/website/src/components/blog/BlogPost.tsx
+++ b/website/src/components/blog/BlogPost.tsx
@@ -36,9 +36,7 @@ export const BlogPost: React.FunctionComponent<Props> = ({
     return (
         <Tag className={`blog-post ${className}`}>
             <header className={headerClassName}>
-                <h1 className={titleClassName}>
-                        {post.frontmatter.title}
-                </h1>
+                <h1 className={titleClassName}>{post.frontmatter.title}</h1>
                 <p className="blog-post__byline mb-0">
                     {post.frontmatter.author} on {post.frontmatter.publishDate}
                 </p>


### PR DESCRIPTION
It has always struck me as odd that the title on our blog post pages is a link to the same blog post 🤔  This is confusing for readers and serves no purpose that I can tell! This PR removes the link from blog post titles.  