### PR TITLE
Changelog redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,14 @@
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
 
+
+# ========== SOURCEGRAPH REDIRECTS ==========
+[[redirects]]
+  from = "/changelog"
+  to = "https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md"
+  status = 301
+# ========== END SOURCEGRAPH REDIRECTS ==========
+
 # ========== HANDBOOK REDIRECTS ==========
 [[redirects]]
   from = "/company"


### PR DESCRIPTION
### Changelog
Closes #5389 . Re-inserts `/changelog` redirect to SG Changelog

### Test

1. Ensure linting passes.
2. Ensure prettier has standardized the proposed changes.
3. Ensure dev and production builds work.
4. Try going to about.sourcegraph.com/changelog and observe if expected redirect happens