### PR TITLE
Bug fixes for case study and use case pages

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -10,6 +10,7 @@ Don't forget to:
 -->
 
 ### Changelog
+
 <!--
 Add a bulleted list of your changes in more detail including which issues this PR closes.
 Examples:

--- a/src/components/Blockquote.tsx
+++ b/src/components/Blockquote.tsx
@@ -3,6 +3,8 @@ import { FunctionComponent, ReactFragment } from 'react'
 import ArrowRightIcon from 'mdi-react/ArrowRightIcon'
 import Link from 'next/link'
 
+import { buttonStyle, buttonLocation } from '@data'
+
 interface Logo {
     src: string
     alt: string
@@ -113,9 +115,14 @@ export const BlockquoteWithBorder: FunctionComponent<{
                     <ArrowRightIcon className="icon-inline ml-1" />
                 </a>
             ) : (
-                <Link href={link} passHref={true}>
+                <Link href={link.href} passHref={true}>
                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                    <a className="d-flex justify-content-center mt-3">
+                    <a
+                        className="d-flex justify-content-center mt-3"
+                        data-button-style={buttonStyle.textWithArrow}
+                        data-button-location={buttonLocation.body}
+                        data-button-type="cta"
+                    >
                         <p className="font-weight-bold">{link.text}</p>
                         <ArrowRightIcon className="icon-inline ml-1" />
                     </a>

--- a/src/components/CaseStudies/AuthorBio.tsx
+++ b/src/components/CaseStudies/AuthorBio.tsx
@@ -5,11 +5,14 @@ export const AuthorBio: React.FunctionComponent<{
     title: string
     about: string
 }> = ({ customer, image, author, title, about }) => (
-    <div className="d-flex flex-md-row flex-column align-items-center align-items-md-start container-xl py-6 py-md-8">
+    <div className="d-flex flex-column flex-md-row align-items-center align-items-md-start container-xl py-6 py-md-8">
         {image && (
             <div className="col-md-3 col-xl-2 text-center text-md-right">
-                {/* TODO: On Tailwind migration, trade out auotor-bio_img custom style for utility class: "border border-3 border-sky-400" */}
-                <img className="p-1 rounded-circle author-bio__img" src={image} alt={author} />
+                <img
+                    className="p-1 rounded-circle border border-3 border-pacific-blue max-w-150"
+                    src={image}
+                    alt={author}
+                />
             </div>
         )}
         <div className="col-md-4 col-xl-3 text-center text-md-left">

--- a/src/pages/guides/fixing-vulnerabilities-less-is-more.tsx
+++ b/src/pages/guides/fixing-vulnerabilities-less-is-more.tsx
@@ -23,7 +23,8 @@ export const Guide: FunctionComponent = () => (
                     <p>
                         When your company first got word of Log4j and the Log4Shell vulnerability, did you have the
                         tools in place to immediately fix it across every line of code in your organization? When the
-                        next vulnerability of that scale emerges (and it’s <i>when</i>, not <i>if</i> ), will you be ready?
+                        next vulnerability of that scale emerges (and it’s <i>when</i>, not <i>if</i> ), will you be
+                        ready?
                     </p>
                     <p>
                         Log4j made it clear that organizations need a new approach to prepare for the next inevitable

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -318,7 +318,7 @@ $positions: ('top', 'right', 'bottom', 'left');
 }
 
 /* ==================== Borders ==================== */
-// TODO: On Tailwind migration, trade out this style for utility class: "border-3"
+// TODO: On Tailwind migration, trade out these styles for border-x utility classes"
 .border-2 {
     border-width: 2px !important;
 }

--- a/src/styles/pages/__case_studies.scss
+++ b/src/styles/pages/__case_studies.scss
@@ -56,13 +56,6 @@
     }
 }
 
-.case-study .author-bio {
-    &__img {
-        // TODO: On Tailwind migration, trade out this style for utility class: "border border-3 border-sky-400"
-        border: 3px solid #00a1c7;
-    }
-}
-
 .lyft-case-study {
     .case-studies {
         &__logo {


### PR DESCRIPTION
This fixes two bugs and closes #5400 and closes #5402.

### Changelog
- Fixed max width on author image to prevent text overlapping in the `AuthorBio` component
- Cleanup: Removed one-off border style in lieu of our own border utility classes
- Fixed broken href attribute for the `BlockquoteWithBorder` component
- Addition: Added tracking to `BlockquoteWithBorder`

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure the author img does not overlap text on `/case-studies/nutanix-fixed-log4j-with-sourcegraph`
3. Ensure the `Read the case study` link on `/use-cases/code-reuse` in the blockquote section navigates to `/case-studies/factset-migrates-from-perforce-to-github`