### PR TITLE
Fix table scrolling gray bar on SCIP-TS blogpost

### DIFF
--- a/content/blogposts/2022/announcing-scip-typescript.md
+++ b/content/blogposts/2022/announcing-scip-typescript.md
@@ -46,7 +46,7 @@ Indexing a codebase with scip-typescript should have roughly similar performance
 
 We benchmarked scip-typescript by running it against several open source codebases to measure the indexing performance. The numbers are measured with a 2019 MacBook Pro with a 2.6 GHz 6-Core Intel Core.
 
-<div style={{overflowX: 'scroll'}}>
+<div style={{overflowX: 'auto'}}>
 <table>
     <tr>
         <th></th>


### PR DESCRIPTION
This closes #5457. If this solution is agreeable, we may reuse it for the other markdown tables in #5454. 

### Changelog

Before
<img width="500" alt="Screen Shot 2022-06-08 at 4 56 21 PM" src="https://user-images.githubusercontent.com/60713139/172725351-2fb82d49-f9d2-4b1a-b729-d85a6b46dca9.png">

After
<img width="500" alt="Screen Shot 2022-06-08 at 5 03 07 PM" src="https://user-images.githubusercontent.com/60713139/172725355-91f633b0-7afd-4d48-a783-8c1ef122175a.png">


### Test

1. Ensure prettier has standardized the proposed changes.
2. Navigate to `/blog/announcing-scip-typescript`
3. Please check that gray bar does not appear beneath the post on desktop
4. Please check that the table is scrollable when overflowing (on mobile)
