### PR TITLE
Code Security Copy Update

### DIFF
--- a/src/pages/2022-gartner-cool-vendors-in-software-engineering.tsx
+++ b/src/pages/2022-gartner-cool-vendors-in-software-engineering.tsx
@@ -28,13 +28,22 @@ export const Report: FunctionComponent = () => (
                         Get complimentary access to the 2022 Gartner® Cool Vendors™ report.
                     </h3>
                     <p className="pb-2">
-                        Learn how we believe Sourcegraph and other innovative tools help engineers and engineering leaders boost developer productivity while mitigating security risks.
+                        Learn how we believe Sourcegraph and other innovative tools help engineers and engineering
+                        leaders boost developer productivity while mitigating security risks.
                     </p>
                     <p className="text-muted">
-                        The GARTNER COOL VENDOR badge and Gartner are registered trademarks and service mark of Gartner, Inc. and/or its affiliates and is used herein with permission. All rights reserved. Gartner does not endorse any vendor, product or service depicted in its research publications and does not advise technology users to select only those vendors with the highest ratings or other designation. Gartner research publications consist of the opinions of Gartner’s Research & Advisory organization and should not be construed as statements of fact. Gartner disclaims all warranties, expressed or implied, with respect to this research, including any warranties of merchantability or fitness for a particular purpose.
+                        The GARTNER COOL VENDOR badge and Gartner are registered trademarks and service mark of Gartner,
+                        Inc. and/or its affiliates and is used herein with permission. All rights reserved. Gartner does
+                        not endorse any vendor, product or service depicted in its research publications and does not
+                        advise technology users to select only those vendors with the highest ratings or other
+                        designation. Gartner research publications consist of the opinions of Gartner’s Research &
+                        Advisory organization and should not be construed as statements of fact. Gartner disclaims all
+                        warranties, expressed or implied, with respect to this research, including any warranties of
+                        merchantability or fitness for a particular purpose.
                     </p>
                     <p className="pb-2 text-muted">
-                        Gartner, Cool Vendors in Software Engineering: Enhancing Developer Productivity, Cool Vendors in Software Engineering: Enhancing Developer Productivity, 16th May 2022.
+                        Gartner, Cool Vendors in Software Engineering: Enhancing Developer Productivity, Cool Vendors in
+                        Software Engineering: Enhancing Developer Productivity, 16th May 2022.
                     </p>
                 </section>
             }

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -129,11 +129,7 @@ export const Community: FunctionComponent = () => (
                         </li>
                         <li className="mt-2">Share the road less traveled so that everyone can learn</li>
                     </ul>
-                    <a
-                        className="btn btn-primary"
-                        href="https://discord.gg/rDPqBejz93"
-                        title="Join us on Discord"
-                    >
+                    <a className="btn btn-primary" href="https://discord.gg/rDPqBejz93" title="Join us on Discord">
                         Join us on Discord
                     </a>
                 </div>
@@ -223,8 +219,8 @@ export const Community: FunctionComponent = () => (
                 <div className="col-lg-7">
                     <h2 className="display-3 font-weight-bold mb-3">We’d love to hear from you!</h2>
                     <br />
-                    Connect with us on the Sourcegraph Community Discord server, direct message us on Twitter, LinkedIn, or
-                    email us at <a href="mailto:community@sourcegraph.com">community@sourcegraph.com</a>.
+                    Connect with us on the Sourcegraph Community Discord server, direct message us on Twitter, LinkedIn,
+                    or email us at <a href="mailto:community@sourcegraph.com">community@sourcegraph.com</a>.
                 </div>
                 <div className="col-lg-5 mt-3">
                     <a

--- a/src/pages/support.tsx
+++ b/src/pages/support.tsx
@@ -49,7 +49,7 @@ const Support: FunctionComponent = () => (
                             <div className="card-body">
                                 <h1 className="card-title mt-3 mb-3 text-center">Free</h1>
                                 <a
-                                    className="font-size-base min-w-150 btn btn-outline-primary w-100 justify-content-center text-center d-inline-flex"
+                                    className="font-size-base btn btn-outline-primary w-100 justify-content-center text-center d-inline-flex"
                                     href="https://docs.sourcegraph.com#quickstart-guide"
                                 >
                                     Deploy
@@ -99,7 +99,7 @@ const Support: FunctionComponent = () => (
                             <div className="card-body">
                                 <h1 className="card-title mt-3 mb-3 text-center">Team</h1>
                                 <a
-                                    className="font-size-base min-w-150 btn btn-success w-100 justify-content-center text-center d-inline-flex"
+                                    className="font-size-base btn btn-success w-100 justify-content-center text-center d-inline-flex"
                                     href="https://sourcegraph.com/subscriptions/new"
                                 >
                                     Buy now
@@ -153,7 +153,7 @@ const Support: FunctionComponent = () => (
                                     passHref={true}
                                 >
                                     {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                    <a className="font-size-base min-w-150 btn btn-outline-primary w-100 justify-content-center text-center d-inline-flex">
+                                    <a className="font-size-base btn btn-outline-primary w-100 justify-content-center text-center d-inline-flex">
                                         Contact us
                                     </a>
                                 </Link>

--- a/src/pages/use-cases/code-health.tsx
+++ b/src/pages/use-cases/code-health.tsx
@@ -348,7 +348,7 @@ const UseCasePage: FunctionComponent = () => (
                         <h1 className="font-weight-bold">Get started with Sourcegraph</h1>
                         <p>Give your team the tools they need to build a healthier codebase.</p>
                     </div>
-                    <div className="text-center col-12">
+                    <div className="text-center col-12 px-0">
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
@@ -375,7 +375,10 @@ const UseCasePage: FunctionComponent = () => (
                     </div>
                 </div>
             </ContentSection>
-            <CustomerLogos />
+
+            <div className="mt-6">
+                <CustomerLogos />
+            </div>
         </div>
 
         <ContentSection className="py-lg-7 py-5">

--- a/src/pages/use-cases/code-health.tsx
+++ b/src/pages/use-cases/code-health.tsx
@@ -352,7 +352,7 @@ const UseCasePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary min-w-200"
+                                className="btn btn-primary max-w-200 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/code-health.tsx
+++ b/src/pages/use-cases/code-health.tsx
@@ -237,7 +237,7 @@ const UseCasePage: FunctionComponent = () => (
                                     Improve code health with large-scale changes and track key initiatives across your
                                     entire codebase.
                                 </div>
-                                <div className="flex-column flex-md-row d-md-flex align-items-center">
+                                <div className="flex-column flex-md-row d-md-flex text-center">
                                     <div className="mb-3 mb-md-0">
                                         <Link href="/demo" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
@@ -352,7 +352,7 @@ const UseCasePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary max-w-200 w-100"
+                                className="btn btn-primary max-w-350 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/code-health.tsx
+++ b/src/pages/use-cases/code-health.tsx
@@ -237,12 +237,12 @@ const UseCasePage: FunctionComponent = () => (
                                     Improve code health with large-scale changes and track key initiatives across your
                                     entire codebase.
                                 </div>
-                                <div className="max-w-400 flex-column flex-md-row d-md-flex align-items-center">
+                                <div className="flex-column flex-md-row d-md-flex align-items-center">
                                     <div className="mb-3 mb-md-0">
                                         <Link href="/demo" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                             <a
-                                                className="btn btn-primary w-100"
+                                                className="btn btn-primary w-100 max-w-350"
                                                 title="Request a Demo."
                                                 data-button-style={buttonStyle.primary}
                                                 data-button-location={buttonLocation.hero}
@@ -256,7 +256,7 @@ const UseCasePage: FunctionComponent = () => (
                                         <Link href="/get-started" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                             <a
-                                                className="btn btn-outline-primary w-100"
+                                                className="btn btn-outline-primary w-100 max-w-350"
                                                 title="Try Sourcegraph."
                                                 data-button-style={buttonStyle.outline}
                                                 data-button-location={buttonLocation.hero}

--- a/src/pages/use-cases/code-reuse.tsx
+++ b/src/pages/use-cases/code-reuse.tsx
@@ -178,7 +178,7 @@ const CodeReusePage: FunctionComponent = () => (
                                 Identify existing code libraries for reuse and use innersourcing to avoid spending time
                                 on problems a teammate already solved.
                             </div>
-                            <div className="flex-column flex-md-row d-md-flex align-items-center">
+                            <div className="flex-column flex-md-row d-md-flex text-center">
                                 <div className="mb-3 mb-md-0">
                                     <Link href="/demo" passHref={true}>
                                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
@@ -288,7 +288,7 @@ const CodeReusePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary max-w-200 w-100"
+                                className="btn btn-primary max-w-350 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/code-reuse.tsx
+++ b/src/pages/use-cases/code-reuse.tsx
@@ -178,12 +178,12 @@ const CodeReusePage: FunctionComponent = () => (
                                 Identify existing code libraries for reuse and use innersourcing to avoid spending time
                                 on problems a teammate already solved.
                             </div>
-                            <div className="max-w-400 flex-column flex-md-row d-md-flex align-items-center">
+                            <div className="flex-column flex-md-row d-md-flex align-items-center">
                                 <div className="mb-3 mb-md-0">
                                     <Link href="/demo" passHref={true}>
                                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                         <a
-                                            className="btn btn-primary w-100"
+                                            className="btn btn-primary w-100 max-w-350"
                                             title="Request a Demo."
                                             data-button-style={buttonStyle.primary}
                                             data-button-location={buttonLocation.hero}
@@ -197,7 +197,7 @@ const CodeReusePage: FunctionComponent = () => (
                                     <Link href="/get-started" passHref={true}>
                                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                         <a
-                                            className="btn btn-outline-primary w-100"
+                                            className="btn btn-outline-primary w-100 max-w-350"
                                             title="Try Sourcegraph."
                                             data-button-style={buttonStyle.outline}
                                             data-button-location={buttonLocation.hero}

--- a/src/pages/use-cases/code-reuse.tsx
+++ b/src/pages/use-cases/code-reuse.tsx
@@ -274,9 +274,9 @@ const CodeReusePage: FunctionComponent = () => (
             </div>
         </ContentSection>
 
-        <div className="bg-light-gray-3">
+        <div className="bg-light-gray-3 py-7">
             <ContentSection>
-                <div className="row d-flex flex-column mx-4 mx-lg-0 py-7 align-items-lg-center align-items-left">
+                <div className="row d-flex flex-column mx-4 mx-lg-0 align-items-lg-center align-items-left">
                     <div className="mb-5 d-flex flex-column text-start text-md-center max-w-600 mx-auto">
                         <h1 className="font-weight-bold">Get started with Sourcegraph</h1>
                         <p>
@@ -288,7 +288,7 @@ const CodeReusePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary"
+                                className="btn btn-primary min-w-200"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}
@@ -307,7 +307,7 @@ const CodeReusePage: FunctionComponent = () => (
                 </div>
             </ContentSection>
 
-            <div className="py-6">
+            <div className="mt-6">
                 <CustomerLogos />
             </div>
         </div>

--- a/src/pages/use-cases/code-reuse.tsx
+++ b/src/pages/use-cases/code-reuse.tsx
@@ -288,7 +288,7 @@ const CodeReusePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary min-w-200"
+                                className="btn btn-primary max-w-200 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/code-security.tsx
+++ b/src/pages/use-cases/code-security.tsx
@@ -227,7 +227,7 @@ const UseCasePage: FunctionComponent = () => (
                                     Find, fix, and track vulnerable code across your entire codebase in minutes, not
                                     days
                                 </div>
-                                <div className="flex-column flex-md-row d-md-flex align-items-center">
+                                <div className="flex-column flex-md-row d-md-flex text-center">
                                     <div className="mb-3 mb-md-0">
                                         <Link href="/demo" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
@@ -352,7 +352,7 @@ const UseCasePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary max-w-200 w-100"
+                                className="btn btn-primary max-w-350 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/code-security.tsx
+++ b/src/pages/use-cases/code-security.tsx
@@ -227,12 +227,12 @@ const UseCasePage: FunctionComponent = () => (
                                     Find, fix, and track vulnerable code across your entire codebase in minutes, not
                                     days
                                 </div>
-                                <div className="max-w-400 flex-column flex-md-row d-md-flex align-items-center">
+                                <div className="flex-column flex-md-row d-md-flex align-items-center">
                                     <div className="mb-3 mb-md-0">
                                         <Link href="/demo" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                             <a
-                                                className="btn btn-primary w-100"
+                                                className="btn btn-primary w-100 max-w-350"
                                                 title="Request a Demo."
                                                 data-button-style={buttonStyle.primary}
                                                 data-button-location={buttonLocation.hero}
@@ -246,7 +246,7 @@ const UseCasePage: FunctionComponent = () => (
                                         <Link href="/get-started" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                             <a
-                                                className="btn btn-outline-primary w-100"
+                                                className="btn btn-outline-primary w-100 max-w-350"
                                                 title="Try Sourcegraph."
                                                 data-button-style={buttonStyle.outline}
                                                 data-button-location={buttonLocation.hero}

--- a/src/pages/use-cases/code-security.tsx
+++ b/src/pages/use-cases/code-security.tsx
@@ -352,7 +352,7 @@ const UseCasePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary min-w-200"
+                                className="btn btn-primary max-w-200 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/code-security.tsx
+++ b/src/pages/use-cases/code-security.tsx
@@ -341,18 +341,18 @@ const UseCasePage: FunctionComponent = () => (
         <div className="bg-light-gray-3 py-7">
             <ContentSection>
                 <div className="row d-flex flex-column mx-4 mx-lg-0 align-items-lg-center align-items-left">
-                    <div className="mb-5 d-flex flex-column">
+                    <div className="mb-5 d-flex flex-column text-start text-md-center mx-auto align-items-lg-center">
                         <h1 className="font-weight-bold">Get started with Sourcegraph</h1>
-                        <p>
+                        <p className="max-w-450">
                             Find, fix, and track vulnerable code quickly across your entire codebase to improve code
                             security.
                         </p>
                     </div>
-                    <div className="d-flex flex-column">
+                    <div className="text-center col-12 px-0">
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary"
+                                className="btn btn-primary min-w-200"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/code-security.tsx
+++ b/src/pages/use-cases/code-security.tsx
@@ -103,9 +103,9 @@ const items = [
                 header="Bring peace of mind to customers"
                 text={
                     <p>
-                        The last thing you want to do is walk back an “all clear” report. With Sourcegraph, you can know
-                        you'll find every instance of affected code, be able to fix it at scale, monitor for its
-                        presence long-term, and ensure your customers that your code is safe.
+                        The last thing you want to do is walk back an “all clear” report. With Sourcegraph, you can
+                        quickly identify and understand the severity of a vulnerability so you can communicate your
+                        remediation plan to customers faster and deploy fixes sooner.
                     </p>
                 }
             />
@@ -218,16 +218,14 @@ const UseCasePage: FunctionComponent = () => (
         hero={
             <>
                 <div className={styles.pageHeader}>
-                    <div className="container pb-4">
+                    <div className="container">
                         <div className="row">
                             <div className="col-lg-7 mb-8 mt-7">
                                 <BackButtonBold href="/use-cases" text="USE CASES" />
-                                <h1 className="display-2 font-weight-bold mb-4">
-                                    Find and fix security vulnerabilities
-                                </h1>
+                                <h1 className="display-2 font-weight-bold mb-4">Improve code security</h1>
                                 <div className="display-4 font-weight-normal mb-5">
-                                    Search across all your repositories to find and resolve vulnerabilities in minutes,
-                                    not days.
+                                    Find, fix, and track vulnerable code across your entire codebase in minutes, not
+                                    days
                                 </div>
                                 <div className="max-w-400 flex-column flex-md-row d-md-flex align-items-center">
                                     <div className="mb-3 mb-md-0">
@@ -345,7 +343,10 @@ const UseCasePage: FunctionComponent = () => (
                 <div className="row d-flex flex-column mx-4 mx-lg-0 align-items-lg-center align-items-left">
                     <div className="mb-5 d-flex flex-column">
                         <h1 className="font-weight-bold">Get started with Sourcegraph</h1>
-                        <p>Find, fix, and track vulnerable code quickly across your entire codebase.</p>
+                        <p>
+                            Find, fix, and track vulnerable code quickly across your entire codebase to improve code
+                            security.
+                        </p>
                     </div>
                     <div className="d-flex flex-column">
                         <Link href="/demo" passHref={true}>

--- a/src/pages/use-cases/incident-response.tsx
+++ b/src/pages/use-cases/incident-response.tsx
@@ -196,12 +196,12 @@ const IncidentResponsePage: FunctionComponent = () => (
                                 Identify the root cause of an incident, understand its potential impact on other
                                 services, and fix the issue everywhere in your codebase so it won't reoccur.
                             </div>
-                            <div className="max-w-400 flex-column flex-md-row d-md-flex align-items-center">
+                            <div className="flex-column flex-md-row d-md-flex align-items-center">
                                 <div className="mb-3 mb-md-0">
                                     <Link href="/demo" passHref={true}>
                                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                         <a
-                                            className="btn btn-primary w-100"
+                                            className="btn btn-primary w-100 max-w-350"
                                             title="Request a Demo."
                                             data-button-style={buttonStyle.primary}
                                             data-button-location={buttonLocation.hero}
@@ -215,7 +215,7 @@ const IncidentResponsePage: FunctionComponent = () => (
                                     <Link href="/get-started" passHref={true}>
                                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                         <a
-                                            className="btn btn-outline-primary w-100"
+                                            className="btn btn-outline-primary w-100 max-w-350"
                                             title="Try Sourcegraph."
                                             data-button-style={buttonStyle.outline}
                                             data-button-location={buttonLocation.hero}

--- a/src/pages/use-cases/incident-response.tsx
+++ b/src/pages/use-cases/incident-response.tsx
@@ -196,7 +196,7 @@ const IncidentResponsePage: FunctionComponent = () => (
                                 Identify the root cause of an incident, understand its potential impact on other
                                 services, and fix the issue everywhere in your codebase so it won't reoccur.
                             </div>
-                            <div className="flex-column flex-md-row d-md-flex align-items-center">
+                            <div className="flex-column flex-md-row d-md-flex text-center">
                                 <div className="mb-3 mb-md-0">
                                     <Link href="/demo" passHref={true}>
                                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
@@ -328,7 +328,7 @@ const IncidentResponsePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary max-w-200 w-100"
+                                className="btn btn-primary max-w-350 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/incident-response.tsx
+++ b/src/pages/use-cases/incident-response.tsx
@@ -328,7 +328,7 @@ const IncidentResponsePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary min-w-200"
+                                className="btn btn-primary max-w-200 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/incident-response.tsx
+++ b/src/pages/use-cases/incident-response.tsx
@@ -314,9 +314,9 @@ const IncidentResponsePage: FunctionComponent = () => (
             </ContentSection>
         </div>
 
-        <div className="bg-light-gray-3">
+        <div className="bg-light-gray-3 py-7">
             <ContentSection>
-                <div className="row d-flex flex-column mx-4 mx-lg-0 py-7 align-items-lg-center align-items-left">
+                <div className="row d-flex flex-column mx-4 mx-lg-0 align-items-lg-center align-items-left">
                     <div className="mb-5 d-flex flex-column text-start text-md-center max-w-600 mx-auto">
                         <h1 className="font-weight-bold">Get started with Sourcegraph</h1>
                         <p>
@@ -328,7 +328,7 @@ const IncidentResponsePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary"
+                                className="btn btn-primary min-w-200"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}
@@ -347,7 +347,7 @@ const IncidentResponsePage: FunctionComponent = () => (
                 </div>
             </ContentSection>
 
-            <div className="py-6">
+            <div className="mt-6">
                 <CustomerLogos />
             </div>
         </div>

--- a/src/pages/use-cases/index.tsx
+++ b/src/pages/use-cases/index.tsx
@@ -11,7 +11,7 @@ import styles from './useCases.module.scss'
 const features: { id: string; description: string }[] = [
     {
         id: 'code-security',
-        description: 'Find and fix security vulnerabilities',
+        description: 'Improve code security',
     },
     {
         id: 'onboarding',
@@ -51,7 +51,7 @@ const UseCases: React.FunctionComponent = () => (
                     </div>
 
                     <div className="col-lg-5 mt-lg-6 pt-4 mb-6">
-                        <h2 className={`${styles.seeHow} font-weight-normal`}>See how customers use Sourcegraph to</h2>
+                        <h4 className="font-weight-bold pb-2">See how customers use Sourcegraph to</h4>
 
                         <div className="list-group">
                             {features.map((feature: { id: string; description: string }) => (
@@ -84,7 +84,7 @@ const UseCases: React.FunctionComponent = () => (
             <ContentSection id="code-security" className="pt-8">
                 <div className="row justify-content-center">
                     <div className="col-lg-6">
-                        <h2 className="display-3 font-weight-bold mb-3">Find and fix security vulnerabilities</h2>
+                        <h2 className="display-3 font-weight-bold mb-3">Improve code security</h2>
                         <h5>Find, fix, and track vulnerable code quickly across your entire codebase.</h5>
                         <p>
                             You can't fix what you can't find. Remediate vulnerabilities with confidence knowing you

--- a/src/pages/use-cases/onboarding.tsx
+++ b/src/pages/use-cases/onboarding.tsx
@@ -179,7 +179,7 @@ const UseCasePage: FunctionComponent = () => (
                                     Decrease time to first commit for new developers, help existing engineers master
                                     your codebase, and fast-track full codebase understanding.
                                 </div>
-                                <div className="flex-column flex-md-row d-md-flex align-items-center">
+                                <div className="flex-column flex-md-row d-md-flex text-center">
                                     <div className="mb-3 mb-md-0">
                                         <Link href="/demo" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
@@ -304,7 +304,7 @@ const UseCasePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary max-w-200 w-100"
+                                className="btn btn-primary max-w-350 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/onboarding.tsx
+++ b/src/pages/use-cases/onboarding.tsx
@@ -179,12 +179,12 @@ const UseCasePage: FunctionComponent = () => (
                                     Decrease time to first commit for new developers, help existing engineers master
                                     your codebase, and fast-track full codebase understanding.
                                 </div>
-                                <div className="max-w-400 flex-column flex-md-row d-md-flex align-items-center">
+                                <div className="flex-column flex-md-row d-md-flex align-items-center">
                                     <div className="mb-3 mb-md-0">
                                         <Link href="/demo" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                             <a
-                                                className="btn btn-primary w-100"
+                                                className="btn btn-primary w-100 max-w-350"
                                                 title="Request a Demo."
                                                 data-button-style={buttonStyle.primary}
                                                 data-button-location={buttonLocation.hero}
@@ -198,7 +198,7 @@ const UseCasePage: FunctionComponent = () => (
                                         <Link href="/get-started" passHref={true}>
                                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                             <a
-                                                className="btn btn-outline-primary w-100"
+                                                className="btn btn-outline-primary w-100 max-w-350"
                                                 title="Try Sourcegraph."
                                                 data-button-style={buttonStyle.outline}
                                                 data-button-location={buttonLocation.hero}

--- a/src/pages/use-cases/onboarding.tsx
+++ b/src/pages/use-cases/onboarding.tsx
@@ -304,7 +304,7 @@ const UseCasePage: FunctionComponent = () => (
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary min-w-200"
+                                className="btn btn-primary max-w-200 w-100"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}

--- a/src/pages/use-cases/onboarding.tsx
+++ b/src/pages/use-cases/onboarding.tsx
@@ -293,18 +293,18 @@ const UseCasePage: FunctionComponent = () => (
         <div className="bg-light-gray-3 py-7">
             <ContentSection>
                 <div className="row d-flex flex-column mx-4 mx-lg-0 align-items-lg-center align-items-left">
-                    <div className="mb-5 d-flex flex-column px-lg-7 text-center">
+                    <div className="mb-5 d-flex flex-column text-start text-md-center mx-auto max-w-550">
                         <h1 className="font-weight-bold">Give your team the onboarding experience they deserve.</h1>
                         <p>
                             Enable all your devs to find the answers they need to work more efficiently, ship code more
                             confidently, and stay in flow.
                         </p>
                     </div>
-                    <div className="d-flex flex-column">
+                    <div className="text-center col-12 px-0">
                         <Link href="/demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                             <a
-                                className="btn btn-primary"
+                                className="btn btn-primary min-w-200"
                                 title="Request a Demo."
                                 data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.bodyDemo}


### PR DESCRIPTION
This closes #5405. It updates the copy on the Code Security Use Case page.

### Changelog

- Changes made to copy on `/use-cases/code-security`
- Discovered inconsistencies in the spacing, buttons, and responsiveness of the "Try Sourcegraph" sections on the Use Case pages

### Notes

- No spec, but the copy changes are captured in this Markup: [link](https://app.markup.io/markup/856a513d-8fff-404f-8a1c-f48373ca3ce1)

### Test

1. Ensure prettier has standardized the proposed changes.
2. Navigate to `/use-cases/code-security`
3. Please ensure copy is transcribed
