### PR TITLE
Add video instructions for team page

### DIFF
--- a/handbook/company/team/index.md
+++ b/handbook/company/team/index.md
@@ -4,6 +4,8 @@ This page contains brief bios of our team. Teammates may also have a personal do
 
 ## Adding Yourself to the Team Page
 
+<div style="position: relative; padding-bottom: 56.25%; height: 0;"><iframe src="https://www.loom.com/embed/d30dc796396b45bc97a12e9cf4377924" frameborder="0" webkitallowfullscreen mozallowfullscreen allowfullscreen style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"></iframe></div>
+
 1. Accept GitHub's email invite to the Sourcegraph org (you should be a member of [the `Everyone` group](https://github.com/orgs/sourcegraph/teams/everyone) in Sourcegraph's GitHub organization).
 1. Go to the bottom right of this page and click "Edit this page."
 1. In the edit view, copy the following template, paste it at the end of the edit view, and make it about yourself! Look at others' bios for examples.


### PR DESCRIPTION
Video explaining how to add yourself to the team page in the handbook