### PR TITLE
Remove strategy from all scripts

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -22,7 +22,6 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
                 id="triblio-p"
                 type="text/javascript"
                 src="https://tribl.io/h.js?orgId=Yee6bMKj7QSARqAePdE8"
-                strategy="beforeInteractive"
             />
 
             {/* Triblio "Analytics and Overlay Cards" */}
@@ -30,7 +29,6 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
                 id="triblio-a"
                 type="text/javascript"
                 src="https://tribl.io/footer.js?orgId=Yee6bMKj7QSARqAePdE8"
-                strategy="afterInteractive"
             />
 
             {/* Google Analytics */}
@@ -67,7 +65,6 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
                 data-cbid="fb31dc3e-afb3-4be8-ae84-7090bba7797d"
                 data-blockingmode="auto"
                 type="text/javascript"
-                strategy="afterInteractive"
             />
 
             {/* Drift */}


### PR DESCRIPTION
This removes the `strategy` attribute on our third party loaded scripts which was identified to cause issues noted in #5415.

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure the IDs `triblio-p` is loaded in the head, `triblio-a` is loaded in the body, and `Cookiebot` is loaded in the body. You can also test if they are available on the window. `window.TriblioAnalyticsObject` and `window.Cookiebot`