### PR TITLE
Relocate RSS feed for blog

### DIFF
--- a/website/gatsby-config.js
+++ b/website/gatsby-config.js
@@ -154,15 +154,8 @@ module.exports = {
                 }
               }
             `,
-            output: '/rss.xml',
+            output: '/blog/rss.xml',
             title: 'Sourcegraph blog RSS feed',
-            // optional configuration to insert feed reference in pages:
-            // if `string` is used, it will be used to create RegExp and then test if pathname of
-            // current page satisfied this regular expression;
-            // if not provided or `undefined`, all pages will have feed reference inserted
-            match: '^/blog/',
-            // optional configuration to specify external rss feed, such as feedburner
-            link: 'https://feeds.feedburner.com/sourcegraph/blog',
           },
         ],
       },


### PR DESCRIPTION
Closes #5067 by relocating RSS feed. The feed functionality was already there, but it seems like the ask was for it to not be at the root of the site.