### PR TITLE
Ignore insights self-hosted video from Cookiebot

### DIFF
--- a/website/src/pages/code-insights.tsx
+++ b/website/src/pages/code-insights.tsx
@@ -340,6 +340,8 @@ export const CodeInsightsPage: React.FunctionComponent<PageProps> = props => (
                         loop={true}
                         playsInline={true}
                         controls={false}
+                        // GCS does not set cookies, so we don't want Cookiebot to block this video based on consent
+                        data-cookieconsent="ignore"
                     >
                         <source
                             type="video/webm"


### PR DESCRIPTION
Cookiebot blocks cross-domain videos by default until consent is given because videos _might_ set cookies. This breaks the animation from autoplaying on the first page visit. However, we know that GCS does not set cookies (Cookiebot just doesn't know) and it's not an iframe so it can't use local storage, so we can safely disable the blocking for this video.