### PR TITLE
Updating hero image on the SCIP+TS blog

### DIFF
--- a/content/blogposts/2022/announcing-scip-typescript.md
+++ b/content/blogposts/2022/announcing-scip-typescript.md
@@ -7,8 +7,8 @@ authors:
 publishDate: 2022-06-08T18:00+02:00
 tags: [blog]
 slug: announcing-scip-typescript
-heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/announcing-scip-typescript.png
-socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/announcing-scip-typescript.png
+heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/announcing-scip-typescript-2.png
+socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/announcing-scip-typescript-2.png
 published: true
 ---
 


### PR DESCRIPTION
Updating to the new hero image to the one featuring the TS logo, for the SCIP+TS blog.