### PR TITLE
Edit approval workflow config

### DIFF
--- a/.github/workflows/approve.yml
+++ b/.github/workflows/approve.yml
@@ -1,8 +1,10 @@
+# This skips PR approvals for specific directories listed below
+# See https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/content-platform/#pull-requests for context.
 name: Skip Approval
 
 on:
   pull_request:
-    types: opened
+    types: [opened, synchronize]
     branches:
       - main
 
@@ -10,6 +12,7 @@ on:
     paths:
       - 'docs/**/*'
       - 'blogposts/**/*'
+      - 'podcast/**/*'
 
 jobs:
   approve:


### PR DESCRIPTION
- adds podcast directory as per our [pr process](https://handbook.sourcegraph.com/departments/product-engineering/engineering/enablement/content-platform/#pull-requests)
- adds synchronize to re-trigger workflow after new commits are pushed to pr
- adds documentation for context