### PR TITLE
/code-search updated CTA buttons

### DIFF
--- a/src/components/Install/index.tsx
+++ b/src/components/Install/index.tsx
@@ -70,7 +70,7 @@ export const Install: FunctionComponent = () => {
                 <a
                     className="d-inline-block text-lg"
                     href="https://docs.sourcegraph.com"
-                    data-button-style={buttonStyle.textWithArrow}
+                    data-button-style={buttonStyle.text}
                     data-button-location={buttonLocation.trySourcegraph}
                     data-button-type="cta"
                 >

--- a/src/components/SelfHostedSection.tsx
+++ b/src/components/SelfHostedSection.tsx
@@ -41,7 +41,7 @@ export const SelfHostedSection: FunctionComponent = () => (
                         <a
                             className="d-inline-block text-lg"
                             href="#none"
-                            data-button-style={buttonStyle.textWithArrow}
+                            data-button-style={buttonStyle.text}
                             data-button-location={buttonLocation.trySourcegraph}
                             data-button-type="cta"
                         >

--- a/src/components/SelfHostedSection.tsx
+++ b/src/components/SelfHostedSection.tsx
@@ -37,14 +37,14 @@ export const SelfHostedSection: FunctionComponent = () => (
                         ))}
                     </ul>
 
-                    <Link
-                        href="/get-started"
-                        data-button-style={buttonStyle.textWithArrow}
-                        data-button-location={buttonLocation.trySourcegraph}
-                        data-button-type="cta"
-                        passHref={true}
-                    >
-                        <a className="d-inline-block text-lg" href="#none">
+                    <Link href="/get-started" passHref={true}>
+                        <a
+                            className="d-inline-block text-lg"
+                            href="#none"
+                            data-button-style={buttonStyle.textWithArrow}
+                            data-button-location={buttonLocation.trySourcegraph}
+                            data-button-type="cta"
+                        >
                             Learn about self-hosted vs Cloud features
                         </a>
                     </Link>

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -28,15 +28,15 @@ export const BatchChangesPage: FunctionComponent = () => (
                             Keep your code up to date, fix critical security issues, and pay down tech debt across all
                             of your repositories with Batch Changes.
                         </p>
-                        <Link
-                            href={batchChangesDemoFormURL}
-                            passHref={true}
-                            data-button-style={buttonStyle.primary}
-                            data-button-location={buttonLocation.hero}
-                            data-button-type="cta"
-                        >
+                        <Link href={batchChangesDemoFormURL} passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a className="btn btn-primary" title="Request a demo">
+                            <a
+                                className="btn btn-primary"
+                                title="Request a demo"
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.hero}
+                                data-button-type="cta"
+                            >
                                 Request a demo
                             </a>
                         </Link>

--- a/src/pages/code-insights.tsx
+++ b/src/pages/code-insights.tsx
@@ -584,15 +584,15 @@ const CodeInsightsPage: FunctionComponent = () => {
                             </p>
                         </div>
                         <div className="col-lg-7 d-flex flex-column pt-1">
-                            <Link
-                                href="/contact/request-code-insights-demo"
-                                passHref={true}
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.trySourcegraph}
-                                data-button-type="cta"
-                            >
+                            <Link href="/contact/request-code-insights-demo" passHref={true}>
                                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                <a className="btn btn-primary col-4 mr-3" title="Request a Demo of Code Insights.">
+                                <a
+                                    className="btn btn-primary col-4 mr-3"
+                                    title="Request a Demo of Code Insights."
+                                    data-button-style={buttonStyle.primary}
+                                    data-button-location={buttonLocation.trySourcegraph}
+                                    data-button-type="cta"
+                                >
                                     Request a demo
                                 </a>
                             </Link>

