### PR TITLE
Fix footer copyright date

### DIFF
--- a/website/src/components/Footer.tsx
+++ b/website/src/components/Footer.tsx
@@ -166,7 +166,7 @@ export const Footer: FunctionComponent<Props> = ({ minimal, className }) => (
             )}
             <div className="footer__postscript d-flex justify-content-between pt-4 pb-2 small">
                 <ul className="nav">
-                    <li className="nav-item text-muted mr-3">&copy; 2021 Sourcegraph</li>
+                    <li className="nav-item text-muted mr-3">&copy; {new Date().getFullYear()} Sourcegraph</li>
                     <li className="nav-item">
                         <Link to="/terms" className="nav-link">
                             Terms


### PR DESCRIPTION
Fixes the footer copyright date to always be the current year.

Closes #5215

---

### Test
1. Check the preview link
2. Ensure the footer shows the current year