### PR TITLE
Fixes broken handbook links on about/about

### DIFF
--- a/website/src/pages/about.tsx
+++ b/website/src/pages/about.tsx
@@ -54,7 +54,8 @@ export default class About extends React.Component<any, any> {
                                 <p>
                                     The <Link to="https://handbook.sourcegraph.com">Sourcegraph handbook</Link> has
                                     everything from our high-level{' '}
-                                    <Link to="https://handbook.sourcegraph.com/strategy-goals/strategy">strategy</Link> and{` `}
+                                    <Link to="https://handbook.sourcegraph.com/strategy-goals/strategy">strategy</Link>{' '}
+                                    and{` `}
                                     <Link to="https://handbook.sourcegraph.com/company/values">values</Link>, to
                                     documentation of business processes including{' '}
                                     <Link to="https://handbook.sourcegraph.com/marketing/messaging">messaging</Link> and{' '}

--- a/website/src/pages/about.tsx
+++ b/website/src/pages/about.tsx
@@ -54,12 +54,11 @@ export default class About extends React.Component<any, any> {
                                 <p>
                                     The <Link to="https://handbook.sourcegraph.com">Sourcegraph handbook</Link> has
                                     everything from our high-level{' '}
-                                    <Link to="https://handbook.sourcegraph.com/company/strategy">strategy</Link>,{' '}
-                                    <Link to="https://handbook.sourcegraph.com/direction">product direction</Link>, and{' '}
+                                    <Link to="https://handbook.sourcegraph.com/strategy-goals/strategy">strategy</Link> and{` `}
                                     <Link to="https://handbook.sourcegraph.com/company/values">values</Link>, to
                                     documentation of business processes including{' '}
                                     <Link to="https://handbook.sourcegraph.com/marketing/messaging">messaging</Link> and{' '}
-                                    <Link to="/https://handbook.sourcegraph.com/engineering#guiding-principles">
+                                    <Link to="https://handbook.sourcegraph.com/departments/product-engineering/engineering/process/principles-and-practices">
                                         engineering principles
                                     </Link>
                                     . It's public for everyone to read because we are{' '}


### PR DESCRIPTION
### What should this PR do?

This fixes #5064 due to some broken links pointing towards the handbook.

The Direction and Strategy page were combined into a single Strategy page in sourcegraph/handbook#287 so I've updated the new links accordingly.

### What are the acceptance criteria?

The links should point to the corresponding pages.

### How should this PR be tested?

Check the preview link and test that the links point to the corresponding pages.