### PR TITLE
Add code insights back to mobile nav

### DIFF
--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -146,6 +146,9 @@ const Header: FunctionComponent<Props> = props => {
                                             <Link href="/batch-changes">Batch Changes</Link>
                                         </li>
                                         <li className="nav-link" role="presentation">
+                                            <Link href="/code-insights">Code Insights</Link>
+                                        </li>
+                                        <li className="nav-link" role="presentation">
                                             <a href="https://docs.sourcegraph.com/code_intelligence">
                                                 Code Intelligence
                                             </a>


### PR DESCRIPTION
Adds code insights back to mobile nav and closes #5391 5391

### Test

1. Ensure linting passes.
2. Ensure prettier has standardized the proposed changes.
3. Ensure dev and production builds work.
4. Ensure Code Insights nav link shows on mobile nav