### PR TITLE
Update references of `deploy-sourcegraph-dot-com` to `deploy-sourcegraph-cloud`

### DIFF
--- a/docsite.json
+++ b/docsite.json
@@ -1,5 +1,5 @@
 {
-  "$comment": "This configures the documentation server used in local development only. If you make any substantive changes, also make them to the about-sourcegraph-com.Deployment.yaml file in the deploy-sourcegraph-dot-com repository.",
+  "$comment": "This configures the documentation server used in local development only. If you make any substantive changes, also make them to the about-sourcegraph-com.Deployment.yaml file in the deploy-sourcegraph-cloud repository.",
   "content": ".",
   "contentExcludePattern": "^/(press-releases|podcast|website|blogposts|docs|README\\.md|node_modules)(/|$)",
   "baseURLPath": "/",


### PR DESCRIPTION
The `deploy-sourcegraph-dot-com` repository is being renamed to `deploy-sourcegraph-cloud`. This PR will resolve any references to the old repository.

https://github.com/sourcegraph/sourcegraph/issues/28319

[_Created by Sourcegraph batch change `daniel.dides/update-dot-com-to-cloud`._](https://k8s.sgdev.org/users/daniel.dides/batch-changes/update-dot-com-to-cloud)