### PR TITLE
Script loading strategies, HubSpot hook refactor, and Triblio script fix

### DIFF
--- a/src/hooks/hubSpot.ts
+++ b/src/hooks/hubSpot.ts
@@ -54,7 +54,7 @@ interface HookProps {
 
 // Global script integrations for this hook used for HubSpot forms
 const hubSpotScript = '//js.hsforms.net/forms/v2.js'
-const jQueryScript = 'https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js'
+const jQueryScript = '//ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js'
 const clearbitScript = '!function(e){var o=document.getElementsByTagName("script")[0];if("object"==typeof e.ClearbitForHubspot)return console.log("Clearbit For HubSpot included more than once"),!1;e.ClearbitForHubspot={},e.ClearbitForHubspot.forms=[],e.ClearbitForHubspot.addForm=function(o){var t=o[0];"function"==typeof e.ClearbitForHubspot.onFormReady?e.ClearbitForHubspot.onFormReady(t):e.ClearbitForHubspot.forms.push(t)};var t=document.createElement("script");t.async=!0,t.src="https://hubspot.clearbit.com/v1/forms/pk_a66b9ed76e62c713c06aab39bfae7234/forms.js",o.parentNode.insertBefore(t,o),e.addEventListener("message",function(o){if("hsFormCallback"===o.data.type&&"onFormReady"===o.data.eventName)if(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0)e.ClearbitForHubspot.addForm(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'));else if(document.querySelectorAll("iframe.hs-form-iframe").length>0){document.querySelectorAll("iframe.hs-form-iframe").forEach(function(t){t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0&&e.ClearbitForHubspot.addForm(t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'))})}})}(window);'
 
 // Gets a script element by its id

--- a/src/hooks/hubSpot.ts
+++ b/src/hooks/hubSpot.ts
@@ -24,6 +24,7 @@ interface HubSpotProps {
     portalId: string
     formId: string
     target: string
+    onBeforeFormInit: () => void
     formInstanceId?: string
     onFormSubmit?: (object: { data: { name: string; value: string }[] }) => void
     onFormReady?: ($form: HubSpotForm) => void
@@ -51,24 +52,45 @@ interface HookProps {
     onFormSubmitted?: () => void
 }
 
+// Global script integrations for this hook used for HubSpot forms
 const hubSpotScript = '//js.hsforms.net/forms/v2.js'
+const jQueryScript = 'https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js'
+const clearbitScript = '!function(e){var o=document.getElementsByTagName("script")[0];if("object"==typeof e.ClearbitForHubspot)return console.log("Clearbit For HubSpot included more than once"),!1;e.ClearbitForHubspot={},e.ClearbitForHubspot.forms=[],e.ClearbitForHubspot.addForm=function(o){var t=o[0];"function"==typeof e.ClearbitForHubspot.onFormReady?e.ClearbitForHubspot.onFormReady(t):e.ClearbitForHubspot.forms.push(t)};var t=document.createElement("script");t.async=!0,t.src="https://hubspot.clearbit.com/v1/forms/pk_a66b9ed76e62c713c06aab39bfae7234/forms.js",o.parentNode.insertBefore(t,o),e.addEventListener("message",function(o){if("hsFormCallback"===o.data.type&&"onFormReady"===o.data.eventName)if(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0)e.ClearbitForHubspot.addForm(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'));else if(document.querySelectorAll("iframe.hs-form-iframe").length>0){document.querySelectorAll("iframe.hs-form-iframe").forEach(function(t){t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0&&e.ClearbitForHubspot.addForm(t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'))})}})}(window);'
 
-const getHubSpotScript = (): Element | null => {
-    const script = document.querySelector(`script[src="${hubSpotScript}"]`)
-    return script
+// Gets a script element by its id
+const getScriptElement = (id: string): Element | null => 
+    document.querySelector(`#${id}`)
+
+// Removes a script element by its id
+const removeScriptElement = (id: string): void => {
+    const scriptElement = getScriptElement(id)
+    scriptElement?.remove()
 }
 
-const loadHubSpotScript = (): HTMLScriptElement | Element => {
-    const script = getHubSpotScript()
+/**
+ * This loads a script element and appends it to the document's head tag.
+ * 
+ * @param id - a unique identifier for the script element
+ * @param script - the script src (whether it's used for the script tag's src or innerHTML)
+ * @param innerHTML - whether or not to assign the script to the script tag's src attribute or append to it's innerHTML
+ * @returns - an HTML Script Element
+ */
+const loadScriptElement = (id: string, script: string, innerHTML?: boolean): HTMLScriptElement | Element => {
+    const scriptElement = getScriptElement(id)
 
-    if (!script) {
-        const scriptElement = document.createElement('script')
-        scriptElement.src = hubSpotScript
-        document.head.append(scriptElement)
-        return scriptElement
+    if (!scriptElement) {
+        const newScriptElement = document.createElement('script')
+        newScriptElement.setAttribute('id', id)
+        if (innerHTML) {
+            newScriptElement.innerHTML = script
+        } else {
+            newScriptElement.src = script
+        }
+        document.head.append(newScriptElement)
+        return newScriptElement
     }
 
-    return script
+    return scriptElement
 }
 
 function createHubSpotForm({
@@ -87,7 +109,7 @@ function createHubSpotForm({
     const anonymousId = getAllCookies.sourcegraphAnonymousUid
     const firstSourceURL = getAllCookies.sourcegraphSourceUrl
 
-    const script = loadHubSpotScript()
+    const script = loadScriptElement('hubspot', hubSpotScript)
     script?.addEventListener('load', () => {
         window.hbspt?.forms.create({
             region: region || 'na1',
@@ -95,6 +117,10 @@ function createHubSpotForm({
             formId,
             formInstanceId,
             target: `#${targetId}`,
+            onBeforeFormInit: () => {
+                loadScriptElement('jQuery', jQueryScript)
+                loadScriptElement('clearbit', clearbitScript, true)
+            },
             onFormSubmit,
             onFormSubmitted,
             onFormReady: (form: HubSpotForm) => {
@@ -149,8 +175,9 @@ export const useHubSpot = ({
         })
 
         return () => {
-            const script = getHubSpotScript()
-            script?.remove()
+            removeScriptElement('jQuery')
+            removeScriptElement('clearbit')
+            removeScriptElement('hubspot')
         }
     }, [region, portalId, formId, targetId, formInstanceId, onFormSubmitted])
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -17,11 +17,18 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
 
             {/* // Import all top-level scripts here: https://nextjs.org/docs/messages/no-script-in-document-page */}
 
-            {/* Triblio "Webpage Personalization" for Sales/Marketing */}
+            {/* Triblio "Webpage Personalization" */}
             <Script
                 type="text/javascript"
                 src="https://tribl.io/h.js?orgId=Yee6bMKj7QSARqAePdE8"
                 strategy="beforeInteractive"
+            />
+            
+            {/* Triblio "Analytics and Overlay Cards" */}
+            <Script
+                type="text/javascript"
+                src="https://tribl.io/footer.js?orgId=Yee6bMKj7QSARqAePdE8"
+                strategy="afterInteractive"
             />
 
             {/* Google Analytics */}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,13 +19,17 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
 
             {/* Triblio "Webpage Personalization" for Sales/Marketing */}
             <Script
-                data-cfasync="false"
                 type="text/javascript"
                 src="https://tribl.io/h.js?orgId=Yee6bMKj7QSARqAePdE8"
+                strategy="beforeInteractive"
             />
 
             {/* Google Analytics */}
-            <Script data-cookieconsent="ignore" id="track-ga">
+            <Script
+                id="track-ga"
+                data-cookieconsent="ignore"
+                strategy="beforeInteractive"
+            >
                 {`
                 window.dataLayer = window.dataLayer || [];
                 function gtag() {
@@ -41,7 +45,11 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
             </Script>
 
             {/* Google Tag Manager */}
-            <Script data-cookieconsent="ignore" id="track-gtm">
+            <Script
+                id="track-gtm"
+                data-cookieconsent="ignore"
+                strategy="beforeInteractive"
+            >
                 {`
                 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -58,13 +66,15 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
                 data-cbid="fb31dc3e-afb3-4be8-ae84-7090bba7797d"
                 data-blockingmode="auto"
                 type="text/javascript"
+                strategy="afterInteractive"
             />
 
-            {/* Add jQuery as a dependency for Clearbit - without this Clearbit doesn't work */}
-            <Script type="text/javascript" src="https://ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js" />
-
             {/* Drift */}
-            <Script type="text/javascript" id="drift">
+            <Script
+                type="text/javascript"
+                id="drift"
+                strategy="afterInteractive"
+            >
                 {`
                     "use strict";
                     !function() {
@@ -90,13 +100,6 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
                     drift.SNIPPET_VERSION = '0.3.1';
                     drift.load('bgv3pp29xsp9');
                 `}
-            </Script>
-
-            {/* Clearbit script for Hubspot form enrichment */}
-            <Script type="text/javascript" id="clearbit-hubspot">
-                {
-                    '!function(e){var o=document.getElementsByTagName("script")[0];if("object"==typeof e.ClearbitForHubspot)return console.log("Clearbit For HubSpot included more than once"),!1;e.ClearbitForHubspot={},e.ClearbitForHubspot.forms=[],e.ClearbitForHubspot.addForm=function(o){var t=o[0];"function"==typeof e.ClearbitForHubspot.onFormReady?e.ClearbitForHubspot.onFormReady(t):e.ClearbitForHubspot.forms.push(t)};var t=document.createElement("script");t.async=!0,t.src="https://hubspot.clearbit.com/v1/forms/pk_a66b9ed76e62c713c06aab39bfae7234/forms.js",o.parentNode.insertBefore(t,o),e.addEventListener("message",function(o){if("hsFormCallback"===o.data.type&&"onFormReady"===o.data.eventName)if(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0)e.ClearbitForHubspot.addForm(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'));else if(document.querySelectorAll("iframe.hs-form-iframe").length>0){document.querySelectorAll("iframe.hs-form-iframe").forEach(function(t){t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0&&e.ClearbitForHubspot.addForm(t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'))})}})}(window);'
-                }
             </Script>
 
             <SSRProvider>

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -19,6 +19,7 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
 
             {/* Triblio "Webpage Personalization" */}
             <Script
+                id="triblio-p"
                 type="text/javascript"
                 src="https://tribl.io/h.js?orgId=Yee6bMKj7QSARqAePdE8"
                 strategy="beforeInteractive"
@@ -26,6 +27,7 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
             
             {/* Triblio "Analytics and Overlay Cards" */}
             <Script
+                id="triblio-a"
                 type="text/javascript"
                 src="https://tribl.io/footer.js?orgId=Yee6bMKj7QSARqAePdE8"
                 strategy="afterInteractive"
@@ -78,8 +80,8 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
 
             {/* Drift */}
             <Script
-                type="text/javascript"
                 id="drift"
+                type="text/javascript"
                 strategy="afterInteractive"
             >
                 {`


### PR DESCRIPTION
This changes our script loading strategies for our 3rd party integrations and closes #5373.

### Changelog
- Changed [script loading strategies](https://nextjs.org/docs/basic-features/script#strategy) for 3rd party integrations in `_app.tsx`
  - `beforeInteractive` ensures critical scripts are loaded before render (in the head)
  - `afterInteractive` loads non critical scripts after render (in the body)
- Moved our Clearbit script integration to our HubSpot hook since Clearbit is a HubSpot form enhancement. This ensures we aren't loading scripts unnecessarily on pages that don't need it. Note that [jQuery is required](https://help.clearbit.com/hc/en-us/articles/360037598334-Set-Up-Clearbit-Enrichment-for-HubSpot-Forms#:~:text=To%20confirm%20jQuery%20is%20installed%20on%20your%20site) for our Clearbit integration unfortunately. Also note that Clearbit returns a 401 on local.
- Refactored our HubSpot hook to allow for multiple script integrations. We now have get/remove/load script element functions.
- Added Triblio Analytics and Overlay Cards script

### Test

1. Ensure linting passes.
2. Ensure prettier has standardized the proposed changes.
3. Ensure dev and production builds work.
4. Ensure `jQuery` and `Clearbit` scripts only load in the head on pages with HubSpot forms. You can search for the script tag ids.
5. Ensure our Triblio (personalization), Google Analytics, and Google Tag Manager scripts load in the head
6. Ensure our Triblio (analytics and overlay cards), Cookiebot and Drift scripts load in the body
