### PR TITLE
Hotfix/Webinar spacing

### DIFF
--- a/src/components/GatedResourceLayout/index.tsx
+++ b/src/components/GatedResourceLayout/index.tsx
@@ -101,7 +101,7 @@ export const GatedResourceLayout: FunctionComponent<Props> = ({
                 style={{ backgroundImage: `url('${heroImage().src}')` }}
                 className={classNames('bg-cover', isGuidePg && 'text-white')}
             >
-                <div className="container py-6 d-flex flex-column flex-lg-row justify-content-around align-items-center">
+                <div className="container py-7 d-flex flex-column flex-lg-row justify-content-around align-items-center">
                     {customer && (
                         <>
                             {isWebinarPg ? (

--- a/src/pages/webinars/code-insights-turning-your-metrics-into-action.tsx
+++ b/src/pages/webinars/code-insights-turning-your-metrics-into-action.tsx
@@ -91,7 +91,7 @@ const Webinar: FunctionComponent = () => {
                 }
                 videoSrc="https://www.youtube.com/embed/dXKvetMozB0"
                 learnMoreCTA={
-                    <ContentSection className="d-flex flex-column align-items-center py-6">
+                    <ContentSection className="d-flex flex-column align-items-center py-7">
                         <h1 className="font-weight-bold text-center">Want to learn more about Code Insights?</h1>
                         <Link href="/contact/request-code-insights-demo" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}

--- a/src/pages/webinars/preparing-for-the-next-log4j.tsx
+++ b/src/pages/webinars/preparing-for-the-next-log4j.tsx
@@ -83,7 +83,7 @@ const Webinar: FunctionComponent = () => {
                 }
                 videoSrc="https://www.youtube.com/embed/ANcbjQJ0OGI"
                 learnMoreCTA={
-                    <ContentSection className="d-flex flex-column align-items-center py-6">
+                    <ContentSection className="d-flex flex-column align-items-center py-7">
                         <h1 className="font-weight-bold text-center">Interesting in learning more?</h1>
                         <Link href="/case-studies/nutanix-fixed-log4j-with-sourcegraph" passHref={true}>
                             {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}


### PR DESCRIPTION
Follow up to [PR#5450](https://github.com/sourcegraph/about/pull/5450). Padding should be 6-rem, which is `p-7` in bootstrap, not `p-6`.

I'm checking with Tracey where the new spacing guidelines documentation lives so we can make a follow up ticket to standardize our containers around the site.