### PR TITLE
Dismiss PR approvals for docs and blogposts

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -4,20 +4,20 @@ on:
   pull_request:
     types: opened
     branches:
-        - main
-    
+      - main
+
     # Glob paths to dismiss PR approvals
     paths:
-        - 'docs/**/*'
-        - 'blogposts/**/*'
+      - 'docs/**/*'
+      - 'blogposts/**/*'
 
 jobs:
   approve:
     runs-on: ubuntu-latest
     steps:
-        - run: |
-            curl --request POST \
-            --url https://api.github.com/repos/${{github.repository}}/pulls/${{github.event.number}}/reviews \
-            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
-            --header 'content-type: application/json' \
-            -d '{"event":"APPROVE"}'
+      - run: |
+          curl --request POST \
+          --url https://api.github.com/repos/${{github.repository}}/pulls/${{github.event.number}}/reviews \
+          --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+          --header 'content-type: application/json' \
+          -d '{"event":"APPROVE"}'

--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,0 +1,23 @@
+name: Skip Approval
+
+on:
+  pull_request:
+    types: opened
+    branches:
+        - main
+    
+    # Glob paths to dismiss PR approvals
+    paths:
+        - 'docs/**/*'
+        - 'blogposts/**/*'
+
+jobs:
+  approve:
+    runs-on: ubuntu-latest
+    steps:
+        - run: |
+            curl --request POST \
+            --url https://api.github.com/repos/${{github.repository}}/pulls/${{github.event.number}}/reviews \
+            --header 'authorization: Bearer ${{ secrets.GITHUB_TOKEN }}' \
+            --header 'content-type: application/json' \
+            -d '{"event":"APPROVE"}'


### PR DESCRIPTION
This PR adds a workflow that dismisses PR approvals for:
- `/docs`, and;
- `/blogposts` 

to reduce friction on the legal and content teams.