### PR TITLE
Guides: Microservices with Ceros embed

### DIFF
--- a/website/src/hooks/ceros.ts
+++ b/website/src/hooks/ceros.ts
@@ -1,0 +1,14 @@
+import { useEffect } from 'react'
+
+export const useCerosScript = () => {
+    useEffect(() => {
+        const cerosScrip = '//view.ceros.com/scroll-proxy.min.js'
+        const script = document.createElement('script')
+        script.src = cerosScrip
+        document.head.append(script)
+
+        return () => {
+            script?.remove()
+        }
+    }, [])
+}

--- a/website/src/pages/guides/successful-monolith-to-microservices-transition.tsx
+++ b/website/src/pages/guides/successful-monolith-to-microservices-transition.tsx
@@ -1,0 +1,64 @@
+import React, { FunctionComponent } from 'react'
+import { PageProps } from 'gatsby'
+
+import Layout from '../../components/Layout'
+import { useCerosScript } from '../../hooks/ceros'
+
+const MonolithToMicroservices: FunctionComponent<PageProps> = props => {
+    useCerosScript()
+
+    return (
+        <Layout
+            location={props.location}
+            meta={{
+                title: '5 key elements of successful monolith-to-microservices migrations',
+                description:
+                    'Employ the five key techniques that the best engineering organizations enable to successfully conduct major architectural transitions.',
+            }}
+            className="bg-white"
+        >
+            <section
+                style={{
+                    position: 'relative',
+                    width: 'auto',
+                    padding: '0 0 286.02%',
+                    height: '0',
+                    top: '0',
+                    left: '0',
+                    bottom: '0',
+                    right: '0',
+                    margin: '0',
+                    border: '0 none',
+                }}
+                id="experience-627983184b4c8"
+                data-aspectratio="0.34963125"
+                data-mobile-aspectratio="0.14484881"
+            >
+                <iframe
+                    allowFullScreen
+                    src="https://view.ceros.com/sourcegraph/successful-monolith-to-microservices-transition?heightOverride=3661&mobileHeightOverride=5523"
+                    style={{
+                        position: 'absolute',
+                        top: '0',
+                        left: '0',
+                        bottom: '0',
+                        right: '0',
+                        margin: '0',
+                        padding: '0',
+                        border: '0 none',
+                        height: '1px',
+                        width: '1px',
+                        minHeight: '100%',
+                        minWidth: '100%',
+                    }}
+                    frameBorder="0"
+                    className="ceros-experience"
+                    title="5 key elements of successful monolith-to-microservices migrations"
+                    scrolling="no"
+                />
+            </section>
+        </Layout>
+    )
+}
+
+export default MonolithToMicroservices


### PR DESCRIPTION
Closes #5316 by adding new guide landing page and ceros embed hook.

### Test

- Navigate to `/guides/successful-monolith-to-microservices-transition` and observe ceros embedded behavior
- Ensure meta data is correct

### Notes

- Hook made for ceros script. We can start adding re-usable ceros page scripts once we can determine the necessary props
- PR with Ceros test script for reference: [PR#5282](https://github.com/sourcegraph/about/pull/5282)

### Ceros observations
- I don't love that the popup isn't centered on the screen
- The ceros design isn't responsive. Observe how mobile sizes make the text microscopic, content isn't stacking. XL screens makes the content become mongo sized 😬  - I don't remember this from the ceros test.
![Screen Shot 2022-05-16 at 4 47 02 PM](https://user-images.githubusercontent.com/59381432/168694867-a3721d89-43fe-449c-a931-c801f36df187.png)
![Screen Shot 2022-05-16 at 4 47 56 PM](https://user-images.githubusercontent.com/59381432/168694875-cd630076-61de-440f-8809-20df390caceb.png)
![Screen Shot 2022-05-16 at 4 48 08 PM](https://user-images.githubusercontent.com/59381432/168694881-c9dd73dd-1b43-477c-b19a-d821ad10f245.png)

