### PR TITLE
HubSpot form loading, Clearbit, and automated build/linting workflow

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,6 +1,6 @@
-<!-- Provide a brief summary in a sentence or two of your changes. -->
-
 <!--
+Provide a brief summary in a sentence or two of your changes.
+
 Don't forget to:
 - Add reviewers
 - Assign yourself
@@ -10,7 +10,6 @@ Don't forget to:
 -->
 
 ### Changelog
-
 <!--
 Add a bulleted list of your changes in more detail including which issues this PR closes.
 Examples:
@@ -21,9 +20,7 @@ Examples:
 
 ### Test
 
-1. Ensure linting passes.
-2. Ensure prettier has standardized the proposed changes.
-3. Ensure dev and production builds work.
+1. Ensure prettier has standardized the proposed changes.
 <!--
 Please list any other relevant steps that your reviewer should do to test this PR.
 Examples:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,23 @@
+# This ensures our production-ready builds work
+name: Production Builds
+
+on:
+  pull_request:
+    types: [opened, synchronize]
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v3
+      - name: Setup Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16.15.0'
+      - name: Install dependencies
+        run: yarn ci
+      - name: Build production-ready site
+        run: yarn build

--- a/.github/workflows/lintAndBuild.yml
+++ b/.github/workflows/lintAndBuild.yml
@@ -1,5 +1,5 @@
-# This ensures our production-ready builds work
-name: Production Builds
+# This ensures our linting passes and our production-ready builds work
+name: Lint & Build
 
 on:
   pull_request:
@@ -19,5 +19,7 @@ jobs:
           node-version: '16.15.0'
       - name: Install dependencies
         run: yarn ci
+      - name: Linting
+        run: yarn lint
       - name: Build production-ready site
         run: yarn build

