### PR TITLE
HubSpot/ChiliPiper multi-form bug fix

### DIFF
--- a/website/src/hooks/hubSpot.ts
+++ b/website/src/hooks/hubSpot.ts
@@ -69,10 +69,10 @@ const loadHubSpotScript = (): HTMLScriptElement => {
     const script = document.querySelector(`script[src="${hubSpotScript}"]`)
     const scriptElement = document.createElement('script')
     scriptElement.src = hubSpotScript
-    if (!script) {        
+    if (!script) {
         document.head.append(scriptElement)
         return scriptElement
-    } else {        
+    } else {
         return script
     }
 }
@@ -90,11 +90,11 @@ const loadChiliPiperScript = (cb: Function): void => {
 
 function createHubSpotForm({ region, portalId, formId, targetId, onFormSubmit, onFormReady }: HubSpotForm): void {
     const getAllCookies: { [index: string]: string } = document.cookie
-    .split(';')
-    .reduce((key, string) => Object.assign(key, { [string.split('=')[0].trim()]: string.split('=')[1] }), {})
+        .split(';')
+        .reduce((key, string) => Object.assign(key, { [string.split('=')[0].trim()]: string.split('=')[1] }), {})
     const anonymousId = getAllCookies.sourcegraphAnonymousUid
     const firstSourceURL = getAllCookies.sourcegraphSourceUrl
-    
+
     const script = loadHubSpotScript()
     script?.addEventListener('load', () => {
         ;(window as Window).hbspt?.forms.create({


### PR DESCRIPTION
### What should this PR do?

This fixes a bug where HubSpot and ChiliPiper would have unexpected loading results due to the scripts being loaded more than once on the same page. This caused the ChiliPiper scheduler to hang ([noted here](https://github.com/sourcegraph/about/issues/5106#issuecomment-1072883997)).

This solution improves the ability to have [multiple HubSpot forms](https://github.com/sourcegraph/about/pull/5179/files#diff-eed8c0ceaaee7bcf8769e4a7cb2dce59af170c8e1a48c27aef3695fd88004de4R9-R11) of the same type on a single page where designs request it.

### How to test

Check out the following pages:
- /fixing-vulnerabilities
- /accelerate-developer-onboarding

Test each form with `yourEmailPrefix+testing@sourcegraph.com and ensure the form submits and the ChiliPiper scheduler displays in a modal and doesn't hang with a loader.