### PR TITLE
Put ignore tag on the right element

### DIFF
--- a/website/src/pages/code-insights.tsx
+++ b/website/src/pages/code-insights.tsx
@@ -346,10 +346,12 @@ export const CodeInsightsPage: React.FunctionComponent<PageProps> = props => (
                         <source
                             type="video/webm"
                             src="https://storage.googleapis.com/sourcegraph-assets/code_insights/code-insights-720.webm"
+                            data-cookieconsent="ignore"
                         />
                         <source
                             type="video/mp4"
                             src="https://storage.googleapis.com/sourcegraph-assets/code_insights/code-insights-720.mp4"
+                            data-cookieconsent="ignore"
                         />
                     </video>
                 </div>


### PR DESCRIPTION
The `<source>` tag is what has the `src` attribute, so they need to be tagged too I think (wasn't working yet).