--- a/src/hooks/hubSpot.ts
+++ b/src/hooks/hubSpot.ts
@@ -54,11 +54,11 @@ interface HookProps {
 // Global script integrations for this hook used for HubSpot forms
 const hubSpotScript = '//js.hsforms.net/forms/v2.js'
 const jQueryScript = '//ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js'
-const clearbitScript = '!function(e){var o=document.getElementsByTagName("script")[0];if("object"==typeof e.ClearbitForHubspot)return console.log("Clearbit For HubSpot included more than once"),!1;e.ClearbitForHubspot={},e.ClearbitForHubspot.forms=[],e.ClearbitForHubspot.addForm=function(o){var t=o[0];"function"==typeof e.ClearbitForHubspot.onFormReady?e.ClearbitForHubspot.onFormReady(t):e.ClearbitForHubspot.forms.push(t)};var t=document.createElement("script");t.async=!0,t.src="https://hubspot.clearbit.com/v1/forms/pk_a66b9ed76e62c713c06aab39bfae7234/forms.js",o.parentNode.insertBefore(t,o),e.addEventListener("message",function(o){if("hsFormCallback"===o.data.type&&"onFormReady"===o.data.eventName)if(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0)e.ClearbitForHubspot.addForm(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'));else if(document.querySelectorAll("iframe.hs-form-iframe").length>0){document.querySelectorAll("iframe.hs-form-iframe").forEach(function(t){t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0&&e.ClearbitForHubspot.addForm(t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'))})}})}(window);'
+const clearbitScript =
+    '!function(e){var o=document.getElementsByTagName("script")[0];if("object"==typeof e.ClearbitForHubspot)return console.log("Clearbit For HubSpot included more than once"),!1;e.ClearbitForHubspot={},e.ClearbitForHubspot.forms=[],e.ClearbitForHubspot.addForm=function(o){var t=o[0];"function"==typeof e.ClearbitForHubspot.onFormReady?e.ClearbitForHubspot.onFormReady(t):e.ClearbitForHubspot.forms.push(t)};var t=document.createElement("script");t.async=!0,t.src="https://hubspot.clearbit.com/v1/forms/pk_a66b9ed76e62c713c06aab39bfae7234/forms.js",o.parentNode.insertBefore(t,o),e.addEventListener("message",function(o){if("hsFormCallback"===o.data.type&&"onFormReady"===o.data.eventName)if(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0)e.ClearbitForHubspot.addForm(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'));else if(document.querySelectorAll("iframe.hs-form-iframe").length>0){document.querySelectorAll("iframe.hs-form-iframe").forEach(function(t){t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0&&e.ClearbitForHubspot.addForm(t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'))})}})}(window);'
 
 // Gets a script element by its id
-const getScriptElement = (id: string): HTMLScriptElement | Element | null => 
-    document.querySelector(`#${id}`)
+const getScriptElement = (id: string): HTMLScriptElement | Element | null => document.querySelector(`#${id}`)
 
 // Removes a script element by its id
 const removeScriptElement = (id: string): void => {
@@ -68,13 +68,17 @@ const removeScriptElement = (id: string): void => {
 
 /**
  * This loads a script element and appends it to the document's head tag.
- * 
+ *
  * @param id - a unique identifier for the script element
  * @param script - the script src (whether it's used for the script tag's src or innerHTML)
  * @param innerHTML - whether or not to assign the script to the script tag's src attribute or append to it's innerHTML
  * @returns - an HTML Script Element
  */
-const loadScriptElement = (id: string, script: string, innerHTML?: boolean): Promise<HTMLScriptElement | Element | null> =>
+const loadScriptElement = (
+    id: string,
+    script: string,
+    innerHTML?: boolean
+): Promise<HTMLScriptElement | Element | null> =>
     new Promise(resolve => {
         const scriptElement = getScriptElement(id)
 
@@ -107,7 +111,7 @@ async function createHubSpotForm({
         .split(';')
         .reduce((key, string) => Object.assign(key, { [string.split('=')[0].trim()]: string.split('=')[1] }), {})
     const anonymousId = getAllCookies.sourcegraphAnonymousUid
-    const firstSourceURL = getAllCookies.sourcegraphSourceUrl    
+    const firstSourceURL = getAllCookies.sourcegraphSourceUrl
 
     const script = await loadScriptElement('hubspot', hubSpotScript)
     await loadScriptElement('jQuery', jQueryScript)

--- a/src/hooks/hubSpot.ts
+++ b/src/hooks/hubSpot.ts
@@ -102,7 +102,7 @@ async function createHubSpotForm({
     onFormSubmit,
     onFormSubmitted,
     onFormReady,
-}: HubSpotForm): void {
+}: HubSpotForm): Promise<void> {
     const getAllCookies: { [index: string]: string } = document.cookie
         .split(';')
         .reduce((key, string) => Object.assign(key, { [string.split('=')[0].trim()]: string.split('=')[1] }), {})
@@ -164,6 +164,7 @@ export const useHubSpot = ({
     onFormSubmitted,
 }: HookProps): void => {
     useEffect(() => {
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
         createHubSpotForm({
             region,
             portalId,

--- a/src/hooks/hubSpot.ts
+++ b/src/hooks/hubSpot.ts
@@ -24,7 +24,6 @@ interface HubSpotProps {
     portalId: string
     formId: string
     target: string
-    onBeforeFormInit: () => void
     formInstanceId?: string
     onFormSubmit?: (object: { data: { name: string; value: string }[] }) => void
     onFormReady?: ($form: HubSpotForm) => void
@@ -58,12 +57,12 @@ const jQueryScript = '//ajax.googleapis.com/ajax/libs/jquery/3.5.1/jquery.min.js
 const clearbitScript = '!function(e){var o=document.getElementsByTagName("script")[0];if("object"==typeof e.ClearbitForHubspot)return console.log("Clearbit For HubSpot included more than once"),!1;e.ClearbitForHubspot={},e.ClearbitForHubspot.forms=[],e.ClearbitForHubspot.addForm=function(o){var t=o[0];"function"==typeof e.ClearbitForHubspot.onFormReady?e.ClearbitForHubspot.onFormReady(t):e.ClearbitForHubspot.forms.push(t)};var t=document.createElement("script");t.async=!0,t.src="https://hubspot.clearbit.com/v1/forms/pk_a66b9ed76e62c713c06aab39bfae7234/forms.js",o.parentNode.insertBefore(t,o),e.addEventListener("message",function(o){if("hsFormCallback"===o.data.type&&"onFormReady"===o.data.eventName)if(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0)e.ClearbitForHubspot.addForm(document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'));else if(document.querySelectorAll("iframe.hs-form-iframe").length>0){document.querySelectorAll("iframe.hs-form-iframe").forEach(function(t){t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\').length>0&&e.ClearbitForHubspot.addForm(t.contentWindow.document.querySelectorAll(\'form[data-form-id="\'+o.data.id+\'"]\'))})}})}(window);'
 
 // Gets a script element by its id
-const getScriptElement = (id: string): Element | null => 
+const getScriptElement = (id: string): HTMLScriptElement | Element | null => 
     document.querySelector(`#${id}`)
 
 // Removes a script element by its id
 const removeScriptElement = (id: string): void => {
-    const scriptElement = getScriptElement(id)
+    const scriptElement: HTMLScriptElement | Element | null = getScriptElement(id)
     scriptElement?.remove()
 }
 
@@ -75,25 +74,26 @@ const removeScriptElement = (id: string): void => {
  * @param innerHTML - whether or not to assign the script to the script tag's src attribute or append to it's innerHTML
  * @returns - an HTML Script Element
  */
-const loadScriptElement = (id: string, script: string, innerHTML?: boolean): HTMLScriptElement | Element => {
-    const scriptElement = getScriptElement(id)
+const loadScriptElement = (id: string, script: string, innerHTML?: boolean): Promise<HTMLScriptElement | Element | null> =>
+    new Promise(resolve => {
+        const scriptElement = getScriptElement(id)
 
-    if (!scriptElement) {
-        const newScriptElement = document.createElement('script')
-        newScriptElement.setAttribute('id', id)
-        if (innerHTML) {
-            newScriptElement.innerHTML = script
-        } else {
-            newScriptElement.src = script
+        if (!scriptElement) {
+            const newScriptElement = document.createElement('script')
+            newScriptElement.setAttribute('id', id)
+            if (innerHTML) {
+                newScriptElement.innerHTML = script
+            } else {
+                newScriptElement.src = script
+            }
+            document.head.append(newScriptElement)
+            resolve(newScriptElement)
         }
-        document.head.append(newScriptElement)
-        return newScriptElement
-    }
 
-    return scriptElement
-}
+        resolve(scriptElement)
+    })
 
-function createHubSpotForm({
+async function createHubSpotForm({
     region,
     portalId,
     formId,
@@ -107,9 +107,12 @@ function createHubSpotForm({
         .split(';')
         .reduce((key, string) => Object.assign(key, { [string.split('=')[0].trim()]: string.split('=')[1] }), {})
     const anonymousId = getAllCookies.sourcegraphAnonymousUid
-    const firstSourceURL = getAllCookies.sourcegraphSourceUrl
+    const firstSourceURL = getAllCookies.sourcegraphSourceUrl    
 
-    const script = loadScriptElement('hubspot', hubSpotScript)
+    const script = await loadScriptElement('hubspot', hubSpotScript)
+    await loadScriptElement('jQuery', jQueryScript)
+    await loadScriptElement('clearbit', clearbitScript, true)
+
     script?.addEventListener('load', () => {
         window.hbspt?.forms.create({
             region: region || 'na1',
@@ -117,10 +120,6 @@ function createHubSpotForm({
             formId,
             formInstanceId,
             target: `#${targetId}`,
-            onBeforeFormInit: () => {
-                loadScriptElement('jQuery', jQueryScript)
-                loadScriptElement('clearbit', clearbitScript, true)
-            },
             onFormSubmit,
             onFormSubmitted,
             onFormReady: (form: HubSpotForm) => {

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -24,7 +24,7 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
                 src="https://tribl.io/h.js?orgId=Yee6bMKj7QSARqAePdE8"
                 strategy="beforeInteractive"
             />
-            
+
             {/* Triblio "Analytics and Overlay Cards" */}
             <Script
                 id="triblio-a"
@@ -34,11 +34,7 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
             />
 
             {/* Google Analytics */}
-            <Script
-                id="track-ga"
-                data-cookieconsent="ignore"
-                strategy="beforeInteractive"
-            >
+            <Script id="track-ga" data-cookieconsent="ignore" strategy="beforeInteractive">
                 {`
                 window.dataLayer = window.dataLayer || [];
                 function gtag() {
@@ -54,11 +50,7 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
             </Script>
 
             {/* Google Tag Manager */}
-            <Script
-                id="track-gtm"
-                data-cookieconsent="ignore"
-                strategy="beforeInteractive"
-            >
+            <Script id="track-gtm" data-cookieconsent="ignore" strategy="beforeInteractive">
                 {`
                 (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                 new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -79,11 +71,7 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
             />
 
             {/* Drift */}
-            <Script
-                id="drift"
-                type="text/javascript"
-                strategy="afterInteractive"
-            >
+            <Script id="drift" type="text/javascript" strategy="afterInteractive">
                 {`
                     "use strict";
                     !function() {


### PR DESCRIPTION
This PR ensures HubSpot, jQuery, and Clearbit are loaded sequentially in the proper order, so the necessary integrations work well together. This closes #5396.

### Changelog
- Changed `loadScriptElement` to resolve a promise so we can ensure scripts are loaded one by one instead of relying on HubSpot's `onBeforeFormInit` callback
- Added a GitHub workflow to ensure our linting and production builds work properly before merging to production
- Updated our PR template to remove manual testing

### Notes
- jQuery is [required](https://help.clearbit.com/hc/en-us/articles/360037598334-Set-Up-Clearbit-Enrichment-for-HubSpot-Forms#:~:text=To%20confirm%20jQuery%20is%20installed%20on%20your%20site) for Clearbit
- Clearbit could be configured to trigger [on specific pages](https://help.clearbit.com/hc/en-us/articles/360063559573-Install-the-Clearbit-Tag-#h_01FZBPR1N4GC5GY388F7RG0YDP) but the scripts would still be loaded site-wide. This PR only loads jQuery and Clearbit on pages with HubSpot forms for efficiency and performance gains.
- Clearbit whitelists `about.sourcegraph.com` and `info.sourcegraph.com` to recognize users. Our preview environments on Netlify `deploy-preview-{PullRequestNumber}-sourcegraph.netlify.com` can't be whitelisted since preview URLs are unique per PR.

### Test
1. Ensure prettier has standardized the proposed changes.
2. Ensure HubSpot forms load only once in the production build preview.
3. Test `/guides/continuous-developer-onboarding` as an example and submit a test to see if the form submits.
