### PR TITLE
remove jobs redirect to greenhouse

### DIFF
--- a/website/static/_redirects
+++ b/website/static/_redirects
@@ -101,7 +101,6 @@
 /handbook/people-ops/roles/onboarding_teammate_success_manager https://jobs.lever.co/sourcegraph/700949a2-09ce-4de7-b3bd-a5af5032a4a9 301!
 /handbook/people-ops/roles/technical_recruiter_product https://jobs.lever.co/sourcegraph/c1630817-8de1-41e5-b199-00e1664be861 301!
 /handbook/people-ops/roles/recruiter_customer_facing https://jobs.lever.co/sourcegraph/15af1881-2a4d-4c1c-86c2-0e157e4af889 301!
-/jobs https://boards.greenhouse.io/sourcegraph91 301!
 /plan https://handbook.sourcegraph.com/company/strategy 301!
 /press-releases/our-abcs-childrens-book /press-release/our-abcs-childrens-book 301!
 /press-releases/sourcegraph-announces-new-gitlab-native-integration /press-release/sourcegraph-announces-new-gitlab-native-integration 301!


### PR DESCRIPTION
I notice we have an amazing new careers page but i can’t share it with others because it redirects to greenhouse :(