### PR TITLE
Hotfix/Webinar spacing

### DIFF
--- a/src/components/GatedResourceLayout/index.tsx
+++ b/src/components/GatedResourceLayout/index.tsx
@@ -158,7 +158,7 @@ export const GatedResourceLayout: FunctionComponent<Props> = ({
                 </div>
             ) : (
                 // ---- DEFAULT BODY VARIATION ----
-                <section className="bg-white py-6 pb-md-8">
+                <section className="bg-white py-7 pb-md-8">
                     <ContentSection className="d-flex flex-column-reverse flex-md-row">
                         {description}
 

--- a/src/components/GatedResourceLayout/index.tsx
+++ b/src/components/GatedResourceLayout/index.tsx
@@ -175,7 +175,7 @@ export const GatedResourceLayout: FunctionComponent<Props> = ({
             )}
 
             {speakers?.length && (
-                <section className="bg-white pb-6">
+                <section className="bg-white pb-7">
                     <ContentSection>
                         <h2 className="font-weight-bold">Speakers</h2>
 


### PR DESCRIPTION
Follow up to [PR#5450](https://github.com/sourcegraph/about/pull/5450). Padding should be 6-rem, which is `p-7` in bootstrap, not `p-6`.

Adheres to new spacing standardizations on webinar pages: https://www.figma.com/file/o1QRtdQI0ozKq0n7ATrKlx/Marketing-DLS?node-id=7649%3A36393.

~~Receiving brand design approval before engineering.~~ Approved by Brand Design