--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -26,9 +26,9 @@ export const CodeSearchPage: FunctionComponent = () => (
                             Onboard to a new codebase, find answers faster, and identify security risks with universal
                             code search.
                         </p>
-                        <div className="pt-1">
+                        <div className="d-flex flex-column flex-lg-row max-w-sm-400 pt-1">
                             <Link
-                                href="/get-started"
+                                href="/demo"
                                 passHref={true}
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.hero}
@@ -36,22 +36,24 @@ export const CodeSearchPage: FunctionComponent = () => (
                             >
                                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                 <a
-                                    className="btn btn-primary mr-3"
-                                    title="Use this if you want to search your (or your company's) code, invite teammates, and try all the features."
+                                    className="btn btn-primary mr-lg-3 mb-lg-0 mb-3 w-md-100"
+                                    title="Request a Demo."
                                 >
-                                    Deploy locally <ArrowRightIcon className="ml-1" />
+                                    Request a demo
                                 </a>
                             </Link>
-                            <a
-                                className="btn btn-outline-primary my-3"
+                            <Link
+                                href="/get-started"
+                                passHref={true}
                                 data-button-style={buttonStyle.outline}
                                 data-button-location={buttonLocation.hero}
                                 data-button-type="cta"
-                                href="https://sourcegraph.com/search"
-                                title="Use this if you want to search across top open source repositories (or add your own projects)."
                             >
-                                Search open source <ArrowRightIcon className="ml-1" />
-                            </a>
+                                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                                <a className="btn btn-outline-primary w-md-100" title="Try Sourcegraph.">
+                                    Try Sourcegraph now
+                                </a>
+                            </Link>
                         </div>
                     </div>
                 </div>

--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -1,7 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
 import ArrowRightBoxIcon from 'mdi-react/ArrowRightBoxIcon'
-import ArrowRightIcon from 'mdi-react/ArrowRightIcon'
 import Link from 'next/link'
 
 import { ContentSection, BlockquoteWithBorder, IntegrationsSection, Layout, SelfHostedSection } from '@components'
@@ -27,30 +26,27 @@ export const CodeSearchPage: FunctionComponent = () => (
                             code search.
                         </p>
                         <div className="d-flex flex-column flex-lg-row max-w-sm-400 pt-1">
-                            <Link
-                                href="/demo"
-                                passHref={true}
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
+                            <Link href="/demo" passHref={true}>
                                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                 <a
                                     className="btn btn-primary mr-lg-3 mb-lg-0 mb-3 w-md-100"
                                     title="Request a Demo."
+                                    data-button-style={buttonStyle.primary}
+                                    data-button-location={buttonLocation.hero}
+                                    data-button-type="cta"
                                 >
                                     Request a demo
                                 </a>
                             </Link>
-                            <Link
-                                href="/get-started"
-                                passHref={true}
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
+                            <Link href="/get-started" passHref={true}>
                                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                <a className="btn btn-outline-primary w-md-100" title="Try Sourcegraph.">
+                                <a
+                                    className="btn btn-outline-primary w-md-100"
+                                    title="Try Sourcegraph."
+                                    data-button-style={buttonStyle.outline}
+                                    data-button-location={buttonLocation.hero}
+                                    data-button-type="cta"
+                                >
                                     Try Sourcegraph now
                                 </a>
                             </Link>

--- a/src/pages/home/_Features.tsx
+++ b/src/pages/home/_Features.tsx
@@ -184,13 +184,13 @@ const FeatureSection: FunctionComponent = () => {
                                 Learn more about {startCase(feature.productFeature)}
                             </a>
                         ) : (
-                            <Link
-                                href={feature.ctaLink}
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.body}
-                                passHref={true}
-                            >
-                                <a className="btn btn-outline-primary mt-2" href="#none">
+                            <Link href={feature.ctaLink} passHref={true}>
+                                <a
+                                    className="btn btn-outline-primary mt-2"
+                                    href="#none"
+                                    data-button-style={buttonStyle.outline}
+                                    data-button-location={buttonLocation.body}
+                                >
                                     Learn more about {startCase(feature.productFeature)}
                                 </a>
                             </Link>

--- a/src/pages/home/_Hero.tsx
+++ b/src/pages/home/_Hero.tsx
@@ -53,27 +53,29 @@ const Hero: FunctionComponent = () => {
 
                 <div className="max-w-350 mx-auto flex-column flex-sm-row d-sm-flex align-items-center">
                     <div className="col-sm-6 px-sm-0 mb-3 mb-sm-0 mr-sm-3">
-                        <Link
-                            href="/get-started"
-                            data-button-style={buttonStyle.primary}
-                            data-button-location={buttonLocation.hero}
-                            data-button-type="cta"
-                            passHref={true}
-                        >
-                            <a className="btn btn-primary w-100" href="#none" title="Get started">
+                        <Link href="/get-started" passHref={true}>
+                            <a
+                                className="btn btn-primary w-100"
+                                href="#none"
+                                title="Get started"
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.hero}
+                                data-button-type="cta"
+                            >
                                 Get started
                             </a>
                         </Link>
                     </div>
                     <div className="col-sm-6 px-sm-0">
-                        <Link
-                            href="/demo"
-                            data-button-style={buttonStyle.outline}
-                            data-button-location={buttonLocation.hero}
-                            data-button-type="cta"
-                            passHref={true}
-                        >
-                            <a className="btn btn-outline-primary w-100" href="#none" title="Request a demo">
+                        <Link href="/demo" passHref={true}>
+                            <a
+                                className="btn btn-outline-primary w-100"
+                                href="#none"
+                                title="Request a demo"
+                                data-button-style={buttonStyle.outline}
+                                data-button-location={buttonLocation.hero}
+                                data-button-type="cta"
+                            >
                                 Request a demo
                             </a>
                         </Link>

--- a/src/pages/home/_UseCases.tsx
+++ b/src/pages/home/_UseCases.tsx
@@ -140,14 +140,14 @@ const UseCases: FunctionComponent = () => {
                     <Link href="/get-started">Get started</Link> for free with up to 10 teammates or{' '}
                     <Link href="/demo">request a demo</Link> to learn about our enterprise plan and to see Sourcegraph
                     in your own environment.
-                    <Link
-                        href="/demo"
-                        data-button-style={buttonStyle.primary}
-                        data-button-location={buttonLocation.bodyDemo}
-                        passHref={true}
-                        data-button-type="cta"
-                    >
-                        <a className="btn btn-primary mt-5 d-block d-sm-inline-block" href="#none">
+                    <Link href="/demo" passHref={true}>
+                        <a
+                            className="btn btn-primary mt-5 d-block d-sm-inline-block"
+                            href="#none"
+                            data-button-style={buttonStyle.primary}
+                            data-button-location={buttonLocation.bodyDemo}
+                            data-button-type="cta"
+                        >
                             Request a demo
                         </a>
                     </Link>

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -259,15 +259,15 @@ const PricingPage: FunctionComponent = () => (
                         </p>
                     </div>
                     <div className="col-md-6 pt-3 align-self-center text-center">
-                        <Link
-                            href="/get-started"
-                            data-button-style={buttonStyle.primary}
-                            data-button-location={buttonLocation.trySourcegraph}
-                            data-button-type="cta"
-                            passHref={true}
-                        >
+                        <Link href="/get-started"passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a className="btn btn-primary mx-2 mb-3" title="Try Sourcegraph now">
+                            <a
+                                className="btn btn-primary mx-2 mb-3"
+                                title="Try Sourcegraph now"
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.trySourcegraph}
+                                data-button-type="cta"
+                            >
                                 Try Sourcegraph now
                             </a>
                         </Link>

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -259,7 +259,7 @@ const PricingPage: FunctionComponent = () => (
                         </p>
                     </div>
                     <div className="col-md-6 pt-3 align-self-center text-center">
-                        <Link href="/get-started"passHref={true}>
+                        <Link href="/get-started" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
                                 className="btn btn-primary mx-2 mb-3"

--- a/src/pages/use-cases/code-health.tsx
+++ b/src/pages/use-cases/code-health.tsx
@@ -238,30 +238,27 @@ const UseCasePage: FunctionComponent = () => (
                                     entire codebase.
                                 </div>
                                 <div className="d-flex flex-column flex-lg-row pt-1">
-                                    <Link
-                                        href="/demo"
-                                        passHref={true}
-                                        data-button-style={buttonStyle.primary}
-                                        data-button-location={buttonLocation.hero}
-                                        data-button-type="cta"
-                                    >
+                                    <Link href="/demo" passHref={true}>
                                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                         <a
                                             className="btn btn-primary mr-lg-3 mb-lg-0 mb-3 w-md-100"
                                             title="Request a Demo."
+                                            data-button-style={buttonStyle.primary}
+                                            data-button-location={buttonLocation.hero}
+                                            data-button-type="cta"
                                         >
                                             Request a demo
                                         </a>
                                     </Link>
-                                    <Link
-                                        href="/get-started"
-                                        passHref={true}
-                                        data-button-style={buttonStyle.outline}
-                                        data-button-location={buttonLocation.hero}
-                                        data-button-type="cta"
-                                    >
+                                    <Link href="/get-started" passHref={true}>
                                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                        <a className="btn btn-outline-primary w-md-100" title="Try Sourcegraph.">
+                                        <a
+                                            className="btn btn-outline-primary w-md-100"
+                                            title="Try Sourcegraph."
+                                            data-button-style={buttonStyle.outline}
+                                            data-button-location={buttonLocation.hero}
+                                            data-button-type="cta"
+                                        >
                                             Try Sourcegraph now
                                         </a>
                                     </Link>
@@ -348,15 +345,15 @@ const UseCasePage: FunctionComponent = () => (
                         <p>Give your team the tools they need to build a healthier codebase.</p>
                     </div>
                     <div className="text-center col-12">
-                        <Link
-                            href="/demo"
-                            passHref={true}
-                            data-button-style={buttonStyle.primary}
-                            data-button-location={buttonLocation.bodyDemo}
-                            data-button-type="cta"
-                        >
+                        <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a className="btn btn-primary min-w-200" title="Request a Demo.">
+                            <a
+                                className="btn btn-primary min-w-200"
+                                title="Request a Demo."
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.bodyDemo}
+                                data-button-type="cta"
+                            >
                                 Request a demo
                             </a>
                         </Link>
@@ -392,15 +389,15 @@ const UseCasePage: FunctionComponent = () => (
             <div className="d-flex flex-wrap justify-content-center text-center mb-md-4">
                 <h2 className="w-100 font-weight-bold mb-4 mx-4 mx-lg-0">Ready to build a healthier codebase?</h2>
                 <div className="d-flex justify-content-center mb-lg-6">
-                    <Link
-                        href="/get-started"
-                        passHref={true}
-                        data-button-style={buttonStyle.primary}
-                        data-button-location={buttonLocation.trySourcegraph}
-                        data-button-type="cta"
-                    >
+                    <Link href="/get-started" passHref={true}>
                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                        <a className="btn btn-primary" title="Ready to get started?">
+                        <a
+                            className="btn btn-primary"
+                            title="Ready to get started?"
+                            data-button-style={buttonStyle.primary}
+                            data-button-location={buttonLocation.trySourcegraph}
+                            data-button-type="cta"
+                        >
                             Ready to get started?
                         </a>
                     </Link>

--- a/src/pages/use-cases/code-reuse.tsx
+++ b/src/pages/use-cases/code-reuse.tsx
@@ -179,30 +179,27 @@ const CodeReusePage: FunctionComponent = () => (
                                 on problems a teammate already solved.
                             </div>
                             <div className="d-flex flex-column flex-lg-row pt-1">
-                                <Link
-                                    href="/demo"
-                                    passHref={true}
-                                    data-button-style={buttonStyle.primary}
-                                    data-button-location={buttonLocation.hero}
-                                    data-button-type="cta"
-                                >
+                                <Link href="/demo" passHref={true}>
                                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                     <a
                                         className="btn btn-primary mr-lg-3 mb-lg-0 mb-3 w-md-100"
                                         title="Request a Demo."
+                                        data-button-style={buttonStyle.primary}
+                                        data-button-location={buttonLocation.hero}
+                                        data-button-type="cta"
                                     >
                                         Request a demo
                                     </a>
                                 </Link>
-                                <Link
-                                    href="/get-started"
-                                    passHref={true}
-                                    data-button-style={buttonStyle.outline}
-                                    data-button-location={buttonLocation.hero}
-                                    data-button-type="cta"
-                                >
+                                <Link href="/get-started" passHref={true}>
                                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                    <a className="btn btn-outline-primary w-md-100" title="Try Sourcegraph.">
+                                    <a
+                                        className="btn btn-outline-primary w-md-100"
+                                        title="Try Sourcegraph."
+                                        data-button-style={buttonStyle.outline}
+                                        data-button-location={buttonLocation.hero}
+                                        data-button-type="cta"
+                                    >
                                         Try Sourcegraph now
                                     </a>
                                 </Link>
@@ -284,15 +281,15 @@ const CodeReusePage: FunctionComponent = () => (
                         </p>
                     </div>
                     <div className="text-center col-12 px-0">
-                        <Link
-                            href="/demo"
-                            passHref={true}
-                            data-button-style={buttonStyle.primary}
-                            data-button-location={buttonLocation.bodyDemo}
-                            data-button-type="cta"
-                        >
+                        <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a className="btn btn-primary" title="Request a Demo.">
+                            <a
+                                className="btn btn-primary"
+                                title="Request a Demo."
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.bodyDemo}
+                                data-button-type="cta"
+                            >
                                 Request a demo
                             </a>
                         </Link>
@@ -325,15 +322,16 @@ const CodeReusePage: FunctionComponent = () => (
         <ContentSection>
             <div className="text-center">
                 <h1 className="font-weight-bold mb-6">Make the most of your existing code.</h1>
-                <Link
-                    href="/get-started"
-                    passHref={true}
-                    data-button-style={buttonStyle.primary}
-                    data-button-location={buttonLocation.trySourcegraph}
-                    data-button-type="cta"
-                >
+                <Link href="/get-started" passHref={true}>
                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                    <a className="btn btn-primary">Ready to get started?</a>
+                    <a
+                        className="btn btn-primary"
+                        data-button-style={buttonStyle.primary}
+                        data-button-location={buttonLocation.trySourcegraph}
+                        data-button-type="cta"
+                    >
+                        Ready to get started?
+                    </a>
                 </Link>
             </div>
         </ContentSection>

--- a/src/pages/use-cases/incident-response.tsx
+++ b/src/pages/use-cases/incident-response.tsx
@@ -197,30 +197,27 @@ const IncidentResponsePage: FunctionComponent = () => (
                                 services, and fix the issue everywhere in your codebase so it won't reoccur.
                             </div>
                             <div className="d-flex flex-column flex-lg-row pt-1">
-                                <Link
-                                    href="/demo"
-                                    passHref={true}
-                                    data-button-style={buttonStyle.primary}
-                                    data-button-location={buttonLocation.hero}
-                                    data-button-type="cta"
-                                >
+                                <Link href="/demo" passHref={true}>
                                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                     <a
                                         className="btn btn-primary mr-lg-3 mb-lg-0 mb-3 w-md-100"
                                         title="Request a Demo."
+                                        data-button-style={buttonStyle.primary}
+                                        data-button-location={buttonLocation.hero}
+                                        data-button-type="cta"
                                     >
                                         Request a demo
                                     </a>
                                 </Link>
-                                <Link
-                                    href="/get-started"
-                                    passHref={true}
-                                    data-button-style={buttonStyle.outline}
-                                    data-button-location={buttonLocation.hero}
-                                    data-button-type="cta"
-                                >
+                                <Link href="/get-started" passHref={true}>
                                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                    <a className="btn btn-outline-primary w-md-100" title="Try Sourcegraph.">
+                                    <a
+                                        className="btn btn-outline-primary w-md-100"
+                                        title="Try Sourcegraph."
+                                        data-button-style={buttonStyle.outline}
+                                        data-button-location={buttonLocation.hero}
+                                        data-button-type="cta"
+                                    >
                                         Try Sourcegraph now
                                     </a>
                                 </Link>
@@ -324,15 +321,15 @@ const IncidentResponsePage: FunctionComponent = () => (
                         </p>
                     </div>
                     <div className="text-center col-12 px-0">
-                        <Link
-                            href="/demo"
-                            passHref={true}
-                            data-button-style={buttonStyle.primary}
-                            data-button-location={buttonLocation.bodyDemo}
-                            data-button-type="cta"
-                        >
+                        <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a className="btn btn-primary" title="Request a Demo.">
+                            <a
+                                className="btn btn-primary"
+                                title="Request a Demo."
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.bodyDemo}
+                                data-button-type="cta"
+                            >
                                 Request a demo
                             </a>
                         </Link>
@@ -367,15 +364,16 @@ const IncidentResponsePage: FunctionComponent = () => (
                 <h2 className="font-weight-bold mb-4 mx-4 mx-lg-0">
                     Respond to incidents faster and more effectively.
                 </h2>
-                <Link
-                    href="/get-started"
-                    passHref={true}
-                    data-button-style={buttonStyle.primary}
-                    data-button-location={buttonLocation.trySourcegraph}
-                    data-button-type="cta"
-                >
+                <Link href="/get-started" passHref={true}>
                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                    <a className="btn btn-primary">Ready to get started?</a>
+                    <a
+                        className="btn btn-primary"
+                        data-button-style={buttonStyle.primary}
+                        data-button-location={buttonLocation.trySourcegraph}
+                        data-button-type="cta"
+                    >
+                        Ready to get started?
+                    </a>
                 </Link>
             </div>
         </ContentSection>

--- a/src/pages/use-cases/index.tsx
+++ b/src/pages/use-cases/index.tsx
@@ -40,11 +40,7 @@ const UseCases: React.FunctionComponent = () => (
 
                         <div className="list-group">
                             {features.map((feature: string) => (
-                                <Link
-                                    key={feature}
-                                    href={`#${kebabCase(feature)}`}
-                                    passHref={true}
-                                >
+                                <Link key={feature} href={`#${kebabCase(feature)}`} passHref={true}>
                                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                     <a
                                         className="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-decoration-none"

--- a/src/pages/use-cases/index.tsx
+++ b/src/pages/use-cases/index.tsx
@@ -44,12 +44,14 @@ const UseCases: React.FunctionComponent = () => (
                                     key={feature}
                                     href={`#${kebabCase(feature)}`}
                                     passHref={true}
-                                    data-button-style={buttonStyle.textWithArrow}
-                                    data-button-location={buttonLocation.hero}
-                                    data-button-type="cta"
                                 >
                                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                    <a className="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-decoration-none">
+                                    <a
+                                        className="list-group-item list-group-item-action d-flex justify-content-between align-items-center text-decoration-none"
+                                        data-button-style={buttonStyle.textWithArrow}
+                                        data-button-location={buttonLocation.hero}
+                                        data-button-type="cta"
+                                    >
                                         {feature}
                                         <ArrowRightIcon className="icon-inline ml-1" />
                                     </a>

--- a/src/pages/use-cases/onboarding.tsx
+++ b/src/pages/use-cases/onboarding.tsx
@@ -288,15 +288,15 @@ const UseCasePage: FunctionComponent = () => (
                         </p>
                     </div>
                     <div className="d-flex flex-column">
-                        <Link
-                            href="/demo"
-                            passHref={true}
-                            data-button-style={buttonStyle.primary}
-                            data-button-location={buttonLocation.bodyDemo}
-                            data-button-type="cta"
-                        >
+                        <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a className="btn btn-primary" title="Request a Demo.">
+                            <a
+                                className="btn btn-primary"
+                                title="Request a Demo."
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.bodyDemo}
+                                data-button-type="cta"
+                            >
                                 Request a demo
                             </a>
                         </Link>

--- a/src/pages/use-cases/vulnerabilities.tsx
+++ b/src/pages/use-cases/vulnerabilities.tsx
@@ -335,15 +335,15 @@ const UseCasePage: FunctionComponent = () => (
                         <p>Find, fix, and track vulnerable code quickly across your entire codebase.</p>
                     </div>
                     <div className="d-flex flex-column">
-                        <Link
-                            href="/demo"
-                            passHref={true}
-                            data-button-style={buttonStyle.primary}
-                            data-button-location={buttonLocation.bodyDemo}
-                            data-button-type="cta"
-                        >
+                        <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a className="btn btn-primary" title="Request a Demo.">
+                            <a
+                                className="btn btn-primary"
+                                title="Request a Demo."
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.bodyDemo}
+                                data-button-type="cta"
+                            >
                                 Request a demo
                             </a>
                         </Link>


### PR DESCRIPTION
### Changelog
- Closes #5390 
- Reinstates CTA changes from #5318 that were wiped in the merge

### Test

1. Ensure linting passes.
2. Ensure prettier has standardized the proposed changes.
3. Ensure dev and production builds work.
4. Nav to `/code-search` and ensure CTA's match the requirements
