### PR TITLE
Collocated home redirect trailing slash fix

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -142,4 +142,5 @@
 [[redirects]]
   from = "/home"
   to = "/"
+  force = true
 # ========== END INDIVIDUAL REDIRECTS ==========

--- a/netlify.toml
+++ b/netlify.toml
@@ -140,6 +140,6 @@
 
 # Due to our collocated directory for the homepage
 [[redirects]]
-  from = "/home/*"
+  from = "/home"
   to = "/"
 # ========== END INDIVIDUAL REDIRECTS ==========

--- a/netlify.toml
+++ b/netlify.toml
@@ -140,7 +140,7 @@
 
 # Due to our collocated directory for the homepage
 [[redirects]]
-  from = "/home"
+  from = "/home/*"
   to = "/"
   force = true
 # ========== END INDIVIDUAL REDIRECTS ==========


### PR DESCRIPTION
Minor fix to the `/home` redirect which should point to `/` when there is and isn't a trailing slash. This forces the redirect no matter what to the root `/`.

Note, this implementation may change in the future with more added support for collocated/nested layouts in the next version of Next.js with their [layouts RFC](https://nextjs.org/blog/layouts-rfc).

### Test
1. Ensure `/home/` or `/home` or `/home/_hero` redirects to `/`