### PR TITLE
HubSpot Hook API Fix

### DIFF
--- a/website/src/hooks/hubSpot.ts
+++ b/website/src/hooks/hubSpot.ts
@@ -126,7 +126,7 @@ function createHubSpotForm({
 
     const script = loadHubSpotScript()
     script?.addEventListener('load', () => {
-        ;(window as Window).hbspt?.forms.create({
+        window.hbspt?.forms.create({
             region: region || 'na1',
             portalId,
             formId,
@@ -170,6 +170,8 @@ export const useHubSpot = ({ region, portalId, formId, targetId, chiliPiper, onF
     useEffect(() => {
         if (Array.isArray(targetId)) {
             for (const id of targetId) {
+                console.log(`id: ${id}`);
+                
                 createHubSpotForm({
                     region,
                     portalId,

--- a/website/src/hooks/hubSpot.ts
+++ b/website/src/hooks/hubSpot.ts
@@ -68,7 +68,7 @@ interface HubSpotForm {
     [index: number]: HTMLFormElement
     portalId: string
     formId: string
-    targetId: string | string[]
+    targetId: string
     onFormSubmit?: (object: { data: { name: string; value: string }[] }) => void
     onFormReady?: ($form: HTMLFormElement) => void
     onFormSubmitted?: () => void
@@ -78,7 +78,7 @@ interface HookProps {
     region?: string
     portalId: string
     formId: string
-    targetId: string | string[]
+    targetId: string
     chiliPiper: boolean
     onFormSubmitted?: () => void
 }
@@ -125,68 +125,45 @@ function createHubSpotForm({
     const firstSourceURL = getAllCookies.sourcegraphSourceUrl
 
     const script = loadHubSpotScript()
-    
-    const invokeHubSpotForm = ({region, portalId, formId, targetId, onFormSubmitted}: HubSpotForm): void => {
-        script?.addEventListener('load', () => {
-            window.hbspt?.forms.create({
-                region: region || 'na1',
-                portalId,
-                formId,
-                target: `#${targetId}`,
-                onFormSubmit,
-                onFormSubmitted,
-                onFormReady: (form: HubSpotForm) => {
-                    if (form) {
-                        // Populate hidden form fields with values stored in cookies
-                        const anonymousIdInput = form[0].querySelector(
-                            'input[name="anonymous_user_id"]'
-                        ) as HTMLInputElement
-                        if (anonymousIdInput && anonymousIdInput.value === '') {
-                            // Populate hidden anonymous_user_id form field with value from sourcegraphAnonymousUid
-                            anonymousIdInput.value = anonymousId || ''
-                        }
-    
-                        const firstSourceURLInput = form[0].querySelector(
-                            'input[name="first_source_url"]'
-                        ) as HTMLInputElement
-                        const emailInput = form[0].querySelector('input[name="email"]') as HTMLInputElement
-                        if (
-                            firstSourceURLInput &&
-                            firstSourceURLInput.value === '' &&
-                            emailInput &&
-                            emailInput.value === ''
-                        ) {
-                            // Populate hidden first_source_url form field with value from sourcegraphSourceUrl
-                            firstSourceURLInput.value = firstSourceURL || ''
-                        }
-                    }
-                    if (onFormReady) {
-                        onFormReady(form[0])
-                    }
-                },
-            })
-        })
-    }
-
-    if (Array.isArray(targetId)) {
-        targetId.forEach(id => {
-            invokeHubSpotForm({
-                region,
-                portalId,
-                formId,
-                targetId: id,
-                onFormSubmitted,
-            })
-        })
-    } else {
-        invokeHubSpotForm({
-            region,
+    script?.addEventListener('load', () => {
+        window.hbspt?.forms.create({
+            region: region || 'na1',
             portalId,
             formId,
-            targetId,
+            target: `#${targetId}`,
+            onFormSubmit,
             onFormSubmitted,
+            onFormReady: (form: HubSpotForm) => {
+                if (form) {
+                    // Populate hidden form fields with values stored in cookies
+                    const anonymousIdInput = form[0].querySelector(
+                        'input[name="anonymous_user_id"]'
+                    ) as HTMLInputElement
+                    if (anonymousIdInput && anonymousIdInput.value === '') {
+                        // Populate hidden anonymous_user_id form field with value from sourcegraphAnonymousUid
+                        anonymousIdInput.value = anonymousId || ''
+                    }
+
+                    const firstSourceURLInput = form[0].querySelector(
+                        'input[name="first_source_url"]'
+                    ) as HTMLInputElement
+                    const emailInput = form[0].querySelector('input[name="email"]') as HTMLInputElement
+                    if (
+                        firstSourceURLInput &&
+                        firstSourceURLInput.value === '' &&
+                        emailInput &&
+                        emailInput.value === ''
+                    ) {
+                        // Populate hidden first_source_url form field with value from sourcegraphSourceUrl
+                        firstSourceURLInput.value = firstSourceURL || ''
+                    }
+                }
+                if (onFormReady) {
+                    onFormReady(form[0])
+                }
+            },
         })
-    }
+    })
 }
 
 export const useHubSpot = ({ region, portalId, formId, targetId, chiliPiper, onFormSubmitted }: HookProps): void => {

--- a/website/src/hooks/hubSpot.ts
+++ b/website/src/hooks/hubSpot.ts
@@ -169,8 +169,8 @@ function createHubSpotForm({
 export const useHubSpot = ({ region, portalId, formId, targetId, chiliPiper, onFormSubmitted }: HookProps): void => {
     useEffect(() => {
         if (Array.isArray(targetId)) {
-            for (const id of targetId) {
-                console.log(`id: ${id}`);
+            targetId.forEach(id => {
+                console.log(`new id with forEach: ${id}`);
                 
                 createHubSpotForm({
                     region,
@@ -179,7 +179,7 @@ export const useHubSpot = ({ region, portalId, formId, targetId, chiliPiper, onF
                     targetId: id,
                     onFormSubmitted,
                 })
-            }
+            })
         } else {
             createHubSpotForm({
                 region,

--- a/website/src/pages/accelerate-dev-onboarding.tsx
+++ b/website/src/pages/accelerate-dev-onboarding.tsx
@@ -6,7 +6,7 @@ import { FormLegal } from '../components/FormLegal'
 import { useHubSpot } from '../hooks/hubSpot'
 
 const AccelerateDevOnboarding: FunctionComponent<PageProps> = props => {
-    ['topForm', 'bottomForm'].forEach(id => {
+    ;['topForm', 'bottomForm'].forEach(id => {
         useHubSpot({
             portalId: '2762526',
             formId: '98187d3b-d8a9-43e2-bb95-d93dd029c688',

--- a/website/src/pages/accelerate-dev-onboarding.tsx
+++ b/website/src/pages/accelerate-dev-onboarding.tsx
@@ -9,7 +9,7 @@ const AccelerateDevOnboarding: FunctionComponent<PageProps> = props => {
     useHubSpot({
         portalId: '2762526',
         formId: '98187d3b-d8a9-43e2-bb95-d93dd029c688',
-        targetId: ['form-0', 'form-1'],
+        targetId: ['topForm', 'bottomForm'],
         chiliPiper: true,
     })
 
@@ -38,7 +38,7 @@ const AccelerateDevOnboarding: FunctionComponent<PageProps> = props => {
                         </p>
 
                         <div className="mt-5 mw-400">
-                            <div id="form-0" />
+                            <div id="topForm" />
                             <FormLegal />
                         </div>
                     </div>
@@ -86,7 +86,7 @@ const AccelerateDevOnboarding: FunctionComponent<PageProps> = props => {
                     <h2 className="font-weight-bold">Ready to accelerate developer onboarding? Let's talk.</h2>
 
                     <div className="mt-5 mw-400 mx-auto">
-                        <div id="form-1" />
+                        <div id="bottomForm" />
                         <FormLegal />
                     </div>
                 </div>

--- a/website/src/pages/accelerate-dev-onboarding.tsx
+++ b/website/src/pages/accelerate-dev-onboarding.tsx
@@ -6,11 +6,13 @@ import { FormLegal } from '../components/FormLegal'
 import { useHubSpot } from '../hooks/hubSpot'
 
 const AccelerateDevOnboarding: FunctionComponent<PageProps> = props => {
-    useHubSpot({
-        portalId: '2762526',
-        formId: '98187d3b-d8a9-43e2-bb95-d93dd029c688',
-        targetId: ['topForm', 'bottomForm'],
-        chiliPiper: true,
+    ['topForm', 'bottomForm'].forEach(id => {
+        useHubSpot({
+            portalId: '2762526',
+            formId: '98187d3b-d8a9-43e2-bb95-d93dd029c688',
+            targetId: id,
+            chiliPiper: true,
+        })
     })
 
     return (

--- a/website/src/pages/accelerate-dev-onboarding.tsx
+++ b/website/src/pages/accelerate-dev-onboarding.tsx
@@ -6,9 +6,12 @@ import { FormLegal } from '../components/FormLegal'
 import { useHubSpot } from '../hooks/hubSpot'
 
 const AccelerateDevOnboarding: FunctionComponent<PageProps> = props => {
-    for (let n = 0; n < 2; n++) {
-        useHubSpot('na1', '2762526', '98187d3b-d8a9-43e2-bb95-d93dd029c688', `form-${n}`, true)
-    }
+    useHubSpot({
+        portalId: '2762526',
+        formId: '98187d3b-d8a9-43e2-bb95-d93dd029c688',
+        targetId: ['form-0', 'form-1'],
+        chiliPiper: true,
+    })
 
     return (
         <Layout

--- a/website/src/pages/fixing-vulnerabilities.tsx
+++ b/website/src/pages/fixing-vulnerabilities.tsx
@@ -9,7 +9,7 @@ const FixingVulnerabilities: FunctionComponent<PageProps> = props => {
     useHubSpot({
         portalId: '2762526',
         formId: '721ac3eb-d213-45b1-858a-2df8743ad143',
-        targetId: ['form-0', 'form-1'],
+        targetId: ['topForm', 'bottomForm'],
         chiliPiper: true,
     })
 
@@ -35,7 +35,7 @@ const FixingVulnerabilities: FunctionComponent<PageProps> = props => {
                         </p>
 
                         <div className="mt-5 mw-400">
-                            <div id="form-0" />
+                            <div id="topForm" />
                             <FormLegal />
                         </div>
                     </div>
@@ -92,7 +92,7 @@ const FixingVulnerabilities: FunctionComponent<PageProps> = props => {
                     </h2>
 
                     <div className="mt-5 mw-400 mx-auto">
-                        <div id="form-1" />
+                        <div id="bottomForm" />
                         <FormLegal />
                     </div>
                 </div>

--- a/website/src/pages/fixing-vulnerabilities.tsx
+++ b/website/src/pages/fixing-vulnerabilities.tsx
@@ -6,9 +6,12 @@ import { FormLegal } from '../components/FormLegal'
 import { useHubSpot } from '../hooks/hubSpot'
 
 const FixingVulnerabilities: FunctionComponent<PageProps> = props => {
-    for (let n = 0; n < 2; n++) {
-        useHubSpot('na1', '2762526', '721ac3eb-d213-45b1-858a-2df8743ad143', `form-${n}`, true)
-    }
+    useHubSpot({
+        portalId: '2762526',
+        formId: '721ac3eb-d213-45b1-858a-2df8743ad143',
+        targetId: ['form-0', 'form-1'],
+        chiliPiper: true,
+    })
 
     return (
         <Layout

--- a/website/src/pages/fixing-vulnerabilities.tsx
+++ b/website/src/pages/fixing-vulnerabilities.tsx
@@ -6,11 +6,13 @@ import { FormLegal } from '../components/FormLegal'
 import { useHubSpot } from '../hooks/hubSpot'
 
 const FixingVulnerabilities: FunctionComponent<PageProps> = props => {
-    useHubSpot({
-        portalId: '2762526',
-        formId: '721ac3eb-d213-45b1-858a-2df8743ad143',
-        targetId: ['topForm', 'bottomForm'],
-        chiliPiper: true,
+    ['topForm', 'bottomForm'].forEach(id => {
+        useHubSpot({
+            portalId: '2762526',
+            formId: '721ac3eb-d213-45b1-858a-2df8743ad143',
+            targetId: id,
+            chiliPiper: true,
+        })
     })
 
     return (

--- a/website/src/pages/fixing-vulnerabilities.tsx
+++ b/website/src/pages/fixing-vulnerabilities.tsx
@@ -6,7 +6,7 @@ import { FormLegal } from '../components/FormLegal'
 import { useHubSpot } from '../hooks/hubSpot'
 
 const FixingVulnerabilities: FunctionComponent<PageProps> = props => {
-    ['topForm', 'bottomForm'].forEach(id => {
+    ;['topForm', 'bottomForm'].forEach(id => {
         useHubSpot({
             portalId: '2762526',
             formId: '721ac3eb-d213-45b1-858a-2df8743ad143',

--- a/website/src/pages/guides/continuous-developer-onboarding/index.tsx
+++ b/website/src/pages/guides/continuous-developer-onboarding/index.tsx
@@ -9,7 +9,7 @@ const ContinuousDevOnboarding: FunctionComponent<PageProps> = props => {
     useHubSpot({
         portalId: '2762526',
         formId: '35e18409-5be7-4fcb-aa57-8152b34eef66',
-        targetId: `form`,
+        targetId: 'form',
         chiliPiper: false,
         onFormSubmitted: () => window.open('/guides/dev-onboarding/sg-continuous-developer-onboarding.pdf'),
     })


### PR DESCRIPTION
The [dev onboarding guide page](https://github.com/sourcegraph/about/pull/5207) introduced new API changes to our HubSpot hook ported over from the replatform. This fixes two pages that use the new API.

### Test
Use a test email to check if ChiliPiper loads on the following pages:
1. `/accelerate-dev-onboarding`
2. `/fixing-vulnerabilities` 