### PR TITLE
Update Use Case blog list items

### DIFF
--- a/website/src/pages/use-cases/code-health.tsx
+++ b/website/src/pages/use-cases/code-health.tsx
@@ -133,26 +133,38 @@ const quoteCarouselItems = [
     },
 ]
 
-const blogListItems = [
+const resourceItems = [
     {
         title: 'How not to break a search engine or: What I learned about unglamorous engineering',
-        description: `When Sourcegraph switched to a new search query parser, you'd never know anything had changed.  This is an account of the rigorous testing that happened behind the scenes to ensure a seamless transition.`,
+        description:
+            "When Sourcegraph switched to a new search query parser, you'd never know anything had changed.  This is an account of the rigorous testing that happened behind the scenes to ensure a seamless transition.",
         type: 'Blog post',
-        image: 'https://storage.googleapis.com/sourcegraph-assets/blog/how-not-to-break-a-search-engine-new.png',
+        img: {
+            src: 'https://storage.googleapis.com/sourcegraph-assets/blog/how-not-to-break-a-search-engine-new.png',
+            alt: 'Unglamorous engineering blog thumbnail',
+        },
         href: '/blog/how-not-to-break-a-search-engine-unglamorous-engineering',
     },
     {
         title: 'How we migrated entirely to CSS Modules using codemods and Sourcegraph Code Insights',
-        description: `Learn how Sourcegraph's Frontend Platform team overhauled our web application's design system and UI using codemods to automate a challenging global migration to CSS modules and Code Insights to track and communicate progress.`,
+        description:
+            "Learn how Sourcegraph's Frontend Platform team overhauled our web application's design system and UI using codemods to automate a challenging global migration to CSS modules and Code Insights to track and communicate progress.",
         type: 'Blog post',
-        image: 'https://storage.googleapis.com/sourcegraph-assets/blog/code-insights-ga-blogs/migrating-to-css-modules.png',
+        img: {
+            src: 'https://storage.googleapis.com/sourcegraph-assets/blog/code-insights-ga-blogs/migrating-to-css-modules.png',
+            alt: 'CSS modules migration blog thumbnail',
+        },
         href: '/blog/migrating-to-css-modules-with-codemods-and-code-insights',
     },
     {
         title: 'How we added backend integration testing to our CI pipeline',
-        description: `Here's the story and the lessons learned from our work to remove all existing backend-related end-to-end tests and reliably run their corresponding unit and integration tests as part of our CI pipeline on all branches.`,
+        description:
+            "Here's the story and the lessons learned from our work to remove all existing backend-related end-to-end tests and reliably run their corresponding unit and integration tests as part of our CI pipeline on all branches.",
         type: 'Blog post',
-        image: 'https://storage.googleapis.com/sourcegraph-assets/blog/backend-integration-testing/backend-integration-testing.png',
+        img: {
+            src: 'https://storage.googleapis.com/sourcegraph-assets/blog/backend-integration-testing/backend-integration-testing.png',
+            alt: 'Backend integration testing blog thumbnail',
+        },
         href: '/blog/integration-testing',
     },
 ]
@@ -330,7 +342,7 @@ const UseCasePage: FunctionComponent<PageProps> = props => (
                 <div className="col-lg-6">
                     <h1 className="mb-5 font-weight-bold">Related resources</h1>
                 </div>
-                {blogListItems.map(item => (
+                {resourceItems.map(item => (
                     <BlogListItem key={item.title} blog={item} />
                 ))}
             </div>

--- a/website/src/pages/use-cases/incident-response.tsx
+++ b/website/src/pages/use-cases/incident-response.tsx
@@ -115,21 +115,27 @@ const quoteCarouselItems = [
     },
 ]
 
-const blogListItems = [
+const resourceItems = [
     {
         title: 'Log4j Log4Shell 0-day: find, fix, and track affected code',
         description:
             'In the biggest security vulnerability incident since Heartbleed, Sourcegraph co-founder and CEO Quinn Slack shared how you can find affected code, automate fixes, and track progress.',
         type: 'Blog post',
-        image: 'https://sourcegraphstatic.com/blog/log4j/log4j-blog-thumbnail.png',
+        img: {
+            src: 'https://sourcegraphstatic.com/blog/log4j/log4j-blog-thumbnail.png',
+            alt: 'Log4j blog thumbnail',
+        },
         href: '/blog/log4j-log4shell-0-day',
     },
     {
-        title: `The real weakest link in software supply chain security (it's not open source)`,
+        title: "The real weakest link in software supply chain security (it's not open source)",
         description:
             'Using open source code can jump-start development but it can also expose you to security vulnerabilities. In this post, learn how to design an effective vulnerability management process that can make dependencies visible and mitigation less time-consuming.',
         type: 'Blog post',
-        image: 'https://storage.googleapis.com/sourcegraph-assets/blog/third-party-open-source-vulnerabilities.png',
+        img: {
+            src: 'https://storage.googleapis.com/sourcegraph-assets/blog/third-party-open-source-vulnerabilities.png',
+            alt: 'The weakest link in software supply blog thumbnail',
+        },
         href: '/blog/real-weakest-link-in-software-supply-chain-security',
     },
     {
@@ -137,7 +143,10 @@ const blogListItems = [
         description:
             'Back in early 2021, Sourcegraph stored infrastructure and service passwords in private repositories. Security engineer André Eleuterio moved every secret to a secure vault and used code search to ensure the move was successful and complete.',
         type: 'Blog post',
-        image: 'https://sourcegraphstatic.com/blog/securing-sourcegraph-eliminating-secrets.png',
+        img: {
+            src: 'https://sourcegraphstatic.com/blog/securing-sourcegraph-eliminating-secrets.png',
+            alt: 'Remove secrets from your codebase blog thumbnail',
+        },
         href: '/blog/eliminate-secrets-from-codebase-with-universal-code-search',
     },
 ]
@@ -333,7 +342,7 @@ const UseCasePage: FunctionComponent<PageProps> = props => (
                 <div className="col-lg-6">
                     <h1 className="mb-5 font-weight-bold">Related resources</h1>
                 </div>
-                {blogListItems.map(item => (
+                {resourceItems.map(item => (
                     <BlogListItem key={item.title} blog={item} />
                 ))}
             </div>


### PR DESCRIPTION
This closes #5337. It updates the blog post list arrays on the Incident Response and Code Health Use Case pages.

### Testing
- Please check that blog thumbnails render on `/use-cases/incident-response` and `/use-cases/code-health`