### PR TITLE
Disable Renovate for now

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,6 @@
 {
   "$schema": "http://json.schemastore.org/renovate",
   "extends": ["github>sourcegraph/renovate-config"],
-  "semanticCommits": false
+  "semanticCommits": false,
+  "enabled": false
 }


### PR DESCRIPTION
Nobody is merging these at the moment, so there are way too many open at the same time and being rebased, and they take up build quota in Netlify, which throttles e.g. Handbook previews.

Disabling for now until there are engineers owning keeping dependencies up to date here.
