### PR TITLE
Dev onboarding ebook landing page

### DIFF
--- a/website/src/pages/guides/continuous-developer-onboarding/index.module.scss
+++ b/website/src/pages/guides/continuous-developer-onboarding/index.module.scss
@@ -11,7 +11,3 @@
         height: 516px;
     }
 }
-
-.formContainer {
-    background: $light-gray-5;
-}

--- a/website/src/pages/guides/continuous-developer-onboarding/index.tsx
+++ b/website/src/pages/guides/continuous-developer-onboarding/index.tsx
@@ -65,7 +65,7 @@ const ContinuousDevOnboarding: FunctionComponent<PageProps> = props => {
                         </ul>
                     </div>
 
-                    <div className={`${styles.formContainer} col-lg-6 p-6 mt-5 mt-lg-0`}>
+                    <div className="col-lg-6 p-5 p-lg-6 mt-5 mt-lg-0">
                         <div id="form" />
                     </div>
                 </div>

--- a/website/src/pages/guides/continuous-developer-onboarding/index.tsx
+++ b/website/src/pages/guides/continuous-developer-onboarding/index.tsx
@@ -51,14 +51,14 @@ const ContinuousDevOnboarding: FunctionComponent<PageProps> = props => {
 
                         <p>Download this guide to learn:</p>
                         <ul>
-                            <li>
+                            <li className="mb-1">
                                 How to recontextualize traditional onboarding practices with long-term developer growth
                                 in mind
                             </li>
-                            <li>
+                            <li className="mb-1">
                                 How to cultivate an environment that enables developers to be flexible and resilient
                             </li>
-                            <li>
+                            <li className="mb-1">
                                 How to approach people, knowledge, and tools as fundamental aspects of engineering
                                 culture
                             </li>

--- a/website/src/pages/guides/dev-onboarding-how-is-it-unique/index.module.scss
+++ b/website/src/pages/guides/dev-onboarding-how-is-it-unique/index.module.scss
@@ -1,0 +1,13 @@
+@import '@styles/colors';
+
+.hero {
+    background-image: url('/guides/dev-onboarding-unique/hero-mobile.png');
+    background-repeat: no-repeat;
+    background-position: center;
+    background-size: cover;
+    height: 395px;
+    @media only screen and (min-width: 576px) {
+        background-image: url('/guides/dev-onboarding-unique/hero.png');
+        height: 516px;
+    }
+}

--- a/website/src/pages/guides/dev-onboarding-how-is-it-unique/index.tsx
+++ b/website/src/pages/guides/dev-onboarding-how-is-it-unique/index.tsx
@@ -49,16 +49,16 @@ const DevOnboardingUnique: FunctionComponent<PageProps> = props => {
 
                         <p>Download the developer onboarding guide to learn:</p>
                         <ul>
-                            <li>
+                            <li className="mb-1">
                                 How developer onboarding differs from general employee onboarding, and how to offer the
                                 best of both
                             </li>
-                            <li>
+                            <li className="mb-1">
                                 How to build the foundational <i>and</i> exceptional components of a developer
                                 onboarding program
                             </li>
-                            <li>Examples of how 3 major tech companies onboard their developers</li>
-                            <li>And more!</li>
+                            <li className="mb-1">Examples of how 3 major tech companies onboard their developers</li>
+                            <li className="mb-1">And more!</li>
                         </ul>
                     </div>
 

--- a/website/src/pages/guides/dev-onboarding-how-is-it-unique/index.tsx
+++ b/website/src/pages/guides/dev-onboarding-how-is-it-unique/index.tsx
@@ -1,0 +1,74 @@
+import React, { FunctionComponent } from 'react'
+import { PageProps } from 'gatsby'
+
+import Layout from '../../../components/Layout'
+import { useHubSpot } from '../../../hooks/hubSpot'
+import styles from './index.module.scss'
+
+const DevOnboardingUnique: FunctionComponent<PageProps> = props => {
+    useHubSpot({
+        portalId: '2762526',
+        formId: '25249bac-6544-4f50-9fc0-559745de5334',
+        targetId: 'form',
+        chiliPiper: false,
+        onFormSubmitted: () => window.open('/guides/dev-onboarding-unique/sg-dev-onboarding-what-makes-it-unique.pdf'),
+    })
+
+    return (
+        <Layout
+            location={props.location}
+            meta={{
+                title: 'Developer onboarding: How is it unique? | Sourcegraph',
+                description:
+                    'A guide to understanding how to create a developer onboarding program that differs from general employee onboarding and creates an engaged development team.',
+                image: 'https://about.sourcegraph.com/sourcegraph-og.png',
+            }}
+            hero={<div className={styles.hero} />}
+            className="bg-white"
+        >
+            <div className="container py-lg-6 py-4">
+                <div className="row">
+                    <div className="col-lg-6 pr-lg-6">
+                        <h3 className="display-3 mb-5">
+                            Developer onboarding: What makes it unique? A guide to creating an effective developer
+                            onboarding programs
+                        </h3>
+
+                        <p className="mb-4">
+                            Your organization’s ability to onboard new developers may be the difference between high
+                            attrition rates and an engaged, productive development team. But designing effective,
+                            delightful developer onboarding programs can be challenging.
+                        </p>
+
+                        <p className="mb-4">
+                            Why? Developer onboarding and general employee onboarding are two distinct programs. When
+                            companies don't understand how they differ, their developer onboarding experience can
+                            suffer.{' '}
+                            <strong>So, how can companies design a developer onboarding program that works?</strong>
+                        </p>
+
+                        <p>Download the developer onboarding guide to learn:</p>
+                        <ul>
+                            <li>
+                                How developer onboarding differs from general employee onboarding, and how to offer the
+                                best of both
+                            </li>
+                            <li>
+                                How to build the foundational <i>and</i> exceptional components of a developer
+                                onboarding program
+                            </li>
+                            <li>Examples of how 3 major tech companies onboard their developers</li>
+                            <li>And more!</li>
+                        </ul>
+                    </div>
+
+                    <div className="col-lg-6 p-5 p-lg-6 mt-5 mt-lg-0">
+                        <div id="form" />
+                    </div>
+                </div>
+            </div>
+        </Layout>
+    )
+}
+
+export default DevOnboardingUnique


### PR DESCRIPTION
This closes #5231 and #5277. This adds a new landing page for the Developer Onboarding ebook based on the same layout as the [Developer Onboarding guide](https://about.sourcegraph.com/guides/continuous-developer-onboarding/). We also remove the gray background on HubSpot forms.

There is no Figma file for this ticket. The copy is located [here](https://docs.google.com/document/d/1_xq82eTShP269UEgNAI7-2syuUxxu5W3j_AaBhrWCr0/edit#).

### Testing
- Please navigate to `guides/dev-onboarding-how-is-it-unique` to check the design and copy
- Test that the ebook downloads correctly upon form submission
- Check that the HubSpot configuration is correct: 
-- `portalId: "2762526"`
-- `formId: "25249bac-6544-4f50-9fc0-559745de5334"`
- Please test the static build
