### PR TITLE
Add tracking for buttons

### DIFF
--- a/website/src/components/Header.tsx
+++ b/website/src/components/Header.tsx
@@ -126,7 +126,9 @@ export default class Header extends React.Component<HeaderProps, any> {
                                     )}
 
                                     <Nav.Link
-                                        className="btn btn-outline-primary ml-3 px-5 py-2"
+                                        className="btn btn-outline-primary ml-3 px-5 py-2 cta-btn"
+                                        data-button-style="2"
+                                        data-button-location="1"
                                         href="https://info.sourcegraph.com/demo-request"
                                         title="Request a demo"
                                     >
@@ -136,6 +138,8 @@ export default class Header extends React.Component<HeaderProps, any> {
                                     {!this.props.hideGetStartedButton && (
                                         <Nav.Link
                                             className="btn btn-primary ml-3 px-5 py-2"
+                                            data-button-style="1"
+                                            data-button-location="1"
                                             href="/get-started"
                                             title="Get started"
                                         >

--- a/website/src/components/SelfHostedSection.tsx
+++ b/website/src/components/SelfHostedSection.tsx
@@ -14,7 +14,12 @@ export const SelfHostedSection: FunctionComponent = () => (
                     <Install />
 
                     <p>
-                        <a className="d-inline-flex mt-5 font-weight-bold" href="https://docs.sourcegraph.com">
+                        <a 
+                            className="d-inline-flex mt-5 font-weight-bold" 
+                            href="https://docs.sourcegraph.com"
+                            data-button-style="3"
+                            data-button-location="4"
+                        >
                             Deploy to a server or cluster <ArrowRightIcon className="ml-1" />
                         </a>
                     </p>
@@ -24,6 +29,8 @@ export const SelfHostedSection: FunctionComponent = () => (
                     <a
                         className="btn btn-primary d-inline-flex"
                         href="https://info.sourcegraph.com/talk-to-a-developer"
+                        data-button-style="1"
+                        data-button-location="4"
                     >
                         Talk to an engineer <ArrowRightIcon className="ml-1" />
                     </a>
@@ -39,7 +46,12 @@ export const SelfHostedSection: FunctionComponent = () => (
                         <li>Free trial for enterprise features</li>
                     </ul>
 
-                    <a className="d-inline-flex font-weight-bold" href="/get-started">
+                    <a 
+                        className="d-inline-flex font-weight-bold" 
+                        href="/get-started"
+                        data-button-style="3"
+                        data-button-location="4"
+                    >
                         Learn about self-hosted vs.Cloud features <ArrowRightIcon className="ml-1" />
                     </a>
                 </div>

--- a/website/src/components/SelfHostedSection.tsx
+++ b/website/src/components/SelfHostedSection.tsx
@@ -14,8 +14,8 @@ export const SelfHostedSection: FunctionComponent = () => (
                     <Install />
 
                     <p>
-                        <a 
-                            className="d-inline-flex mt-5 font-weight-bold" 
+                        <a
+                            className="d-inline-flex mt-5 font-weight-bold"
                             href="https://docs.sourcegraph.com"
                             data-button-style="3"
                             data-button-location="4"
@@ -46,8 +46,8 @@ export const SelfHostedSection: FunctionComponent = () => (
                         <li>Free trial for enterprise features</li>
                     </ul>
 
-                    <a 
-                        className="d-inline-flex font-weight-bold" 
+                    <a
+                        className="d-inline-flex font-weight-bold"
                         href="/get-started"
                         data-button-style="3"
                         data-button-location="4"

--- a/website/src/components/TrySourcegraph.tsx
+++ b/website/src/components/TrySourcegraph.tsx
@@ -17,17 +17,17 @@ export const TrySourcegraph: React.FunctionComponent<{ demoFormURL?: string; cla
             </div>
             <div className="col-md-6 pt-3 align-self-center text-center">
                 {demoFormURL !== '' && (
-                    <Link 
+                    <Link
                         className="btn btn-outline-secondary mx-2 mb-3"
                         data-button-style="2"
                         data-button-location="4"
-                        to={demoFormURL} 
+                        to={demoFormURL}
                         title="Request a demo"
                     >
                         Schedule a demo
                     </Link>
                 )}
-                <Link 
+                <Link
                     className="btn btn-primary mx-2 mb-3"
                     data-button-style="1"
                     data-button-location="4"

--- a/website/src/components/TrySourcegraph.tsx
+++ b/website/src/components/TrySourcegraph.tsx
@@ -17,11 +17,23 @@ export const TrySourcegraph: React.FunctionComponent<{ demoFormURL?: string; cla
             </div>
             <div className="col-md-6 pt-3 align-self-center text-center">
                 {demoFormURL !== '' && (
-                    <Link className="btn btn-outline-secondary mx-2 mb-3" to={demoFormURL} title="Request a demo">
+                    <Link 
+                        className="btn btn-outline-secondary mx-2 mb-3"
+                        data-button-style="2"
+                        data-button-location="4"
+                        to={demoFormURL} 
+                        title="Request a demo"
+                    >
                         Schedule a demo
                     </Link>
                 )}
-                <Link className="btn btn-primary mx-2 mb-3" to="/#get-started" title="Try Sourcegraph now">
+                <Link 
+                    className="btn btn-primary mx-2 mb-3"
+                    data-button-style="1"
+                    data-button-location="4"
+                    to="/#get-started"
+                    title="Try Sourcegraph now"
+                >
                     Try Sourcegraph now
                 </Link>
             </div>

--- a/website/src/components/content/CaseStudyPage.tsx
+++ b/website/src/components/content/CaseStudyPage.tsx
@@ -148,11 +148,11 @@ export const CaseStudyRequestDemoForm: React.FunctionComponent<{
         <div className="container text-center pt-6">
             <h3 className="display-3 font-weight-bold">{title}</h3>
             <p>{description}</p>
-            <Link 
+            <Link
                 className="btn btn-primary mx-2 mb-3"
                 data-button-style="1"
                 data-button-location="4"
-                to={demoFormURL} 
+                to={demoFormURL}
                 title="Request a demo"
             >
                 Schedule a demo

--- a/website/src/components/content/CaseStudyPage.tsx
+++ b/website/src/components/content/CaseStudyPage.tsx
@@ -148,7 +148,13 @@ export const CaseStudyRequestDemoForm: React.FunctionComponent<{
         <div className="container text-center pt-6">
             <h3 className="display-3 font-weight-bold">{title}</h3>
             <p>{description}</p>
-            <Link className="btn btn-primary mx-2 mb-3" to={demoFormURL} title="Request a demo">
+            <Link 
+                className="btn btn-primary mx-2 mb-3"
+                data-button-style="1"
+                data-button-location="4"
+                to={demoFormURL} 
+                title="Request a demo"
+            >
                 Schedule a demo
             </Link>
         </div>

--- a/website/src/components/product/CustomerLogosSectionAnimated.tsx
+++ b/website/src/components/product/CustomerLogosSectionAnimated.tsx
@@ -400,8 +400,8 @@ export const CustomerLogosSectionAnimated: React.FC<Props> = ({ showButton, clas
             {!showButton && (
                 <div className="row justify-content-center">
                     <div className="col-lg-6 text-center mt-2">
-                        <a 
-                            href="https://info.sourcegraph.com/demo-request" 
+                        <a
+                            href="https://info.sourcegraph.com/demo-request"
                             className="btn btn-outline-primary"
                             data-button-style="5"
                             data-button-location="3"

--- a/website/src/components/product/CustomerLogosSectionAnimated.tsx
+++ b/website/src/components/product/CustomerLogosSectionAnimated.tsx
@@ -400,7 +400,12 @@ export const CustomerLogosSectionAnimated: React.FC<Props> = ({ showButton, clas
             {!showButton && (
                 <div className="row justify-content-center">
                     <div className="col-lg-6 text-center mt-2">
-                        <a href="https://info.sourcegraph.com/demo-request" className="btn btn-outline-primary">
+                        <a 
+                            href="https://info.sourcegraph.com/demo-request" 
+                            className="btn btn-outline-primary"
+                            data-button-style="5"
+                            data-button-location="3"
+                        >
                             Schedule a demo <ArrowRightBoxIcon className="icon-inline ml-1" />
                         </a>
                     </div>

--- a/website/src/pages/batch-changes.tsx
+++ b/website/src/pages/batch-changes.tsx
@@ -47,7 +47,13 @@ export const BatchChangesPage: React.FunctionComponent<PageProps> = props => (
                             Keep your code up to date, fix critical security issues, and pay down tech debt across all
                             of your repositories with Batch Changes.
                         </p>
-                        <Link className="btn btn-primary" to={batchChangesDemoFormURL} title="Request a demo">
+                        <Link 
+                            className="btn btn-primary" 
+                            to={batchChangesDemoFormURL} 
+                            title="Request a demo"
+                            data-button-style="1"
+                            data-button-location="1"
+                        >
                             Request a demo
                         </Link>
                     </div>

--- a/website/src/pages/batch-changes.tsx
+++ b/website/src/pages/batch-changes.tsx
@@ -47,9 +47,9 @@ export const BatchChangesPage: React.FunctionComponent<PageProps> = props => (
                             Keep your code up to date, fix critical security issues, and pay down tech debt across all
                             of your repositories with Batch Changes.
                         </p>
-                        <Link 
-                            className="btn btn-primary" 
-                            to={batchChangesDemoFormURL} 
+                        <Link
+                            className="btn btn-primary"
+                            to={batchChangesDemoFormURL}
                             title="Request a demo"
                             data-button-style="1"
                             data-button-location="2"

--- a/website/src/pages/batch-changes.tsx
+++ b/website/src/pages/batch-changes.tsx
@@ -52,7 +52,7 @@ export const BatchChangesPage: React.FunctionComponent<PageProps> = props => (
                             to={batchChangesDemoFormURL} 
                             title="Request a demo"
                             data-button-style="1"
-                            data-button-location="1"
+                            data-button-location="2"
                         >
                             Request a demo
                         </Link>

--- a/website/src/pages/cloud-beta.tsx
+++ b/website/src/pages/cloud-beta.tsx
@@ -61,6 +61,8 @@ export const CloudBetaPage: React.FunctionComponent<PageProps> = props => (
                         </p>
                         <a
                             className="btn btn-primary join-the-watilist-hero-btn"
+                            data-button-style="1"
+                            data-button-location="2"
                             href="https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku"
                         >
                             Join the waitlist <ArrowRightIcon className="ml-1" />
@@ -118,7 +120,12 @@ export const CloudBetaPage: React.FunctionComponent<PageProps> = props => (
                             <li>Are ready to experience the power of code search</li>
                         </ul>
                     </div>
-                    <a className="btn btn-primary" href="https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku">
+                    <a 
+                        className="btn btn-primary"
+                        data-button-style="1"
+                        data-button-location="4"
+                        href="https://share.hsforms.com/14OQ3RoPpQTOXvZlUpgx6-A1n7ku"
+                    >
                         Join the waitlist <ArrowRightIcon className="ml-1" />
                     </a>
                 </div>

--- a/website/src/pages/cloud-beta.tsx
+++ b/website/src/pages/cloud-beta.tsx
@@ -120,7 +120,7 @@ export const CloudBetaPage: React.FunctionComponent<PageProps> = props => (
                             <li>Are ready to experience the power of code search</li>
                         </ul>
                     </div>
-                    <a 
+                    <a
                         className="btn btn-primary"
                         data-button-style="1"
                         data-button-location="4"

--- a/website/src/pages/code-search.tsx
+++ b/website/src/pages/code-search.tsx
@@ -31,6 +31,8 @@ export const CodeSearchPage: FunctionComponent<PageProps> = props => (
                         <div className="pt-1">
                             <Link
                                 className="btn btn-primary mr-3"
+                                data-button-style="1"
+                                data-button-location="1"
                                 to="#get-started"
                                 title="Use this if you want to search your (or your company's) code, invite teammates, and try all the features."
                             >
@@ -38,6 +40,8 @@ export const CodeSearchPage: FunctionComponent<PageProps> = props => (
                             </Link>
                             <a
                                 className="btn btn-outline-primary my-3"
+                                data-button-style="2"
+                                data-button-location="1"
                                 href="https://sourcegraph.com/search"
                                 title="Use this if you want to search across top open source repositories (or add your own projects)."
                             >

--- a/website/src/pages/code-search.tsx
+++ b/website/src/pages/code-search.tsx
@@ -32,7 +32,7 @@ export const CodeSearchPage: FunctionComponent<PageProps> = props => (
                             <Link
                                 className="btn btn-primary mr-3"
                                 data-button-style="1"
-                                data-button-location="1"
+                                data-button-location="2"
                                 to="#get-started"
                                 title="Use this if you want to search your (or your company's) code, invite teammates, and try all the features."
                             >
@@ -41,7 +41,7 @@ export const CodeSearchPage: FunctionComponent<PageProps> = props => (
                             <a
                                 className="btn btn-outline-primary my-3"
                                 data-button-style="2"
-                                data-button-location="1"
+                                data-button-location="2"
                                 href="https://sourcegraph.com/search"
                                 title="Use this if you want to search across top open source repositories (or add your own projects)."
                             >

--- a/website/src/pages/community.tsx
+++ b/website/src/pages/community.tsx
@@ -29,6 +29,8 @@ export const CommunityPage: React.FunctionComponent<PageProps> = props => (
                         </p>
                         <a
                             className="btn btn-primary"
+                            data-button-style="1"
+                            data-button-location="2"
                             href={
                                 'https://join.slack.com/t/sourcegraph-community/shared_invite/zt-w11gottx-c0PYTK69YVW_06tpJZ0bOQ'
                             }
@@ -233,6 +235,8 @@ export const CommunityPage: React.FunctionComponent<PageProps> = props => (
                 <div className="col-lg-5 mt-3">
                     <a
                         className="btn btn-secondary"
+                        data-button-style="1"
+                        data-button-location="4"
                         href={
                             'https://join.slack.com/t/sourcegraph-community/shared_invite/zt-w11gottx-c0PYTK69YVW_06tpJZ0bOQ'
                         }
@@ -243,6 +247,8 @@ export const CommunityPage: React.FunctionComponent<PageProps> = props => (
                     <br />
                     <a
                         className="btn btn-primary mt-3"
+                        data-button-style="1"
+                        data-button-location="4"
                         href={'mailto:community@sourcegraph.com'}
                         title="Send us an email"
                     >

--- a/website/src/pages/get-started/cloud.tsx
+++ b/website/src/pages/get-started/cloud.tsx
@@ -61,7 +61,12 @@ export const CloudPage: FunctionComponent<PageProps> = props => {
                             <div className={`bg-white rounded p-5 ${navigatedFromProduct ? 'mt-5' : 'mb-5'}`}>
                                 <h3 className="mb-3">Search open source code</h3>
                                 <p className="mb-5">No account required.</p>
-                                <a href="https://sourcegraph.com/search" className="btn btn-primary">
+                                <a 
+                                    href="https://sourcegraph.com/search" 
+                                    className="btn btn-primary"
+                                    data-button-style="1"
+                                    data-button-location="2"
+                                >
                                     Start searching now <ArrowRightIcon />
                                 </a>
                             </div>

--- a/website/src/pages/get-started/cloud.tsx
+++ b/website/src/pages/get-started/cloud.tsx
@@ -61,8 +61,8 @@ export const CloudPage: FunctionComponent<PageProps> = props => {
                             <div className={`bg-white rounded p-5 ${navigatedFromProduct ? 'mt-5' : 'mb-5'}`}>
                                 <h3 className="mb-3">Search open source code</h3>
                                 <p className="mb-5">No account required.</p>
-                                <a 
-                                    href="https://sourcegraph.com/search" 
+                                <a
+                                    href="https://sourcegraph.com/search"
                                     className="btn btn-primary"
                                     data-button-style="1"
                                     data-button-location="2"

--- a/website/src/pages/get-started/index.tsx
+++ b/website/src/pages/get-started/index.tsx
@@ -19,7 +19,7 @@ export const BestForTitle: FunctionComponent = () => (
 
 export const GetStartedPage: FunctionComponent<PageProps> = props => {
     const GetStartedCTA: FunctionComponent<{ href: string }> = ({ href }) => (
-        <Link 
+        <Link
             className="btn btn-primary my-2"
             data-button-style="1"
             data-button-location="2"

--- a/website/src/pages/get-started/index.tsx
+++ b/website/src/pages/get-started/index.tsx
@@ -19,7 +19,12 @@ export const BestForTitle: FunctionComponent = () => (
 
 export const GetStartedPage: FunctionComponent<PageProps> = props => {
     const GetStartedCTA: FunctionComponent<{ href: string }> = ({ href }) => (
-        <Link className="btn btn-primary my-2" to={`${href}${props.location.search}`}>
+        <Link 
+            className="btn btn-primary my-2"
+            data-button-style="1"
+            data-button-location="2"
+            to={`${href}${props.location.search}`}
+        >
             Get started for free <ArrowRightIcon />
         </Link>
     )

--- a/website/src/pages/get-started/self-hosted.tsx
+++ b/website/src/pages/get-started/self-hosted.tsx
@@ -69,12 +69,19 @@ export const SelfHostedPage: FunctionComponent<PageProps> = props => (
                     <div className="d-flex flex-column align-items-start">
                         <a
                             className="btn p-0 my-4 text-primary"
+                            data-button-style="3"
+                            data-button-location="2"
                             href="https://info.sourcegraph.com/talk-to-a-developer"
                         >
                             Talk to an engineer <ArrowRightIcon />
                         </a>
 
-                        <a className="btn p-0 text-primary" href="https://docs.sourcegraph.com/">
+                        <a 
+                            className="btn p-0 text-primary" 
+                            data-button-style="3"
+                            data-button-location="2"
+                            href="https://docs.sourcegraph.com/"
+                        >
                             Deploy to a server or cluster <ArrowRightIcon />
                         </a>
                     </div>

--- a/website/src/pages/get-started/self-hosted.tsx
+++ b/website/src/pages/get-started/self-hosted.tsx
@@ -76,8 +76,8 @@ export const SelfHostedPage: FunctionComponent<PageProps> = props => (
                             Talk to an engineer <ArrowRightIcon />
                         </a>
 
-                        <a 
-                            className="btn p-0 text-primary" 
+                        <a
+                            className="btn p-0 text-primary"
                             data-button-style="3"
                             data-button-location="2"
                             href="https://docs.sourcegraph.com/"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -23,11 +23,19 @@ const Index: React.FunctionComponent = (props: any) => (
                                 security risks, root-cause incidents, and more.
                             </p>
                             <div className="pt-1">
-                                <Link className="btn btn-primary m-3" to="/get-started" title="Get started">
+                                <Link 
+                                    className="btn btn-primary m-3" 
+                                    to="/get-started" 
+                                    title="Get started"
+                                    data-button-style="1"
+                                    data-button-location="1"
+                                >
                                     Get started <ArrowRightIcon className="ml-1" />
                                 </Link>
                                 <a
                                     className="btn btn-outline-primary m-3"
+                                    data-button-style="2"
+                                    data-button-location="1"
                                     href="https://info.sourcegraph.com/demo-request"
                                     title="Request a demo"
                                 >

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -23,9 +23,9 @@ const Index: React.FunctionComponent = (props: any) => (
                                 security risks, root-cause incidents, and more.
                             </p>
                             <div className="pt-1">
-                                <Link 
-                                    className="btn btn-primary m-3" 
-                                    to="/get-started" 
+                                <Link
+                                    className="btn btn-primary m-3"
+                                    to="/get-started"
                                     title="Get started"
                                     data-button-style="1"
                                     data-button-location="2"

--- a/website/src/pages/index.tsx
+++ b/website/src/pages/index.tsx
@@ -28,14 +28,14 @@ const Index: React.FunctionComponent = (props: any) => (
                                     to="/get-started" 
                                     title="Get started"
                                     data-button-style="1"
-                                    data-button-location="1"
+                                    data-button-location="2"
                                 >
                                     Get started <ArrowRightIcon className="ml-1" />
                                 </Link>
                                 <a
                                     className="btn btn-outline-primary m-3"
                                     data-button-style="2"
-                                    data-button-location="1"
+                                    data-button-location="2"
                                     href="https://info.sourcegraph.com/demo-request"
                                     title="Request a demo"
                                 >

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -251,7 +251,13 @@ export default ((props: any) => (
                         </p>
                     </div>
                     <div className="col-md-6 pt-3 align-self-center text-center">
-                        <Link className="btn btn-primary mx-2 mb-3" to="../#get-started" title="Try Sourcegraph now">
+                        <Link 
+                            className="btn btn-primary mx-2 mb-3"
+                            data-button-style="1"
+                            data-button-location="4"
+                            to="../#get-started" 
+                            title="Try Sourcegraph now"
+                        >
                             Try Sourcegraph now
                         </Link>
                     </div>

--- a/website/src/pages/pricing.tsx
+++ b/website/src/pages/pricing.tsx
@@ -251,11 +251,11 @@ export default ((props: any) => (
                         </p>
                     </div>
                     <div className="col-md-6 pt-3 align-self-center text-center">
-                        <Link 
+                        <Link
                             className="btn btn-primary mx-2 mb-3"
                             data-button-style="1"
                             data-button-location="4"
-                            to="../#get-started" 
+                            to="../#get-started"
                             title="Try Sourcegraph now"
                         >
                             Try Sourcegraph now

--- a/website/src/pages/use-cases.tsx
+++ b/website/src/pages/use-cases.tsx
@@ -35,22 +35,41 @@ export default ((props: any) => (
                             <Link
                                 to="#find-and-fix-security-vulnerabilities"
                                 className="list-group-item list-group-item-action"
+                                data-button-style="3"
+                                data-button-location="2"
                             >
                                 Find and fix security vulnerabilities <ArrowRightIcon className="icon-inline ml-1" />
                             </Link>
                             <Link
                                 to="#accelerate-developer-onboarding"
                                 className="list-group-item list-group-item-action"
+                                data-button-style="3"
+                                data-button-location="2"
                             >
                                 Accelerate developer onboarding <ArrowRightIcon className="icon-inline ml-1" />
                             </Link>
-                            <Link to="#resolve-incidents-faster" className="list-group-item list-group-item-action">
+                            <Link 
+                                to="#resolve-incidents-faster" 
+                                className="list-group-item list-group-item-action"
+                                data-button-style="3"
+                                data-button-location="2"
+                            >
                                 Resolve incidents faster <ArrowRightIcon className="icon-inline ml-1" />
                             </Link>
-                            <Link to="#streamline-code-reuse" className="list-group-item list-group-item-action">
+                            <Link 
+                                to="#streamline-code-reuse" 
+                                className="list-group-item list-group-item-action"
+                                data-button-style="3"
+                                data-button-location="2"
+                            >
                                 Streamline code reuse <ArrowRightIcon className="icon-inline ml-1" />
                             </Link>
-                            <Link to="#boost-code-health" className="list-group-item list-group-item-action">
+                            <Link 
+                                to="#boost-code-health" 
+                                className="list-group-item list-group-item-action"
+                                data-button-style="3"
+                                data-button-location="2"
+                            >
                                 Boost code health <ArrowRightIcon className="icon-inline ml-1" />
                             </Link>
                         </div>
@@ -86,6 +105,8 @@ export default ((props: any) => (
                             to="https://info.sourcegraph.com/demo-request"
                             title="Request a demo"
                             className="btn btn-outline-primary"
+                            data-button-style="5"
+                            data-button-location="3"
                         >
                             Request a demo <ArrowRightBoxIcon className="icon-inline ml-1" />
                         </Link>
@@ -157,6 +178,8 @@ export default ((props: any) => (
                             to="https://info.sourcegraph.com/demo-request"
                             title="Request a demo"
                             className="btn btn-outline-primary"
+                            data-button-style="5"
+                            data-button-location="3"
                         >
                             Request a demo <ArrowRightBoxIcon className="icon-inline ml-1" />
                         </Link>
@@ -195,6 +218,8 @@ export default ((props: any) => (
                             to="https://info.sourcegraph.com/demo-request"
                             title="Request a demo"
                             className="btn btn-outline-primary"
+                            data-button-style="5"
+                            data-button-location="3"
                         >
                             Request a demo <ArrowRightBoxIcon className="icon-inline ml-1" />
                         </Link>
@@ -262,6 +287,8 @@ export default ((props: any) => (
                             to="https://info.sourcegraph.com/demo-request"
                             title="Request a demo"
                             className="btn btn-outline-primary"
+                            data-button-style="5"
+                            data-button-location="3"
                         >
                             Request a demo <ArrowRightBoxIcon className="icon-inline ml-1" />
                         </Link>
@@ -299,6 +326,8 @@ export default ((props: any) => (
                             to="https://info.sourcegraph.com/demo-request"
                             title="Request a demo"
                             className="btn btn-outline-primary"
+                            data-button-style="5"
+                            data-button-location="3"
                         >
                             Request a demo <ArrowRightBoxIcon className="icon-inline ml-1" />
                         </Link>

--- a/website/src/pages/use-cases.tsx
+++ b/website/src/pages/use-cases.tsx
@@ -48,24 +48,24 @@ export default ((props: any) => (
                             >
                                 Accelerate developer onboarding <ArrowRightIcon className="icon-inline ml-1" />
                             </Link>
-                            <Link 
-                                to="#resolve-incidents-faster" 
+                            <Link
+                                to="#resolve-incidents-faster"
                                 className="list-group-item list-group-item-action"
                                 data-button-style="3"
                                 data-button-location="2"
                             >
                                 Resolve incidents faster <ArrowRightIcon className="icon-inline ml-1" />
                             </Link>
-                            <Link 
-                                to="#streamline-code-reuse" 
+                            <Link
+                                to="#streamline-code-reuse"
                                 className="list-group-item list-group-item-action"
                                 data-button-style="3"
                                 data-button-location="2"
                             >
                                 Streamline code reuse <ArrowRightIcon className="icon-inline ml-1" />
                             </Link>
-                            <Link 
-                                to="#boost-code-health" 
+                            <Link
+                                to="#boost-code-health"
                                 className="list-group-item list-group-item-action"
                                 data-button-style="3"
                                 data-button-location="2"


### PR DESCRIPTION
Closes #5108 by adding tracking for buttons on the site. For more info about the data attributes, check out the discussion (with screenshots) in [this doc](https://docs.google.com/document/d/1Q1JMzyRmwNKk65KxxtT9EOnxoSf2dHEGkUAPbJkKzI4).

Note that this does **not** add tracking on GA. This will still need to happen.

Tl;dr on the schema in use for this PR:
**data-button-style**:
1 — Bootstrap primary button
2 — Bootstrap outline button
3 — ArrowRightIcon with text
4 — ArrowRightBoxIcon with text
5 — Bootstrap outline button with ArrowRightBoxIcon on the inside

**data-button-location**:
1 — Nav
2 — Hero
3 — Body (for body CTAs, we are only tracking calls to demo Sourcegraph. See the discussion doc for more details).
4 — ”Try Sourcegraph” sections. The sections that offer different callouts to try Sourcegraph, above the footer.

Pages that do not have tracking (but please let me know if they should!):
- `/jobs`
- `/resources/abcs-ebook`
- `/white-papers/remote-work-easier`

## To Test
- Navigate to some of the pages updated in the PR and check that the data attributes have been added.
