### PR TITLE
Follow up for video meta

### DIFF
--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -56,7 +56,7 @@ export const Layout: FunctionComponent<LayoutProps> = props => {
         watchURL: '',
     }
     if (meta.videoID) {
-        videoMeta.thumbnail = `https://i3.ytimg.com/vi/${meta.videoID}/maxresdefault.jpg`
+        videoMeta.thumbnail = `https://i3.ytimg.com/vi/${meta.videoID}/hqdefault.jpg`
         videoMeta.embedURL = `https://www.youtube.com/embed/${meta.videoID}`
         videoMeta.watchURL = `https://www.youtube.com/v/${meta.videoID}`
     }

--- a/src/components/Layout/index.tsx
+++ b/src/components/Layout/index.tsx
@@ -56,7 +56,7 @@ export const Layout: FunctionComponent<LayoutProps> = props => {
         watchURL: '',
     }
     if (meta.videoID) {
-        videoMeta.thumbnail = `https://i3.ytimg.com/vi/${meta.videoID}/hqdefault.jpg`
+        videoMeta.thumbnail = `https://img.youtube.com/vi/${meta.videoID}/maxresdefault.jpg`
         videoMeta.embedURL = `https://www.youtube.com/embed/${meta.videoID}`
         videoMeta.watchURL = `https://www.youtube.com/v/${meta.videoID}`
     }


### PR DESCRIPTION
This is a follow up PR for #5440 which replaces the YouTube thumbnail URL with the latest URL.

The previous URL was causing the inline social player not to render and caused inconsistent results.

### Test

1. Ensure prettier has standardized the proposed changes.
2. Test and share any podcast post that has a YouTube video ID on social media using the staging preview link. Most notably, test the [/podcast/max-howell](https://deploy-preview-5459--sourcegraph.netlify.app/podcast/max-howell) and [/podcast/ravi-parikh](https://deploy-preview-5459--sourcegraph.netlify.app/podcast/ravi-parikh) posts. Optionally use the [FB](https://developers.facebook.com/tools/debug) and [Twitter](https://cards-dev.twitter.com/validator) validator.

### From my tests

Facebook
![Screen Shot 2022-06-08 at 8 00 01 PM](https://user-images.githubusercontent.com/1733936/172737786-90696781-2f3f-4f1d-a7d2-db50cb7cdd58.png)

Twitter
![Screen Shot 2022-06-08 at 8 00 06 PM](https://user-images.githubusercontent.com/1733936/172737789-9c80ee5a-1166-4d81-b788-8dbb1e1e51f0.png)

Facebook
![Screen Shot 2022-06-08 at 8 00 32 PM](https://user-images.githubusercontent.com/1733936/172737790-35620ab3-336d-4f4a-9272-5d875f777a4c.png)

Twitter
![Screen Shot 2022-06-08 at 8 00 37 PM](https://user-images.githubusercontent.com/1733936/172737792-fdf18bc6-53bb-4d8f-8e6f-e9ddb6399abe.png)

