### PR TITLE
Use SVG for career framework Slack screenshot

### DIFF
--- a/blogposts/2021/career-framework.md
+++ b/blogposts/2021/career-framework.md
@@ -42,7 +42,9 @@ In accordance with our [transparency value](https://handbook.sourcegraph.com/com
 
 Even candidates got a peek at the framework:
 
+<div>
 <object role="image" data="https://sourcegraphstatic.com/blog/engineering-framework-images/nick-slack-message-career-framework.svg" aria-label="Nick, informing the working group via Slack, that he shared our work with a candidate."></object>
+</div>
 
 We united around a passion for career growth. We often spent time talking about the specific, minute wordings of different sentences and bullet points. We considered every sentence and bullet point from multiple angles, asking questions like “What if someone takes this too literally?” and “How do we word this in a way that we don’t encourage the wrong sort of behavior?”
 


### PR DESCRIPTION
This was already accessible thanks to the `sr-only` text, the SVG just make it a sharper image and gives it selectable text.

cc @nickmyyz @rebeccadee 