### PR TITLE
Bugfix/Blog post link to author url

### DIFF
--- a/website/src/components/blog/BlogPost.tsx
+++ b/website/src/components/blog/BlogPost.tsx
@@ -49,9 +49,13 @@ export const BlogPost: React.FunctionComponent<Props> = ({
                 {post.frontmatter.author && post.frontmatter.publishDate && (
                     <p className="blog-post__byline mb-0">
                         {post.frontmatter.authorUrl ? (
-                            <a href={post.frontmatter.authorUrl} target="_blank" rel="nofollow noreferrer">
-                                {post.frontmatter.author}
-                            </a>
+                            post.frontmatter.authorUrl.includes('http') ?
+                                <a href={post.frontmatter.authorUrl} target="_blank" rel="nofollow noreferrer">
+                                    {post.frontmatter.author}
+                                </a> :
+                                <Link to={post.frontmatter.authorUrl}>
+                                    {post.frontmatter.author}
+                                </Link>
                         ) : (
                             <span>{post.frontmatter.author}</span>
                         )}{' '}

--- a/website/src/components/blog/BlogPost.tsx
+++ b/website/src/components/blog/BlogPost.tsx
@@ -49,13 +49,13 @@ export const BlogPost: React.FunctionComponent<Props> = ({
                 {post.frontmatter.author && post.frontmatter.publishDate && (
                     <p className="blog-post__byline mb-0">
                         {post.frontmatter.authorUrl ? (
-                            post.frontmatter.authorUrl.includes('http') ?
+                            post.frontmatter.authorUrl.includes('http') ? (
                                 <a href={post.frontmatter.authorUrl} target="_blank" rel="nofollow noreferrer">
                                     {post.frontmatter.author}
-                                </a> :
-                                <Link to={post.frontmatter.authorUrl}>
-                                    {post.frontmatter.author}
-                                </Link>
+                                </a>
+                            ) : (
+                                <Link to={post.frontmatter.authorUrl}>{post.frontmatter.author}</Link>
+                            )
                         ) : (
                             <span>{post.frontmatter.author}</span>
                         )}{' '}

--- a/website/src/components/blog/BlogPost.tsx
+++ b/website/src/components/blog/BlogPost.tsx
@@ -46,9 +46,17 @@ export const BlogPost: React.FunctionComponent<Props> = ({
                         post.frontmatter.title
                     )}
                 </h1>
-                <p className="blog-post__byline mb-0">
-                    {post.frontmatter.author} on {post.frontmatter.publishDate}
-                </p>
+                {post.frontmatter.author && post.frontmatter.publishDate && (
+                    <p className="blog-post__byline mb-0">
+                        {post.frontmatter.authorUrl ?
+                            <a href={post.frontmatter.authorUrl} target="_blank" rel="nofollow noreferrer">
+                                {post.frontmatter.author}
+                            </a> :
+                            <span>{post.frontmatter.author}</span>
+                        }
+                        {' '} on {post.frontmatter.publishDate}
+                    </p>
+                )}
             </header>
             {!full && post.frontmatter.heroImage ? (
                 <div className="card-body pt-0 d-flex flex-card">

--- a/website/src/components/blog/BlogPost.tsx
+++ b/website/src/components/blog/BlogPost.tsx
@@ -55,7 +55,7 @@ export const BlogPost: React.FunctionComponent<Props> = ({
                         ) : (
                             <span>{post.frontmatter.author}</span>
                         )}{' '}
-                        on {post.frontmatter.publishDate}
+                        on <time dateTime={post.frontmatter.publishDate}>{post.frontmatter.publishDate}</time>
                     </p>
                 )}
             </header>

--- a/website/src/components/blog/BlogPost.tsx
+++ b/website/src/components/blog/BlogPost.tsx
@@ -48,13 +48,14 @@ export const BlogPost: React.FunctionComponent<Props> = ({
                 </h1>
                 {post.frontmatter.author && post.frontmatter.publishDate && (
                     <p className="blog-post__byline mb-0">
-                        {post.frontmatter.authorUrl ?
+                        {post.frontmatter.authorUrl ? (
                             <a href={post.frontmatter.authorUrl} target="_blank" rel="nofollow noreferrer">
                                 {post.frontmatter.author}
-                            </a> :
+                            </a>
+                        ) : (
                             <span>{post.frontmatter.author}</span>
-                        }
-                        {' '} on {post.frontmatter.publishDate}
+                        )}{' '}
+                        on {post.frontmatter.publishDate}
                     </p>
                 )}
             </header>


### PR DESCRIPTION
Closes #5323 by making use of `authorUrl` prop to link out to author url when present

### Test
- Nav to https://about.sourcegraph.com/blog/introducing-migrator-service/ or any blog post to ensure `author` under title is a working link