### PR TITLE
Follow up for nav updates

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -31,9 +31,6 @@ const Footer: FunctionComponent<Props> = ({ minimal, className }) => (
                                 <li className="nav-item">
                                     <Link href="/pricing">Pricing</Link>
                                 </li>
-                                <li className="nav-item">
-                                    <Link href="/handouts/Sourcegraph-Overview.pdf">Sourcegraph overview (PDF)</Link>
-                                </li>
                             </ul>
                         </div>
 

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -31,6 +31,9 @@ const Footer: FunctionComponent<Props> = ({ minimal, className }) => (
                                 <li className="nav-item">
                                     <Link href="/pricing">Pricing</Link>
                                 </li>
+                                <li className="nav-item">
+                                    <Link href="/handouts/Sourcegraph-Overview.pdf">Sourcegraph Overview</Link>
+                                </li>
                             </ul>
                         </div>
 

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -32,7 +32,7 @@ const Footer: FunctionComponent<Props> = ({ minimal, className }) => (
                                     <Link href="/pricing">Pricing</Link>
                                 </li>
                                 <li className="nav-item">
-                                    <Link href="/handouts/Sourcegraph-Overview.pdf">Sourcegraph Overview</Link>
+                                    <Link href="/handouts/Sourcegraph-Overview.pdf">Sourcegraph overview</Link>
                                 </li>
                             </ul>
                         </div>


### PR DESCRIPTION
Follow up for #5395, removing "PDF" from the Sourcegraph Overview copy

### Test

1. Ensure prettier has standardized the proposed changes.
2. The copy "pdf" is removed from the "Sourcegraph Overview" link