### PR TITLE
Integrate Drift

### DIFF
--- a/website/src/html.tsx
+++ b/website/src/html.tsx
@@ -105,7 +105,37 @@ export default class HTML extends React.Component<HtmlProps> {
                     />
 
                     {/* Drift Integration */}
-                    {/* TODO: Add our Drift unique code snippet here */}
+                    <script
+                        type="text/javascript"
+                        dangerouslySetInnerHTML={{
+                            __html: `
+                                "use strict";
+
+                                !function() {
+                                var t = window.driftt = window.drift = window.driftt || [];
+                                if (!t.init) {
+                                    if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+                                    t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ], 
+                                    t.factory = function(e) {
+                                    return function() {
+                                        var n = Array.prototype.slice.call(arguments);
+                                        return n.unshift(e), t.push(n), t;
+                                    };
+                                    }, t.methods.forEach(function(e) {
+                                    t[e] = t.factory(e);
+                                    }), t.load = function(t) {
+                                    var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+                                    o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+                                    var i = document.getElementsByTagName("script")[0];
+                                    i.parentNode.insertBefore(o, i);
+                                    };
+                                }
+                                }();
+                                drift.SNIPPET_VERSION = '0.3.1';
+                                drift.load('bgv3pp29xsp9');
+                            `
+                        }}
+                    />
                 </head>
                 <body>
                     {/* Google Tag Manager (noscript) */}

--- a/website/src/html.tsx
+++ b/website/src/html.tsx
@@ -133,7 +133,7 @@ export default class HTML extends React.Component<HtmlProps> {
                                 }();
                                 drift.SNIPPET_VERSION = '0.3.1';
                                 drift.load('bgv3pp29xsp9');
-                            `
+                            `,
                         }}
                     />
                 </head>

--- a/website/src/html.tsx
+++ b/website/src/html.tsx
@@ -103,6 +103,9 @@ export default class HTML extends React.Component<HtmlProps> {
                         `,
                         }}
                     />
+
+                    {/* Drift Integration */}
+                    {/* TODO: Add our Drift unique code snippet here */}
                 </head>
                 <body>
                     {/* Google Tag Manager (noscript) */}


### PR DESCRIPTION
## What should this PR do?

Closes #5142 and integrates Drift.

## Test plan

1. View preview link and check if `window.drift` is available in the console

### Optional:
1. Sign into Drift with 1P shared credentials
2. Go to [settings](https://app.drift.com/settings2/widget) and enable Drift icon visibility
3. Test chat functionality 💬 
4. Disable icon visibility (until we're ready to enable)