### PR TITLE
Shift Left Blogpost

### DIFF
--- a/content/blogposts/2022/announcing-scip.md
+++ b/content/blogposts/2022/announcing-scip.md
@@ -55,10 +55,8 @@ We are already using SCIP in our indexers scip-typescript (which supports TypeSc
 Don Stewart, an engineer at Meta, has integrated SCIP with [Glean](https://glean.software), the system that’s used at Meta for collecting, deriving, and querying facts about code. Don shared on Twitter that SCIP is “8x smaller, and can be processed 3x faster” in comparison with LSIF.
 
 <br/>
-<center>
 <blockquote className="twitter-tweet"><p lang="en" dir="ltr">Fri-yayy so hacked up native <a href="https://twitter.com/sourcegraph?ref_src=twsrc%5Etfw">@sourcegraph</a> SCIP support for TypeScript repos in Glean. The SCIP data is protobuf-encoded and typed, so compared to LSIF its about 8x smaller, and can be processed 3x faster. The mapping into Glean is ~550 loc, vs 1500 for LSIF. <br/><br/>Example queries: <a href="https://t.co/AZIRqVURLR">pic.twitter.com/AZIRqVURLR</a></p>&mdash; Don Stewart (@donsbot) <a href="https://twitter.com/donsbot/status/1530069211032465408?ref_src=twsrc%5Etfw">May 27, 2022</a></blockquote> 
 <script async src="https://platform.twitter.com/widgets.js" charSet="utf-8"></script>
-</center>
 <br/>
 
 Going forward, we anticipate SCIP additionally unblocks the following use-cases that we previously struggled to support with LSIF:

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -152,9 +152,9 @@ The first is having a security review process that is clear, transparent, and id
 The second is about shifting the security stance of the organization from reactive to proactive. Reactive means you wait for the next zero-day to emerge, which forces you to raise a fire-alarm that stops production on all the teams affected. This sort of scenario played out across numerous software organization when the Log4j vulnerability was released in late 2021. We wrote a [blog post](log4j-log4shell-0-day) to help organizations react and remediate quickly with automation.
 
 <YouTube 
-title="Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example."
-showTitle={true}
-id="13OqKPXqZXo"
+  title="Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example."
+  showTitle={true}
+  id="13OqKPXqZXo"
 />
 
 The benefit of this sort of automation is that it lets you preview the prospective change across all the different locations that have to change. Instead of having to manually open up pull requests to many different parts of the codebase, you can preview them before beginning review processes with many different teams. You also have the benefit of re-applying the patch should a new vulnerability emerge in a later version of the library, as happened with Log4j multiple times.

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -1,0 +1,165 @@
+---
+title: “Shift left” - wtf does it mean?
+description: Everyone's telling us to "shift left" these days, but what does that actually mean? What's being shifted? Who's doing the shifting? How far left should we shift it?
+authors:
+  - name: Beyang Liu
+    url: https://twitter.com/beyang
+publishDate: 2022-06-17T18:00+02:00
+tags: [blog]
+slug: shift-left-wtf-does-it-mean
+heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/shift-left.png
+socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/shift-left.png
+published: true
+---
+
+![scip-typescript: a new TypeScript and Javascript indexer](https://storage.googleapis.com/sourcegraph-assets/blog/shift-left.png)
+
+Everyone's telling us to "shift left" these days, but what does that actually mean? What's being shifted? Who's doing the shifting? How far left should we shift it?
+
+Here at Sourcegraph, we're not quite sure ourselves. But what we do know is that in most orgs, there are things you can do to enable devs to ship faster with greater reliability and security. And some of these things can also conceivably be described as "shifting left."
+
+So if your organization has identified "shift left" as a strategic priority, read on! We'll cover five specific things you can do to make your engineering org better while satisfying the "shift left" agenda.
+
+## A concrete definition
+
+"Shift left" is often used in reference to specific testing and security practices, but it also encapsulates a general philosophy that might be best summarized as, "Do the most important things as early as possible." We assert that Shift Left The Good Parts is ultimately about reaching key points of validation faster, so that you can iterate more rapidly against feedback.
+
+Those critical must-have points of validation vary with the project, but they generally fall into one of the following categories:
+1. User value—are you building something the user actually wants?
+2. Context—does it fit well into the broader system and take advantage of what that system provides?
+3. Testing—does it actually do what you say it does correctly and reliably?
+4. Security—does it preserve the privacy and integrity of the overall system?
+5. Review—does it pass muster with the folks responsible for maintaining the system?
+
+The importance of these validation areas can be highlighted by their failure modes, which are all too familiar:
+1. The Over-Engineered Boondoggle that sucks up time and resources but is never used because it doesn't solve a real problem
+2. The Reinvented Wheel, which takes longer to build and doesn't work all that well
+3. The Big Launch that bugs out or falls over under production traffic
+4. The Security Hole and the subsequent Emergency Fire Alarm Patch
+5. The Back to the Drawing Board that must be rewritten after a major design flaw is caught only in final review
+
+To prevent these failure scenarios, the naive inclination is to introduce a new gatekeeper—design review, testing and validation, code review, security review, etc. But the issue is that by the review stage in the development cycle, you've already used up a great deal of developer time. So while gatekeepers may save you from shipping a bad system, they can only get you to the point of not shipping a system at all, rather than shipping a system that works well for your customer.
+
+The real solution is to "shift left" as many of these validation points as possible, which means empowering the developer driving the project to validate these points much earlier than the formal review step.
+
+## User value
+
+It seems like an obvious statement, but a surprising number of software projects make it very far along before validating that the deliverable actually delivers value to the end user. Shifting left the user validation means getting to an MVP as quickly as possible that can be shared with users, even in a hacky state, to solicit direct, high-fidelity feedback.
+
+Time is of the essence. Discovering existing functions and functionality early on—and avoiding the temptation to reinvent the wheel—can save loads of time.
+
+<figcaption>Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.</figcaption>
+<br />
+
+In order to take full advantage of existing libraries, you need to be able to understand how to use them quickly. This applies to both open source and inner source. Shared libraries must not only be available, they must be accessible and understandable.
+
+Investing in great documentation helps, but this is a hard change to make if your codebase isn't already well-documented. The best way to learn is by example. A single real usage example can be worth a thousand words of documentation.
+
+<figcaption>Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.</figcaption>
+<br />
+
+By stitching together existing components, you can spin up a basic, hacky version of a new feature or product 10x more quickly. Ideally, you don't even have to worry about spinning up a production environment before soliciting user feedback—tools like ngrok enable you to quickly and securely share your service running on your local machine to the feedback partners you'd like to reach around the world.
+
+## Context
+
+Most code is written in the context of an existing codebase. It is important to understand the existing code well, as it offers both constraints and opportunities:
+
+- The constraints can be architectural or stylistic, some enforced by convention, others by iron laws of computer science.
+  - Conventional constraints include code style, design patterns, linting rules, static checks, and test coverage.
+  - Iron constraints are things like consistency guarantees provided by the database (and the invocation patterns that accompany accessing a system like this), performance characteristics, and the underlying datastructures and algorithms used to access and process data.
+- The opportunities include reusing and hardening existing libraries and services, or learning useful design patterns and best practices from existing code in the codebase, perhaps written by a senior developer you admire or seek to emulate.
+
+Context acquisition is one of the most time-consuming parts of the job—unless you're in a completely new codebase, you probably spend more time acquiring context than you do writing new code. It's like that old saying: "If I had an hour to chop down a tree, I'd spend the first 45 minutes sharpening my axe." So it goes with context. With the proper context, you can code at the speed of thought. Without the proper context, you'll find yourself pulled out of [flow](developer-productivity-thoughts#picture-2-reaching-flow-state) again and again when you need to go look something up or realize you wasted an hour writing something that already exists.
+
+Acquiring context means understanding the structure and relationships in code. This becomes 10x easier when you have code navigation. Not having jump-to-def and xrefs is like trying to browse the web without hyperlinks.
+
+<figcaption>Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.</figcaption>
+<br />
+
+<figcaption>Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.</figcaption>
+<br />
+
+Targeted pieces of documentation can help guide new devs to quickly acquire the essential aspects of an area of code. You'll ideally want to use a tool that integrates nicely with the source code and doesn't go stale with time.
+
+<figcaption>Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.</figcaption>
+<br />
+
+It may seem obvious to state that you should acquire the necessary context before investing a large amount of time writing code, but many projects waste the first weeks and months of their timeline because the engineers were too eager to start breaking ground and did not acquire a good sense of the lay of the land.
+
+## Testing
+
+Reading tests is a good way to understand the structure of the code. Unit tests provide examples of the canonical invocations of public APIs—they show you how you're supposed to use them. For this reason, reading unit tests is often more helpful than reading the documentation.
+
+<figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
+<br />
+
+It's also helpful to understand how well tested the current code is. Test coverage can be a proxy for general code quality, which is something you want to keep in mind. You may want to add tests beforehand, so you don't have to waste a bunch of time manually testing and debugging uncaught failure modes later.
+
+<figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
+<br />
+
+If the desired functionality is clear and has been validated (see the earlier section about User Value), then writing tests first—before any other code—can help you be disciplined about defining a good API boundary. This is commonly called "Test-Driven Development."
+
+Thorough unit tests are essential to ensuring the correctness and long-term robustness of the software. So if reliability is a key concern (and sometimes it isn't), don't wait until the very end of the cycle, when it's time for formal review, to add tests. If you do this, they'll likely be an afterthought.
+
+## Security
+
+Inside many organizations, the security team and the development team butt heads. Security is a major gatekeeper in the development cycle and a slow security review process can slow development velocity to a crawl. Simultaneously, the security team often uses scanning tools that surface a large number of potential vulnerabilities in the dependency tree, which it wants the dev team to address by updating the dependencies. This is more work for the dev team and often the alerts are noisy, so neither side ends up very happy.
+
+"Shifting left" in security can be thought of in two parts.
+
+The first is having a security review process that is clear, transparent, and ideally as automated as possible. This enables the developer to ensure their patch meets the security standards on their own, without having to go through costly, multi-person round-trip review cycles. You can use tools that automate code coverage, linting, and static checks. And you can implement a security testing suite that validates key aspects of your application security model.
+
+The second is about shifting the security stance of the organization from reactive to proactive. Reactive means you wait for the next zero-day to emerge, which forces you to raise a fire-alarm that stops production on all the teams affected. This sort of scenario played out across virtually every major software organization when the Log4j vulnerability was released in late 2021. We wrote a [blog post](log4j-log4shell-0-day) to help organizations react and remediate quickly with automation.
+
+<figcaption>Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.</figcaption>
+<br />
+
+The benefit of this sort of automation is that it lets you preview the prospective change across all the different locations that have to change. Instead of having to manually open up pull requests to many different parts of the codebase, you can preview them before beginning review processes with many different teams. You also have the benefit of re-applying the patch should a new vulnerability emerge in a later version of the library, as happened with Log4j multiple times.
+
+The better solution, however, is to catch the next Log4j within your organization before it becomes public knowledge. To do that, you must proactively monitor and assess the risk of your open-source dependency tree.
+
+There are many security scanners that do this, but some can be quite noisy. We've heard good things about Snyk and Dependabot, but both of these mainly check your code against the same public database of [security vulnerabilities](https://cve.mitre.org/). You can also run recurring searches for anti-patterns indicative of vulnerable code blocks or dependencies:
+
+<figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
+<br />
+
+<figure>
+  <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-log4j-incident-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
+</figure>
+<figcaption>Example of proactively monitoring dependencies</figcaption>
+<br />
+
+<figure>
+  <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-go-versions-across-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
+</figure>
+<figcaption>Visually tracking overall code health</figcaption>
+<br />
+
+One advantage of the "simple" approach is you can tailor it more to specific codebases and anti-patterns. Rather than rely on the same set of publicly reported vulnerabilities, you can specify your own set of regular expressions and [Comby patterns](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference), and these can even be suggested opportunistically by your dev team.
+
+## Code review
+
+We've talked about "shifting left" many of the previous validation points *from* the review stage to a stage earlier in the dev process. But it's important to realize that code review itself is left of the even more final stages of deployment and production monitoring.
+
+It's important that code reviews are thorough, but often the tools don't scale well to larger changesets. As the old adage goes, "make a 10-line change, you'll get 10 comments, but make a 1,000-line change and you'll get a LGTM rubber stamp."
+
+Having precise code navigation capabilities in code review will help reviewers quickly spin up on the structure and content of the changeset and conduct a review that is both thorough *and* timely.
+
+<figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
+<br />
+
+Another trick is to break up a large changeset into smaller changesets that don't change the behavior of the system until the very last one (e.g., using feature flags). These smaller changes can be more easily reviewed and validated.
+
+Yet another trick is to request review early, when the code is still rough, but the broad strokes are there. If you're doing TDD for a well-defined problem, this might be pushing up the core unit tests and asking to validate the public interface being tested. If you're more prototyping, this might involve pushing up a very hacky implementation and asking for feedback on just the happy-path client-side user interaction.
+
+## The power of tools
+
+Ultimately, "shift left" is a philosophy that guides a set of specific cultural and process changes in the software development lifecycle. Both the general philosophy and the specific changes can be much assisted with the use of tools that enable the developer to take full charge of shipping a new feature or bug fix.
+
+To learn more about dev tools that assist with shifting left and accelerating the dev cycle, check out the following posts:
+
+- An ex-Googler's guide to dev tools
+- A dev's thoughts on dev productivity
+
+Or you can learn more about how Sourcegraph can serve as a dev tools hub for your organization to drive the cultural and process shifts that shifting left entails.

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -150,11 +150,12 @@ Inside many organizations, the security team and the development team butt heads
 The first is having a security review process that is clear, transparent, and ideally as automated as possible. This enables the developer to ensure their patch meets the security standards on their own, without having to go through costly, multi-person round-trip review cycles. You can use tools that automate code coverage, linting, and static checks. And you can implement a security testing suite that validates key aspects of your application security model.
 
 The second is about shifting the security stance of the organization from reactive to proactive. Reactive means you wait for the next zero-day to emerge, which forces you to raise a fire-alarm that stops production on all the teams affected. This sort of scenario played out across numerous software organization when the Log4j vulnerability was released in late 2021. We wrote a [blog post](log4j-log4shell-0-day) to help organizations react and remediate quickly with automation.
-∂
-<YouTube title="Find, fix, and monitor patches to vulnerabilities using Sourcegraph" id="13OqKPXqZXo"/>
-<figcaption>
-  Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.
-</figcaption>
+
+<YouTube 
+title="Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example."
+showTitle={true}
+id="13OqKPXqZXo"
+/>
 
 The benefit of this sort of automation is that it lets you preview the prospective change across all the different locations that have to change. Instead of having to manually open up pull requests to many different parts of the codebase, you can preview them before beginning review processes with many different teams. You also have the benefit of re-applying the patch should a new vulnerability emerge in a later version of the library, as happened with Log4j multiple times.
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -182,3 +182,7 @@ To learn more about dev tools that assist with shifting left and accelerating th
 - A dev's thoughts on dev productivity
 
 Or you can learn more about how Sourcegraph can serve as a dev tools hub for your organization to drive the cultural and process shifts that shifting left entails.
+
+### About the author
+
+_Beyang Liu is the CTO and co-founder of Sourcegraph. Beyang studied Computer Science at Stanford, where he published research in probabilistic graphical models and computer vision at the Stanford AI Lab. You can chat with Beyang on Twitter [@beyang](https://twitter.com/beyang) or our community [Discord](https://discord.com/invite/vqsBW8m5Y8)._

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -228,8 +228,8 @@ Ultimately, "shift left" is a philosophy that guides a set of specific cultural 
 
 To learn more about dev tools that assist with shifting left and accelerating the dev cycle, check out the following posts:
 
-- An ex-Googler's guide to dev tools
-- A dev's thoughts on dev productivity
+- [An ex-Googler's guide to dev tools](ex-googler-guide-dev-tools)
+- [A dev's thoughts on dev productivity](developer-productivity-thoughts)
 
 Or you can learn more about how Sourcegraph can serve as a dev tools hub for your organization to drive the cultural and process shifts that shifting left entails.
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -221,5 +221,4 @@ Or you can learn more about Sourcegraph, a dev tool that provides an interface o
 _Beyang Liu is the CTO and co-founder of Sourcegraph. Beyang studied Computer Science at Stanford, where he published research in probabilistic graphical models and computer vision at the Stanford AI Lab. You can chat with Beyang on Twitter [@beyang](https://twitter.com/beyang) or our community [Discord](https://discord.com/invite/vqsBW8m5Y8)._
 
 ## Interested in seeing a demo of Sourcegraph?
-<EmbeddedHubSpot portalId='2762526' formId='1367e810-da5f-4abd-97bc-49df5a5b459f' targetId='#email-form' />
-<div id="email-form"></div>
+[You can request a demo here.](https://about.sourcegraph.com/demo)

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -51,15 +51,13 @@ It seems like an obvious statement, but a surprising number of software projects
 Time is of the essence. Discovering existing functions and functionality early on—and avoiding the temptation to reinvent the wheel—can save loads of time.
 
 <center>
-  <div className="max-w-650">
-    <video title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.mp4" type="video/mp4" data-cookieconsent="ignore" />
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore" />
-    </video>
-    <figcaption>
-      Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
-    </figcaption>
-  </div>
+  <video title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.mp4" type="video/mp4" data-cookieconsent="ignore" />
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore" />
+  </video>
+  <figcaption>
+    Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
+  </figcaption>
 </center>
 
 In order to take full advantage of existing libraries, you need to be able to understand how to use them quickly. This applies to both open source and inner source. Shared libraries must not only be available, they must be accessible and understandable.
@@ -67,15 +65,13 @@ In order to take full advantage of existing libraries, you need to be able to un
 Investing in great documentation helps, but this is a hard change to make if your codebase isn't already well-documented. The best way to learn is by example. A single real usage example can be worth a thousand words of documentation.
 
 <center>
-  <div className="max-w-650">
-    <video title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
-    </video>
-    <figcaption>
-      Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
-    </figcaption>
-  </div>
+  <video title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.mp4" type="video/mp4" data-cookieconsent="ignore"/>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+  <figcaption>
+    Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
+  </figcaption>
 </center>
 
 By stitching together existing components, you can spin up a basic, hacky version of a new feature or product 10x more quickly. Ideally, you don't even have to worry about spinning up a production environment before soliciting user feedback—tools like ngrok (a favorite of hackathons) enable you to quickly share a service running on your local machine to early adopters around the world.
@@ -94,41 +90,35 @@ Context acquisition is one of the most time-consuming parts of the job—unless 
 Acquiring context means understanding the structure and relationships in code. This becomes 10x easier when you have code navigation. Not having jump-to-def and xrefs is like trying to browse the web without hyperlinks.
 
 <center>
-  <div className="max-w-650">
-    <video title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.mp4" type="video/mp4" data-cookieconsent="ignore" />
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
-    </video>
-    <figcaption>
-      Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
-    </figcaption>
-  </div>
+  <video title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.mp4" type="video/mp4" data-cookieconsent="ignore" />
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+  <figcaption>
+    Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
+  </figcaption>
 </center>
 
 <center>
-  <div className="max-w-650">
-    <video title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
-    </video>
-    <figcaption>
-      Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
-    </figcaption>
-  </div>
+  <video title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.mp4" type="video/mp4" data-cookieconsent="ignore"/>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+  <figcaption>
+    Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
+  </figcaption>
 </center>
 
 Targeted pieces of documentation can help guide new devs to quickly acquire the essential aspects of an area of code. You'll ideally want to use a tool that integrates nicely with the source code and doesn't go stale with time.
 
 <center>
-  <div className="max-w-650">
-    <video title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
-    </video>
-    <figcaption>
-      Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
-    </figcaption>
-  </div>
+  <video title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.mp4" type="video/mp4" data-cookieconsent="ignore"/>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+  <figcaption>
+    Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
+  </figcaption>
 </center>
 
 And don't forget to have conversations with your colleagues! A good code exploration tool should make it easy to discover and get in touch with the person or team who wrote the code. Technical conversations where both parties come to the table well-informed (e.g., with context acquired through self-guided code navigation) to discuss a matter relevant to pushing forward a current priority are rarely wastes of time.
@@ -140,25 +130,21 @@ It may seem obvious to state that you should acquire the necessary context befor
 Reading tests is a good way to understand the structure of the code. Unit tests provide examples of the canonical invocations of public APIs—they show you how you're supposed to use them. For this reason, reading unit tests is often more helpful than reading the documentation.
 
 <center>
-  <div className="max-w-650">
-    <video title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
-    </video>
-    <figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
-  </div>
+  <video title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.mp4" type="video/mp4" data-cookieconsent="ignore"/>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+  <figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
 </center>
 
 It's also helpful to understand how well tested the current code is. Test coverage can be a proxy for general code quality, which is something you want to keep in mind. You may want to add tests beforehand, so you don't have to waste a bunch of time manually testing and debugging uncaught failure modes later.
 
 <center>
-  <div className="max-w-650">
-    <video title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
-    </video>
-    <figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
-  </div>
+  <video title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.mp4" type="video/mp4" data-cookieconsent="ignore"/>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+  <figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
 </center>
 
 If the desired functionality is clear and has been validated (see the earlier section about User Value), then writing tests first—before any other code—can help you be disciplined about defining a good API boundary. This is commonly called "Test-Driven Development."
@@ -175,15 +161,14 @@ The first is having a security review process that is clear, transparent, and id
 
 The second is about shifting the security stance of the organization from reactive to proactive. Reactive means you wait for the next zero-day to emerge, which forces you to raise a fire-alarm that stops production on all the teams affected. This sort of scenario played out across numerous software organization when the Log4j vulnerability was released in late 2021. We wrote a [blog post](log4j-log4shell-0-day) to help organizations react and remediate quickly with automation.
 
+<br/>
 <center>
-  <div className="max-w-650">
-    <div className="container my-4 video-embed embed-responsive embed-responsive-16by9">
-        <iframe className="embed-responsive-item" src="https://www.youtube.com/embed/13OqKPXqZXo" allowFullScreen="" allow="accelerometer; autoPlay; encrypted-media; gyroscope; picture-in-picture"frameBorder="0"></iframe>
-    </div>
-    <figcaption>
-      Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.
-    </figcaption>
+  <div className="max-w-650 container my-4 video-embed embed-responsive embed-responsive-16by9">
+    <iframe className="embed-responsive-item" src="https://www.youtube.com/embed/13OqKPXqZXo" allowFullScreen="" allow="accelerometer; autoPlay; encrypted-media; gyroscope; picture-in-picture"frameBorder="0"></iframe>
   </div>
+  <figcaption>
+    Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.
+  </figcaption>
 </center>
 
 The benefit of this sort of automation is that it lets you preview the prospective change across all the different locations that have to change. Instead of having to manually open up pull requests to many different parts of the codebase, you can preview them before beginning review processes with many different teams. You also have the benefit of re-applying the patch should a new vulnerability emerge in a later version of the library, as happened with Log4j multiple times.
@@ -195,24 +180,22 @@ There are many security scanners that do this, but some can be quite noisy. We'v
 Another approach that is complementary to security scanners is to run recurring searches for anti-patterns indicative of vulnerable code blocks or dependencies. These are patterns you define rather than the same common set of CVEs used by security scanners:
 
 <center>
-  <div className="max-w-650">
-    <video title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
-    </video>
-    <figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
-  </div>
+  <video title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.mp4" type="video/mp4" data-cookieconsent="ignore"/>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+  <figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
 </center>
 
 <figure>
   <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-1-log4j-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
+  <figcaption>Example of proactively monitoring dependencies</figcaption>
 </figure>
-<figcaption>Example of proactively monitoring dependencies</figcaption>
 
 <figure>
   <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-2-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
+  <figcaption>Visually tracking overall code health</figcaption>
 </figure>
-<figcaption>Visually tracking overall code health</figcaption>
 
 One advantage of the search-based approach is you can tailor these more to specific codebases and anti-patterns. Rather than rely on the same set of publicly reported vulnerabilities, you can specify your own set of regular expressions and [Comby patterns](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference), and these can even be suggested opportunistically by your dev team.
 
@@ -225,15 +208,12 @@ It's important that code reviews are thorough, but often the tools don't scale w
 Having precise code navigation capabilities in code review will help reviewers quickly spin up on the structure and content of the changeset and conduct a review that is both thorough *and* timely.
 
 <center>
-  <div className="max-w-650">
-    <video title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
-    </video>
-    <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
-  </div>
+  <video title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.mp4" type="video/mp4" data-cookieconsent="ignore"/>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+  <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
 </center>
-<br/>
 
 Another trick is to break up a large changeset into smaller changesets that don't change the behavior of the system until the very last one (e.g., using feature flags). These smaller changes can be more easily reviewed and validated.
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -12,7 +12,7 @@ socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/shift-left.p
 published: true
 ---
 
-![scip-typescript: a new TypeScript and Javascript indexer](https://storage.googleapis.com/sourcegraph-assets/blog/shift-left.png)
+![Shift left - wtf does it mean?](https://storage.googleapis.com/sourcegraph-assets/blog/shift-left.png)
 
 Everyone's telling us to "shift left" these days, but what does that actually mean? What's being shifted? Who's doing the shifting? How far left should we shift it?
 
@@ -48,6 +48,9 @@ It seems like an obvious statement, but a surprising number of software projects
 
 Time is of the essence. Discovering existing functions and functionality early on—and avoiding the temptation to reinvent the wheel—can save loads of time.
 
+<video className="blog-image" title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.</figcaption>
 <br />
 
@@ -55,6 +58,9 @@ In order to take full advantage of existing libraries, you need to be able to un
 
 Investing in great documentation helps, but this is a hard change to make if your codebase isn't already well-documented. The best way to learn is by example. A single real usage example can be worth a thousand words of documentation.
 
+<video className="blog-image" title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.</figcaption>
 <br />
 
@@ -73,14 +79,23 @@ Context acquisition is one of the most time-consuming parts of the job—unless 
 
 Acquiring context means understanding the structure and relationships in code. This becomes 10x easier when you have code navigation. Not having jump-to-def and xrefs is like trying to browse the web without hyperlinks.
 
+<video className="blog-image" title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.</figcaption>
 <br />
 
+<video className="blog-image" title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.</figcaption>
 <br />
 
 Targeted pieces of documentation can help guide new devs to quickly acquire the essential aspects of an area of code. You'll ideally want to use a tool that integrates nicely with the source code and doesn't go stale with time.
 
+<video className="blog-image" title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.</figcaption>
 <br />
 
@@ -90,11 +105,17 @@ It may seem obvious to state that you should acquire the necessary context befor
 
 Reading tests is a good way to understand the structure of the code. Unit tests provide examples of the canonical invocations of public APIs—they show you how you're supposed to use them. For this reason, reading unit tests is often more helpful than reading the documentation.
 
+<video className="blog-image" title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
 <br />
 
 It's also helpful to understand how well tested the current code is. Test coverage can be a proxy for general code quality, which is something you want to keep in mind. You may want to add tests beforehand, so you don't have to waste a bunch of time manually testing and debugging uncaught failure modes later.
 
+<video className="blog-image" title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
 <br />
 
@@ -112,6 +133,9 @@ The first is having a security review process that is clear, transparent, and id
 
 The second is about shifting the security stance of the organization from reactive to proactive. Reactive means you wait for the next zero-day to emerge, which forces you to raise a fire-alarm that stops production on all the teams affected. This sort of scenario played out across virtually every major software organization when the Log4j vulnerability was released in late 2021. We wrote a [blog post](log4j-log4shell-0-day) to help organizations react and remediate quickly with automation.
 
+<video className="blog-image" title="Monitor vulnerability patches" alt="Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/08-vulnerabilities.mov" type="video/mov" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.</figcaption>
 <br />
 
@@ -121,17 +145,20 @@ The better solution, however, is to catch the next Log4j within your organizatio
 
 There are many security scanners that do this, but some can be quite noisy. We've heard good things about Snyk and Dependabot, but both of these mainly check your code against the same public database of [security vulnerabilities](https://cve.mitre.org/). You can also run recurring searches for anti-patterns indicative of vulnerable code blocks or dependencies:
 
+<video className="blog-image" title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
 <br />
 
 <figure>
-  <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-log4j-incident-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
+<img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-log4j-incident-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
 </figure>
 <figcaption>Example of proactively monitoring dependencies</figcaption>
 <br />
 
 <figure>
-  <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-go-versions-across-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
+<img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-go-versions-across-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
 </figure>
 <figcaption>Visually tracking overall code health</figcaption>
 <br />
@@ -146,6 +173,9 @@ It's important that code reviews are thorough, but often the tools don't scale w
 
 Having precise code navigation capabilities in code review will help reviewers quickly spin up on the structure and content of the changeset and conduct a review that is both thorough *and* timely.
 
+<video className="blog-image" title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
+</video>
 <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
 <br />
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -145,12 +145,12 @@ There are many security scanners that do this, but some can be quite noisy. We'v
 
 <figcaption>Example of proactively monitoring dependencies</figcaption>
 <figure>
-<img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-log4j-incident-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
+<img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-1-log4j-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
 </figure>
 
 <figcaption>Visually tracking overall code health</figcaption>
 <figure>
-<img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-go-versions-across-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
+<img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-2-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
 </figure>
 
 One advantage of the "simple" approach is you can tailor it more to specific codebases and anti-patterns. Rather than rely on the same set of publicly reported vulnerabilities, you can specify your own set of regular expressions and [Comby patterns](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference), and these can even be suggested opportunistically by your dev team.

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -208,13 +208,11 @@ Another approach that is complementary to security scanners is to run recurring 
   <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-1-log4j-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
 </figure>
 <figcaption>Example of proactively monitoring dependencies</figcaption>
-<br/>
 
 <figure>
   <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-2-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
 </figure>
 <figcaption>Visually tracking overall code health</figcaption>
-<br/>
 
 One advantage of the search-based approach is you can tailor these more to specific codebases and anti-patterns. Rather than rely on the same set of publicly reported vulnerabilities, you can specify your own set of regular expressions and [Comby patterns](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference), and these can even be suggested opportunistically by your dev team.
 
@@ -235,6 +233,7 @@ Having precise code navigation capabilities in code review will help reviewers q
     <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
   </div>
 </center>
+<br/>
 
 Another trick is to break up a large changeset into smaller changesets that don't change the behavior of the system until the very last one (e.g., using feature flags). These smaller changes can be more easily reviewed and validated.
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -54,7 +54,8 @@ Time is of the essence. Discovering existing functions and functionality early o
       Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
     </figcaption>
     <video title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
-      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore"/>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.mp4" type="video/mp4" data-cookieconsent="ignore" />
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore" />
     </video>
   </div>
 </center>
@@ -69,6 +70,7 @@ Investing in great documentation helps, but this is a hard change to make if you
       Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
     </figcaption>
     <video title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
   </div>
@@ -95,6 +97,7 @@ Acquiring context means understanding the structure and relationships in code. T
       Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
     </figcaption>
     <video title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.mp4" type="video/mp4" data-cookieconsent="ignore" />
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
   </div>
@@ -106,6 +109,7 @@ Acquiring context means understanding the structure and relationships in code. T
       Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
     </figcaption>
     <video title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
   </div>
@@ -119,6 +123,7 @@ Targeted pieces of documentation can help guide new devs to quickly acquire the 
       Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
     </figcaption>
     <video title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
   </div>
@@ -133,6 +138,7 @@ Reading tests is a good way to understand the structure of the code. Unit tests 
   <div className="max-w-650">
     <figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
     <video title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
   </div>
@@ -144,6 +150,7 @@ It's also helpful to understand how well tested the current code is. Test covera
   <div className="max-w-650">
     <figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
     <video title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
   </div>
@@ -184,6 +191,7 @@ There are many security scanners that do this, but some can be quite noisy. We'v
   <div className="max-w-650">
     <figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
     <video title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
   </div>
@@ -213,6 +221,7 @@ Having precise code navigation capabilities in code review will help reviewers q
   <div className="max-w-650">
     <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
     <video title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
   </div>

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -50,29 +50,29 @@ It seems like an obvious statement, but a surprising number of software projects
 
 Time is of the essence. Discovering existing functions and functionality early on—and avoiding the temptation to reinvent the wheel—can save loads of time.
 
-<center>
-  <video title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.mp4" type="video/mp4" data-cookieconsent="ignore" />
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore" />
-  </video>
-  <figcaption>
-    Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
-  </figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/01-code-reuse', mp4: 'blog/shift-left/01-code-reuse'}} 
+  loop={true}
+  title="Code reuse"
+  caption="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." 
+/>
+<figcaption>
+  Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
+</figcaption>
 
 In order to take full advantage of existing libraries, you need to be able to understand how to use them quickly. This applies to both open source and inner source. Shared libraries must not only be available, they must be accessible and understandable.
 
 Investing in great documentation helps, but this is a hard change to make if your codebase isn't already well-documented. The best way to learn is by example. A single real usage example can be worth a thousand words of documentation.
 
-<center>
-  <video title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-  <figcaption>
-    Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
-  </figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/02-find-references', mp4: 'blog/shift-left/01-code-reuse'}} 
+  loop={true}
+  title="Find references" 
+  caption="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." 
+/>
+<figcaption>
+  Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
+</figcaption>
 
 By stitching together existing components, you can spin up a basic, hacky version of a new feature or product 10x more quickly. Ideally, you don't even have to worry about spinning up a production environment before soliciting user feedback—tools like ngrok (a favorite of hackathons) enable you to quickly share a service running on your local machine to early adopters around the world.
 
@@ -89,37 +89,37 @@ Context acquisition is one of the most time-consuming parts of the job—unless 
 
 Acquiring context means understanding the structure and relationships in code. This becomes 10x easier when you have code navigation. Not having jump-to-def and xrefs is like trying to browse the web without hyperlinks.
 
-<center>
-  <video title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.mp4" type="video/mp4" data-cookieconsent="ignore" />
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-  <figcaption>
-    Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
-  </figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/03-defs-and-refs', mp4: 'blog/shift-left/03-defs-and-refs'}} 
+  loop={true}
+  title="Definitions and references" 
+  caption="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." 
+/>
+<figcaption>
+  Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
+</figcaption>
 
-<center>
-  <video title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-  <figcaption>
-    Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
-  </figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/04-jump-to-definition', mp4: 'blog/shift-left/04-jump-to-definition'}} 
+  loop={true}
+  title="Jump to definition" 
+  caption="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." 
+/>
+<figcaption>
+  Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
+</figcaption>
 
 Targeted pieces of documentation can help guide new devs to quickly acquire the essential aspects of an area of code. You'll ideally want to use a tool that integrates nicely with the source code and doesn't go stale with time.
 
-<center>
-  <video title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-  <figcaption>
-    Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
-  </figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/05-notebooks', mp4: 'blog/shift-left/05-notebooks'}} 
+  loop={true}
+  title="Interactive docs for engineering" 
+  caption="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." 
+/>
+<figcaption>
+  Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
+</figcaption>
 
 And don't forget to have conversations with your colleagues! A good code exploration tool should make it easy to discover and get in touch with the person or team who wrote the code. Technical conversations where both parties come to the table well-informed (e.g., with context acquired through self-guided code navigation) to discuss a matter relevant to pushing forward a current priority are rarely wastes of time.
 
@@ -129,23 +129,23 @@ It may seem obvious to state that you should acquire the necessary context befor
 
 Reading tests is a good way to understand the structure of the code. Unit tests provide examples of the canonical invocations of public APIs—they show you how you're supposed to use them. For this reason, reading unit tests is often more helpful than reading the documentation.
 
-<center>
-  <video title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-  <figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/06-discover-unit-tests', mp4: 'blog/shift-left/06-discover-unit-tests'}} 
+  loop={true}
+  title="Reference lookup" 
+  caption="Discover unit tests by looking up references to a public API function." 
+/>
+<figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
 
 It's also helpful to understand how well tested the current code is. Test coverage can be a proxy for general code quality, which is something you want to keep in mind. You may want to add tests beforehand, so you don't have to waste a bunch of time manually testing and debugging uncaught failure modes later.
 
-<center>
-  <video title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-  <figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/07-test-coverage', mp4: 'blog/shift-left/07-test-coverage'}} 
+  loop={true}
+  title="Reveal gaps in test coverage" 
+  caption="Code coverage tools reveal gaps in test coverage." 
+/>
+<figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
 
 If the desired functionality is clear and has been validated (see the earlier section about User Value), then writing tests first—before any other code—can help you be disciplined about defining a good API boundary. This is commonly called "Test-Driven Development."
 
@@ -160,16 +160,11 @@ Inside many organizations, the security team and the development team butt heads
 The first is having a security review process that is clear, transparent, and ideally as automated as possible. This enables the developer to ensure their patch meets the security standards on their own, without having to go through costly, multi-person round-trip review cycles. You can use tools that automate code coverage, linting, and static checks. And you can implement a security testing suite that validates key aspects of your application security model.
 
 The second is about shifting the security stance of the organization from reactive to proactive. Reactive means you wait for the next zero-day to emerge, which forces you to raise a fire-alarm that stops production on all the teams affected. This sort of scenario played out across numerous software organization when the Log4j vulnerability was released in late 2021. We wrote a [blog post](log4j-log4shell-0-day) to help organizations react and remediate quickly with automation.
-
-<br/>
-<center>
-  <div className="max-w-650 container my-4 video-embed embed-responsive embed-responsive-16by9">
-    <iframe className="embed-responsive-item" src="https://www.youtube.com/embed/13OqKPXqZXo" allowFullScreen="" allow="accelerometer; autoPlay; encrypted-media; gyroscope; picture-in-picture"frameBorder="0"></iframe>
-  </div>
-  <figcaption>
-    Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.
-  </figcaption>
-</center>
+∂
+<YouTube title="Find, fix, and monitor patches to vulnerabilities using Sourcegraph" id="13OqKPXqZXo"/>
+<figcaption>
+  Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.
+</figcaption>
 
 The benefit of this sort of automation is that it lets you preview the prospective change across all the different locations that have to change. Instead of having to manually open up pull requests to many different parts of the codebase, you can preview them before beginning review processes with many different teams. You also have the benefit of re-applying the patch should a new vulnerability emerge in a later version of the library, as happened with Log4j multiple times.
 
@@ -179,13 +174,13 @@ There are many security scanners that do this, but some can be quite noisy. We'v
 
 Another approach that is complementary to security scanners is to run recurring searches for anti-patterns indicative of vulnerable code blocks or dependencies. These are patterns you define rather than the same common set of CVEs used by security scanners:
 
-<center>
-  <video title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-  <figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/09-code-monitoring', mp4: 'blog/shift-left/09-code-monitoring'}} 
+  loop={true}
+  title="Codebase alerts" 
+  caption="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." 
+/>
+<figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
 
 <figure>
   <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-1-log4j-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
@@ -207,13 +202,13 @@ It's important that code reviews are thorough, but often the tools don't scale w
 
 Having precise code navigation capabilities in code review will help reviewers quickly spin up on the structure and content of the changeset and conduct a review that is both thorough *and* timely.
 
-<center>
-  <video title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-  <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
-</center>
+<Video 
+  source={{webm: 'blog/shift-left/10-code-reviews', mp4: 'blog/shift-left/10-code-reviews'}} 
+  loop={true}
+  title="Find references in code reviews" 
+  caption="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." 
+/>
+<figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
 
 Another trick is to break up a large changeset into smaller changesets that don't change the behavior of the system until the very last one (e.g., using feature flags). These smaller changes can be more easily reviewed and validated.
 
@@ -233,3 +228,7 @@ Or you can learn more about Sourcegraph, a dev tool that provides an interface o
 ### About the author
 
 _Beyang Liu is the CTO and co-founder of Sourcegraph. Beyang studied Computer Science at Stanford, where he published research in probabilistic graphical models and computer vision at the Stanford AI Lab. You can chat with Beyang on Twitter [@beyang](https://twitter.com/beyang) or our community [Discord](https://discord.com/invite/vqsBW8m5Y8)._
+
+## Sign up now
+<EmbeddedHubSpot portalId='2762526' formId='1367e810-da5f-4abd-97bc-49df5a5b459f' targetId='#email-form' />
+<div id="email-form"></div>

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -208,11 +208,13 @@ Another approach that is complementary to security scanners is to run recurring 
   <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-1-log4j-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
 </figure>
 <figcaption>Example of proactively monitoring dependencies</figcaption>
+<br/>
 
 <figure>
   <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-2-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
 </figure>
 <figcaption>Visually tracking overall code health</figcaption>
+<br/>
 
 One advantage of the search-based approach is you can tailor these more to specific codebases and anti-patterns. Rather than rely on the same set of publicly reported vulnerabilities, you can specify your own set of regular expressions and [Comby patterns](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference), and these can even be suggested opportunistically by your dev team.
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -48,20 +48,31 @@ It seems like an obvious statement, but a surprising number of software projects
 
 Time is of the essence. Discovering existing functions and functionality early on—and avoiding the temptation to reinvent the wheel—can save loads of time.
 
-<figcaption>Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.</figcaption>
-<video className="blog-image" title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
+<center>
+  <div className="max-w-650">
+    <figcaption>
+      Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
+    </figcaption>
+    <video title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 
 In order to take full advantage of existing libraries, you need to be able to understand how to use them quickly. This applies to both open source and inner source. Shared libraries must not only be available, they must be accessible and understandable.
 
 Investing in great documentation helps, but this is a hard change to make if your codebase isn't already well-documented. The best way to learn is by example. A single real usage example can be worth a thousand words of documentation.
 
-<figcaption>Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.</figcaption>
-<video className="blog-image" title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
-
+<center>
+  <div className="max-w-650">
+    <figcaption>
+      Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
+    </figcaption>
+    <video title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 
 By stitching together existing components, you can spin up a basic, hacky version of a new feature or product 10x more quickly. Ideally, you don't even have to worry about spinning up a production environment before soliciting user feedback—tools like ngrok enable you to quickly and securely share your service running on your local machine to the feedback partners you'd like to reach around the world.
 
@@ -78,40 +89,65 @@ Context acquisition is one of the most time-consuming parts of the job—unless 
 
 Acquiring context means understanding the structure and relationships in code. This becomes 10x easier when you have code navigation. Not having jump-to-def and xrefs is like trying to browse the web without hyperlinks.
 
-<figcaption>Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.</figcaption>
-<video className="blog-image" title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
+<center>
+  <div className="max-w-650">
+    <figcaption>
+      Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
+    </figcaption>
+    <video title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 
-<figcaption>Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.</figcaption>
-<video className="blog-image" title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
+<center>
+  <div className="max-w-650">
+    <figcaption>
+      Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
+    </figcaption>
+    <video title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 
 Targeted pieces of documentation can help guide new devs to quickly acquire the essential aspects of an area of code. You'll ideally want to use a tool that integrates nicely with the source code and doesn't go stale with time.
 
-<figcaption>Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.</figcaption>
-<video className="blog-image" title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
-
+<center>
+  <div className="max-w-650">
+    <figcaption>
+      Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
+    </figcaption>
+    <video title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 It may seem obvious to state that you should acquire the necessary context before investing a large amount of time writing code, but many projects waste the first weeks and months of their timeline because the engineers were too eager to start breaking ground and did not acquire a good sense of the lay of the land.
 
 ## Testing
 
 Reading tests is a good way to understand the structure of the code. Unit tests provide examples of the canonical invocations of public APIs—they show you how you're supposed to use them. For this reason, reading unit tests is often more helpful than reading the documentation.
 
-<figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
-<video className="blog-image" title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
+<center>
+  <div className="max-w-650">
+    <figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
+    <video title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 
 It's also helpful to understand how well tested the current code is. Test coverage can be a proxy for general code quality, which is something you want to keep in mind. You may want to add tests beforehand, so you don't have to waste a bunch of time manually testing and debugging uncaught failure modes later.
 
-<figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
-<video className="blog-image" title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
+<center>
+  <div className="max-w-650">
+    <figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
+    <video title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 
 If the desired functionality is clear and has been validated (see the earlier section about User Value), then writing tests first—before any other code—can help you be disciplined about defining a good API boundary. This is commonly called "Test-Driven Development."
 
@@ -127,10 +163,16 @@ The first is having a security review process that is clear, transparent, and id
 
 The second is about shifting the security stance of the organization from reactive to proactive. Reactive means you wait for the next zero-day to emerge, which forces you to raise a fire-alarm that stops production on all the teams affected. This sort of scenario played out across virtually every major software organization when the Log4j vulnerability was released in late 2021. We wrote a [blog post](log4j-log4shell-0-day) to help organizations react and remediate quickly with automation.
 
-<figcaption>Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.</figcaption>
-<div className="container my-4 video-embed embed-responsive embed-responsive-16by9">
-    <iframe className="embed-responsive-item" src="https://www.youtube.com/embed/13OqKPXqZXo" allowFullScreen="" allow="accelerometer; autoPlay; encrypted-media; gyroscope; picture-in-picture"frameBorder="0"></iframe>
-</div>
+<center>
+  <div className="max-w-650">
+    <figcaption>
+      Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.
+    </figcaption>
+    <div className="container my-4 video-embed embed-responsive embed-responsive-16by9">
+        <iframe className="embed-responsive-item" src="https://www.youtube.com/embed/13OqKPXqZXo" allowFullScreen="" allow="accelerometer; autoPlay; encrypted-media; gyroscope; picture-in-picture"frameBorder="0"></iframe>
+    </div>
+  </div>
+</center>
 
 The benefit of this sort of automation is that it lets you preview the prospective change across all the different locations that have to change. Instead of having to manually open up pull requests to many different parts of the codebase, you can preview them before beginning review processes with many different teams. You also have the benefit of re-applying the patch should a new vulnerability emerge in a later version of the library, as happened with Log4j multiple times.
 
@@ -138,10 +180,14 @@ The better solution, however, is to catch the next Log4j within your organizatio
 
 There are many security scanners that do this, but some can be quite noisy. We've heard good things about Snyk and Dependabot, but both of these mainly check your code against the same public database of [security vulnerabilities](https://cve.mitre.org/). You can also run recurring searches for anti-patterns indicative of vulnerable code blocks or dependencies:
 
-<figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
-<video className="blog-image" title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
+<center>
+  <div className="max-w-650">
+    <figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
+    <video title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 
 <figcaption>Example of proactively monitoring dependencies</figcaption>
 <figure>
@@ -163,10 +209,14 @@ It's important that code reviews are thorough, but often the tools don't scale w
 
 Having precise code navigation capabilities in code review will help reviewers quickly spin up on the structure and content of the changeset and conduct a review that is both thorough *and* timely.
 
-<figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
-<video className="blog-image" title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
-</video>
+<center>
+  <div className="max-w-650">
+    <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
+    <video title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
+      <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
+    </video>
+  </div>
+</center>
 
 Another trick is to break up a large changeset into smaller changesets that don't change the behavior of the system until the very last one (e.g., using feature flags). These smaller changes can be more easily reviewed and validated.
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -50,13 +50,13 @@ Time is of the essence. Discovering existing functions and functionality early o
 
 <center>
   <div className="max-w-650">
-    <figcaption>
-      Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
-    </figcaption>
     <video title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.mp4" type="video/mp4" data-cookieconsent="ignore" />
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore" />
     </video>
+    <figcaption>
+      Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
+    </figcaption>
   </div>
 </center>
 
@@ -66,13 +66,13 @@ Investing in great documentation helps, but this is a hard change to make if you
 
 <center>
   <div className="max-w-650">
-    <figcaption>
-      Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
-    </figcaption>
     <video title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
+    <figcaption>
+      Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
+    </figcaption>
   </div>
 </center>
 
@@ -93,25 +93,25 @@ Acquiring context means understanding the structure and relationships in code. T
 
 <center>
   <div className="max-w-650">
-    <figcaption>
-      Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
-    </figcaption>
     <video title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.mp4" type="video/mp4" data-cookieconsent="ignore" />
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
+    <figcaption>
+      Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
+    </figcaption>
   </div>
 </center>
 
 <center>
   <div className="max-w-650">
-    <figcaption>
-      Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
-    </figcaption>
     <video title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
+    <figcaption>
+      Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
+    </figcaption>
   </div>
 </center>
 
@@ -119,13 +119,13 @@ Targeted pieces of documentation can help guide new devs to quickly acquire the 
 
 <center>
   <div className="max-w-650">
-    <figcaption>
-      Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
-    </figcaption>
     <video title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
+    <figcaption>
+      Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
+    </figcaption>
   </div>
 </center>
 It may seem obvious to state that you should acquire the necessary context before investing a large amount of time writing code, but many projects waste the first weeks and months of their timeline because the engineers were too eager to start breaking ground and did not acquire a good sense of the lay of the land.
@@ -136,11 +136,11 @@ Reading tests is a good way to understand the structure of the code. Unit tests 
 
 <center>
   <div className="max-w-650">
-    <figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
     <video title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
+    <figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
   </div>
 </center>
 
@@ -148,11 +148,11 @@ It's also helpful to understand how well tested the current code is. Test covera
 
 <center>
   <div className="max-w-650">
-    <figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
     <video title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
+    <figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
   </div>
 </center>
 
@@ -172,12 +172,12 @@ The second is about shifting the security stance of the organization from reacti
 
 <center>
   <div className="max-w-650">
-    <figcaption>
-      Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.
-    </figcaption>
     <div className="container my-4 video-embed embed-responsive embed-responsive-16by9">
         <iframe className="embed-responsive-item" src="https://www.youtube.com/embed/13OqKPXqZXo" allowFullScreen="" allow="accelerometer; autoPlay; encrypted-media; gyroscope; picture-in-picture"frameBorder="0"></iframe>
     </div>
+    <figcaption>
+      Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.
+    </figcaption>
   </div>
 </center>
 
@@ -189,23 +189,23 @@ There are many security scanners that do this, but some can be quite noisy. We'v
 
 <center>
   <div className="max-w-650">
-    <figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
     <video title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
+    <figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
   </div>
 </center>
 
+<figure>
+  <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-1-log4j-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
+</figure>
 <figcaption>Example of proactively monitoring dependencies</figcaption>
-<figure>
-<img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-1-log4j-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
-</figure>
 
-<figcaption>Visually tracking overall code health</figcaption>
 <figure>
-<img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-2-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
+  <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-2-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
 </figure>
+<figcaption>Visually tracking overall code health</figcaption>
 
 One advantage of the "simple" approach is you can tailor it more to specific codebases and anti-patterns. Rather than rely on the same set of publicly reported vulnerabilities, you can specify your own set of regular expressions and [Comby patterns](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference), and these can even be suggested opportunistically by your dev team.
 
@@ -219,11 +219,11 @@ Having precise code navigation capabilities in code review will help reviewers q
 
 <center>
   <div className="max-w-650">
-    <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
     <video title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.mp4" type="video/mp4" data-cookieconsent="ignore"/>
       <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
     </video>
+    <figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
   </div>
 </center>
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -48,21 +48,20 @@ It seems like an obvious statement, but a surprising number of software projects
 
 Time is of the essence. Discovering existing functions and functionality early on—and avoiding the temptation to reinvent the wheel—can save loads of time.
 
+<figcaption>Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.</figcaption>
 <video className="blog-image" title="Code reuse" alt="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/01-code-reuse.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.</figcaption>
-<br />
 
 In order to take full advantage of existing libraries, you need to be able to understand how to use them quickly. This applies to both open source and inner source. Shared libraries must not only be available, they must be accessible and understandable.
 
 Investing in great documentation helps, but this is a hard change to make if your codebase isn't already well-documented. The best way to learn is by example. A single real usage example can be worth a thousand words of documentation.
 
+<figcaption>Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.</figcaption>
 <video className="blog-image" title="Find references" alt="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/02-find-references.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.</figcaption>
-<br />
+
 
 By stitching together existing components, you can spin up a basic, hacky version of a new feature or product 10x more quickly. Ideally, you don't even have to worry about spinning up a production environment before soliciting user feedback—tools like ngrok enable you to quickly and securely share your service running on your local machine to the feedback partners you'd like to reach around the world.
 
@@ -79,25 +78,22 @@ Context acquisition is one of the most time-consuming parts of the job—unless 
 
 Acquiring context means understanding the structure and relationships in code. This becomes 10x easier when you have code navigation. Not having jump-to-def and xrefs is like trying to browse the web without hyperlinks.
 
+<figcaption>Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.</figcaption>
 <video className="blog-image" title="Definitions and references" alt="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/03-defs-and-refs.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.</figcaption>
-<br />
 
+<figcaption>Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.</figcaption>
 <video className="blog-image" title="Jump to definition" alt="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/04-jump-to-definition.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.</figcaption>
-<br />
 
 Targeted pieces of documentation can help guide new devs to quickly acquire the essential aspects of an area of code. You'll ideally want to use a tool that integrates nicely with the source code and doesn't go stale with time.
 
+<figcaption>Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.</figcaption>
 <video className="blog-image" title="Interactive docs for engineering" alt="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/05-notebooks.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.</figcaption>
-<br />
 
 It may seem obvious to state that you should acquire the necessary context before investing a large amount of time writing code, but many projects waste the first weeks and months of their timeline because the engineers were too eager to start breaking ground and did not acquire a good sense of the lay of the land.
 
@@ -105,19 +101,17 @@ It may seem obvious to state that you should acquire the necessary context befor
 
 Reading tests is a good way to understand the structure of the code. Unit tests provide examples of the canonical invocations of public APIs—they show you how you're supposed to use them. For this reason, reading unit tests is often more helpful than reading the documentation.
 
+<figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
 <video className="blog-image" title="Reference lookup" alt="Discover unit tests by looking up references to a public API function." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/06-discover-unit-tests.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
-<br />
 
 It's also helpful to understand how well tested the current code is. Test coverage can be a proxy for general code quality, which is something you want to keep in mind. You may want to add tests beforehand, so you don't have to waste a bunch of time manually testing and debugging uncaught failure modes later.
 
+<figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
 <video className="blog-image" title="Reveal gaps in test coverage" alt="Code coverage tools reveal gaps in test coverage." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/07-test-coverage.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
-<br />
 
 If the desired functionality is clear and has been validated (see the earlier section about User Value), then writing tests first—before any other code—can help you be disciplined about defining a good API boundary. This is commonly called "Test-Driven Development."
 
@@ -133,11 +127,10 @@ The first is having a security review process that is clear, transparent, and id
 
 The second is about shifting the security stance of the organization from reactive to proactive. Reactive means you wait for the next zero-day to emerge, which forces you to raise a fire-alarm that stops production on all the teams affected. This sort of scenario played out across virtually every major software organization when the Log4j vulnerability was released in late 2021. We wrote a [blog post](log4j-log4shell-0-day) to help organizations react and remediate quickly with automation.
 
-<video className="blog-image" title="Monitor vulnerability patches" alt="Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example." loop autoPlay muted playsInline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/08-vulnerabilities.mov" type="video/mov" data-cookieconsent="ignore"/>
-</video>
 <figcaption>Here is a 60 second video that shows how you could find, fix, and monitor patches to vulnerabilities using Sourcegraph. This uses Log4 as an example.</figcaption>
-<br />
+<div className="container my-4 video-embed embed-responsive embed-responsive-16by9">
+    <iframe className="embed-responsive-item" src="https://www.youtube.com/embed/13OqKPXqZXo" allowFullScreen="" allow="accelerometer; autoPlay; encrypted-media; gyroscope; picture-in-picture"frameBorder="0"></iframe>
+</div>
 
 The benefit of this sort of automation is that it lets you preview the prospective change across all the different locations that have to change. Instead of having to manually open up pull requests to many different parts of the codebase, you can preview them before beginning review processes with many different teams. You also have the benefit of re-applying the patch should a new vulnerability emerge in a later version of the library, as happened with Log4j multiple times.
 
@@ -145,23 +138,20 @@ The better solution, however, is to catch the next Log4j within your organizatio
 
 There are many security scanners that do this, but some can be quite noisy. We've heard good things about Snyk and Dependabot, but both of these mainly check your code against the same public database of [security vulnerabilities](https://cve.mitre.org/). You can also run recurring searches for anti-patterns indicative of vulnerable code blocks or dependencies:
 
+<figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
 <video className="blog-image" title="Codebase alerts" alt="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/09-code-monitoring.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
-<br />
 
+<figcaption>Example of proactively monitoring dependencies</figcaption>
 <figure>
 <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-log4j-incident-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
 </figure>
-<figcaption>Example of proactively monitoring dependencies</figcaption>
-<br />
 
+<figcaption>Visually tracking overall code health</figcaption>
 <figure>
 <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-go-versions-across-repos.png" alt="Visually tracking overall code health across repos" className="no-shadow" />
 </figure>
-<figcaption>Visually tracking overall code health</figcaption>
-<br />
 
 One advantage of the "simple" approach is you can tailor it more to specific codebases and anti-patterns. Rather than rely on the same set of publicly reported vulnerabilities, you can specify your own set of regular expressions and [Comby patterns](https://docs.sourcegraph.com/code_search/reference/structural#syntax-reference), and these can even be suggested opportunistically by your dev team.
 
@@ -173,11 +163,10 @@ It's important that code reviews are thorough, but often the tools don't scale w
 
 Having precise code navigation capabilities in code review will help reviewers quickly spin up on the structure and content of the changeset and conduct a review that is both thorough *and* timely.
 
+<figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
 <video className="blog-image" title="Find references in code reviews" alt="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." loop autoPlay muted playsInline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left/10-code-reviews.webm" type="video/webm" data-cookieconsent="ignore"/>
 </video>
-<figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
-<br />
 
 Another trick is to break up a large changeset into smaller changesets that don't change the behavior of the system until the very last one (e.g., using feature flags). These smaller changes can be more easily reviewed and validated.
 

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -54,11 +54,9 @@ Time is of the essence. Discovering existing functions and functionality early o
   source={{webm: 'blog/shift-left/01-code-reuse', mp4: 'blog/shift-left/01-code-reuse'}} 
   loop={true}
   title="Code reuse"
-  caption="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product." 
+  caption="Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product."
+  showCaption={true}
 />
-<figcaption>
-  Discovering and reusing existing code can help you spin up a MVP ASAP, so you can quickly validate the user need with a rough sketch of the product.
-</figcaption>
 
 In order to take full advantage of existing libraries, you need to be able to understand how to use them quickly. This applies to both open source and inner source. Shared libraries must not only be available, they must be accessible and understandable.
 
@@ -68,11 +66,9 @@ Investing in great documentation helps, but this is a hard change to make if you
   source={{webm: 'blog/shift-left/02-find-references', mp4: 'blog/shift-left/01-code-reuse'}} 
   loop={true}
   title="Find references" 
-  caption="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it." 
+  caption="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it."
+  showCaption={true}
 />
-<figcaption>
-  Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it.
-</figcaption>
 
 By stitching together existing components, you can spin up a basic, hacky version of a new feature or product 10x more quickly. Ideally, you don't even have to worry about spinning up a production environment before soliciting user feedback—tools like ngrok (a favorite of hackathons) enable you to quickly share a service running on your local machine to early adopters around the world.
 
@@ -93,21 +89,17 @@ Acquiring context means understanding the structure and relationships in code. T
   source={{webm: 'blog/shift-left/03-defs-and-refs', mp4: 'blog/shift-left/03-defs-and-refs'}} 
   loop={true}
   title="Definitions and references" 
-  caption="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works." 
+  caption="Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works."
+  showCaption={true}
 />
-<figcaption>
-  Walking the forward and backward graph of code (defs and refs) is the bread-and-butter of building up a contextual mental model of how the code works.
-</figcaption>
 
 <Video 
   source={{webm: 'blog/shift-left/04-jump-to-definition', mp4: 'blog/shift-left/04-jump-to-definition'}} 
   loop={true}
   title="Jump to definition" 
-  caption="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code." 
+  caption="Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code"
+  showCaption={true} 
 />
-<figcaption>
-  Fast and accurate jump-to-definition that Just Works, even across dependency boundaries, is essential for chasing down context through the winding rabbitholes of code.
-</figcaption>
 
 Targeted pieces of documentation can help guide new devs to quickly acquire the essential aspects of an area of code. You'll ideally want to use a tool that integrates nicely with the source code and doesn't go stale with time.
 
@@ -115,11 +107,9 @@ Targeted pieces of documentation can help guide new devs to quickly acquire the 
   source={{webm: 'blog/shift-left/05-notebooks', mp4: 'blog/shift-left/05-notebooks'}} 
   loop={true}
   title="Interactive docs for engineering" 
-  caption="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase." 
+  caption="Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase."
+  showCaption={true}
 />
-<figcaption>
-  Interactive docs that tie high-level descriptions with entrypoints into the source code conserves senior engineers' time while enabling other engineers to quickly onboard to new parts of the codebase.
-</figcaption>
 
 And don't forget to have conversations with your colleagues! A good code exploration tool should make it easy to discover and get in touch with the person or team who wrote the code. Technical conversations where both parties come to the table well-informed (e.g., with context acquired through self-guided code navigation) to discuss a matter relevant to pushing forward a current priority are rarely wastes of time.
 
@@ -133,9 +123,9 @@ Reading tests is a good way to understand the structure of the code. Unit tests 
   source={{webm: 'blog/shift-left/06-discover-unit-tests', mp4: 'blog/shift-left/06-discover-unit-tests'}} 
   loop={true}
   title="Reference lookup" 
-  caption="Discover unit tests by looking up references to a public API function." 
+  caption="Discover unit tests by looking up references to a public API function."
+  showCaption={true}
 />
-<figcaption>Discover unit tests by looking up references to a public API function.</figcaption>
 
 It's also helpful to understand how well tested the current code is. Test coverage can be a proxy for general code quality, which is something you want to keep in mind. You may want to add tests beforehand, so you don't have to waste a bunch of time manually testing and debugging uncaught failure modes later.
 
@@ -143,9 +133,9 @@ It's also helpful to understand how well tested the current code is. Test covera
   source={{webm: 'blog/shift-left/07-test-coverage', mp4: 'blog/shift-left/07-test-coverage'}} 
   loop={true}
   title="Reveal gaps in test coverage" 
-  caption="Code coverage tools reveal gaps in test coverage." 
+  caption="Code coverage tools reveal gaps in test coverage."
+  showCaption={true}
 />
-<figcaption>Code coverage tools reveal gaps in test coverage.</figcaption>
 
 If the desired functionality is clear and has been validated (see the earlier section about User Value), then writing tests first—before any other code—can help you be disciplined about defining a good API boundary. This is commonly called "Test-Driven Development."
 
@@ -178,9 +168,9 @@ Another approach that is complementary to security scanners is to run recurring 
   source={{webm: 'blog/shift-left/09-code-monitoring', mp4: 'blog/shift-left/09-code-monitoring'}} 
   loop={true}
   title="Codebase alerts" 
-  caption="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase." 
+  caption="Set up alerts for anti-patterns and vulnerable dependency versions in your codebase."
+  showCaption={true}
 />
-<figcaption>Set up alerts for anti-patterns and vulnerable dependency versions in your codebase.</figcaption>
 
 <figure>
   <img src="https://storage.googleapis.com/sourcegraph-assets/blog/shift-left-1-log4j-response.png" alt="log4j incident response example of proactively monitoring dependencies" className="no-shadow" />
@@ -206,9 +196,9 @@ Having precise code navigation capabilities in code review will help reviewers q
   source={{webm: 'blog/shift-left/10-code-reviews', mp4: 'blog/shift-left/10-code-reviews'}} 
   loop={true}
   title="Find references in code reviews" 
-  caption="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient." 
+  caption="Use go-to-definition and find references to conduct code reviews that are both thorough and efficient."
+  showCaption={true}
 />
-<figcaption>Use go-to-definition and find references to conduct code reviews that are both thorough and efficient.</figcaption>
 
 Another trick is to break up a large changeset into smaller changesets that don't change the behavior of the system until the very last one (e.g., using feature flags). These smaller changes can be more easily reviewed and validated.
 

--- a/src/components/Blog/PostLayout.tsx
+++ b/src/components/Blog/PostLayout.tsx
@@ -3,12 +3,12 @@ import { FunctionComponent } from 'react'
 import { MDXRemote } from 'next-mdx-remote'
 import Link from 'next/link'
 
-import { BlockquoteWithBorder } from '@components'
+import { BlockquoteWithBorder, EmbeddedHubSpot, Video, YouTube } from '@components'
 import { PostComponentProps } from '@interfaces/posts'
 import { formatDate } from '@util'
 
 export type Components = import('mdx/types').MDXComponents
-const components = { BlockquoteWithBorder }
+const components = { BlockquoteWithBorder, EmbeddedHubSpot, Video, YouTube }
 
 /**
  * This component is used to render all types of posts:
@@ -69,7 +69,7 @@ export const PostLayout: FunctionComponent<PostComponentProps> = ({
         </header>
 
         {content && (
-            <div className="card-body">
+            <div className="card-body max-w-650">
                 <div className={`blog-post__html ${contentClassName}`}>
                     <MDXRemote {...content} components={components as Components} />
                 </div>

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -11,29 +11,31 @@ interface Video {
 }
 
 export const Video: FunctionComponent<Video> = ({ source, loop, caption, title }) => (
-    <video
-        className="w-100 h-auto shadow"
-        width={1280}
-        height={720}
-        autoPlay={true}
-        muted={true}
-        loop={loop}
-        playsInline={true}
-        controls={false}
-        title={title}
-        // GCS does not set cookies, so we don't want Cookiebot to block this video based on consent
-        data-cookieconsent="ignore"
-    >
-        <source
-            type="video/webm"
-            src={`https://storage.googleapis.com/sourcegraph-assets/${source.webm}.webm`}
+    <figure>
+        <video
+            className="w-100 h-auto shadow"
+            width={1280}
+            height={720}
+            autoPlay={true}
+            muted={true}
+            loop={loop}
+            playsInline={true}
+            controls={false}
+            title={title}
+            // GCS does not set cookies, so we don't want Cookiebot to block this video based on consent
             data-cookieconsent="ignore"
-        />
-        <source
-            type="video/mp4"
-            src={`https://storage.googleapis.com/sourcegraph-assets/${source.mp4}.mp4`}
-            data-cookieconsent="ignore"
-        />
-        {caption}
-    </video>
+        >
+            <source
+                type="video/webm"
+                src={`https://storage.googleapis.com/sourcegraph-assets/${source.webm}.webm`}
+                data-cookieconsent="ignore"
+            />
+            <source
+                type="video/mp4"
+                src={`https://storage.googleapis.com/sourcegraph-assets/${source.mp4}.mp4`}
+                data-cookieconsent="ignore"
+            />
+            {caption && <figcaption>{caption}</figcaption>}
+        </video>
+    </figure>
 )

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -1,27 +1,39 @@
 import { FunctionComponent } from 'react'
 
-export const Video: FunctionComponent<{ filePath: string }> = ({ filePath }) => (
+interface Video {
+    source: {
+        webm: string
+        mp4: string
+    }
+    loop: boolean
+    caption: string // can also be used for alt
+    title: string
+}
+
+export const Video: FunctionComponent<Video> = ({ source, loop, caption, title }) => (
     <video
         className="w-100 h-auto shadow"
         width={1280}
         height={720}
         autoPlay={true}
         muted={true}
-        loop={true}
+        loop={loop}
         playsInline={true}
         controls={false}
+        title={title}
         // GCS does not set cookies, so we don't want Cookiebot to block this video based on consent
         data-cookieconsent="ignore"
     >
         <source
             type="video/webm"
-            src={`https://storage.googleapis.com/sourcegraph-assets/${filePath}.webm`}
+            src={`https://storage.googleapis.com/sourcegraph-assets/${source.webm}.webm`}
             data-cookieconsent="ignore"
         />
         <source
             type="video/mp4"
-            src={`https://storage.googleapis.com/sourcegraph-assets/${filePath}.mp4`}
+            src={`https://storage.googleapis.com/sourcegraph-assets/${source.mp4}.mp4`}
             data-cookieconsent="ignore"
         />
+        {caption}
     </video>
 )

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -12,7 +12,7 @@ interface Video {
 }
 
 export const Video: FunctionComponent<Video> = ({ source, loop, caption, showCaption = false, title }) => (
-    <figure role="tooltip" aria-label="Your accessible description goes here">
+    <figure>
         <video
             className="w-100 h-auto shadow"
             width={1280}

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -6,12 +6,13 @@ interface Video {
         mp4: string
     }
     loop: boolean
+    showCaption?: boolean
     caption: string
     title: string
 }
 
-export const Video: FunctionComponent<Video> = ({ source, loop, caption, title }) => (
-    <figure>
+export const Video: FunctionComponent<Video> = ({ source, loop, caption, showCaption = false, title }) => (
+    <figure role="tooltip" aria-label="Your accessible description goes here">
         <video
             className="w-100 h-auto shadow"
             width={1280}
@@ -35,7 +36,8 @@ export const Video: FunctionComponent<Video> = ({ source, loop, caption, title }
                 src={`https://storage.googleapis.com/sourcegraph-assets/${source.mp4}.mp4`}
                 data-cookieconsent="ignore"
             />
-            {caption && <figcaption>{caption}</figcaption>}
+            {caption && caption}
         </video>
+        {showCaption && <figcaption>{caption}</figcaption>}
     </figure>
 )

--- a/src/components/YouTube.tsx
+++ b/src/components/YouTube.tsx
@@ -1,6 +1,6 @@
 import { FunctionComponent } from 'react'
 
-interface Props {
+interface YouTube {
     className?: string
     id: string
     title: string
@@ -11,13 +11,14 @@ interface Props {
     loop?: boolean
     controls?: boolean
     branding?: boolean
+    showTitle?: boolean
 }
 
 /**
  * A responsive YouTube video player.
  * See https://developers.google.com/youtube/player_parameters for options.
  */
-export const YouTube: FunctionComponent<Props> = ({
+export const YouTube: FunctionComponent<YouTube> = ({
     className = '',
     id,
     title,
@@ -28,19 +29,23 @@ export const YouTube: FunctionComponent<Props> = ({
     loop = false,
     controls = true,
     branding = false,
+    showTitle = false,
 }) => (
-    <div className={`video-embed embed-responsive embed-responsive-16by9 ${className}`}>
-        <iframe
-            className="embed-responsive-item"
-            src={`https://www.youtube-nocookie.com/embed/${id}?autoplay=${autoplay ? 1 : 0}&cc_load_policy=${
-                captions ? 1 : 0
-            }&start=${start}&end=${end}&loop=${loop ? 1 : 0}&controls=${controls ? 1 : 0}&modestbranding=${
-                branding ? 1 : 0
-            }&rel=0`}
-            allowFullScreen={true}
-            allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-            frameBorder="0"
-            title={title}
-        />
-    </div>
+    <figure>
+        <div className={`video-embed embed-responsive embed-responsive-16by9 ${className}`}>
+            <iframe
+                className="embed-responsive-item"
+                src={`https://www.youtube-nocookie.com/embed/${id}?autoplay=${autoplay ? 1 : 0}&cc_load_policy=${
+                    captions ? 1 : 0
+                }&start=${start}&end=${end}&loop=${loop ? 1 : 0}&controls=${controls ? 1 : 0}&modestbranding=${
+                    branding ? 1 : 0
+                }&rel=0`}
+                allowFullScreen={true}
+                allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
+                frameBorder="0"
+                title={title}
+            />
+        </div>
+        {showTitle && <figcaption>{title}</figcaption>}
+    </figure>
 )

--- a/src/pages/accelerate-dev-onboarding.tsx
+++ b/src/pages/accelerate-dev-onboarding.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react'
 
 import Link from 'next/link'
 
-import { Layout, FormLegal } from '@components'
+import { Layout, FormLegal, YouTube } from '@components'
 import { buttonStyle, buttonLocation } from '@data'
 import { useHubSpot, useChiliPiper } from '@hooks'
 
@@ -45,15 +45,7 @@ const AccelerateDevOnboarding: FunctionComponent = () => {
                     </div>
 
                     <div className="col-lg-6 mt-4 mt-lg-0">
-                        <div className="embed-responsive embed-responsive-16by9">
-                            <iframe
-                                src="https://www.youtube.com/embed/DgwvhRW1Cbc"
-                                title="Accelerate developer onboarding with Sourcegraph"
-                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                allowFullScreen={true}
-                                className="embed-responsive-item"
-                            />
-                        </div>
+                        <YouTube title="Accelerate developer onboarding with Sourcegraph" id="DgwvhRW1Cbc" />
                     </div>
                 </div>
             </div>

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -107,7 +107,7 @@ export const BatchChangesPage: FunctionComponent = () => (
                             source={{ webm: 'batch-changes/how-it-works', mp4: 'batch-changes/how-it-works' }}
                             loop={true}
                             title="Batch Changes: How it works"
-                            caption="Search, define, executre and track code changes"
+                            caption="Search, define, execute, and track code changes"
                         />
                     </div>
                 </div>

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -4,7 +4,7 @@ import Link from 'next/link'
 import Tab from 'react-bootstrap/Tab'
 import Tabs from 'react-bootstrap/Tabs'
 
-import { BlockquoteWithBorder, ContentSection, Layout, Video, TrySourcegraph } from '@components'
+import { BlockquoteWithBorder, ContentSection, Layout, Video, TrySourcegraph, YouTube } from '@components'
 import { buttonStyle, buttonLocation } from '@data'
 
 const batchChangesDemoFormURL = '/contact/request-batch-changes-demo'
@@ -103,7 +103,12 @@ export const BatchChangesPage: FunctionComponent = () => (
                         </ul>
                     </div>
                     <div className="col-lg-7">
-                        <Video filePath="batch-changes/how-it-works" />
+                        <Video
+                            source={{ webm: 'batch-changes/how-it-works', mp4: 'batch-changes/how-it-works' }}
+                            loop={true}
+                            title="Batch Changes: How it works"
+                            caption="Search, define, executre and track code changes"
+                        />
                     </div>
                 </div>
             </ContentSection>
@@ -140,7 +145,12 @@ export const BatchChangesPage: FunctionComponent = () => (
                     </p>
                 </div>
                 <div className="col-lg-7">
-                    <Video filePath="batch-changes/creation-to-merge" />
+                    <Video
+                        source={{ webm: 'batch-changes/creation-to-merge', mp4: 'batch-changes/creation-to-merge' }}
+                        loop={true}
+                        title="Batch Changes: Creation to merge"
+                        caption="Automatically track changeset lifecycle status"
+                    />
                 </div>
             </div>
         </ContentSection>
@@ -226,15 +236,8 @@ export const BatchChangesPage: FunctionComponent = () => (
         <ContentSection className="py-4 py-md-7">
             <h1 className="mb-3 text-center">See Batch Changes in action</h1>
             <div className="row justify-content-center pt-md-4">
-                <div className="col-lg-8 container video-embed embed-responsive embed-responsive-16by9">
-                    <iframe
-                        className="embed-responsive-item"
-                        src="https://www.youtube-nocookie.com/embed/eOmiyXIWTCw?autoplay=0&amp;cc_load_policy=0&amp;start=0&amp;end=0&amp;loop=0&amp;controls=1&amp;modestbranding=1&amp;rel=0"
-                        allowFullScreen={true}
-                        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-                        frameBorder={0}
-                        title="Sourcegraph Batch Changes demo"
-                    />
+                <div className="col-lg-8">
+                    <YouTube title="Sourcegraph Batch Changes demo" id="eOmiyXIWTCw" />
                 </div>
             </div>
         </ContentSection>

--- a/src/pages/blog/[...slug].tsx
+++ b/src/pages/blog/[...slug].tsx
@@ -42,7 +42,7 @@ const BlogPage: NextPage<PageProps> = ({ post, content }) => {
                     <BlogHeader {...blogInfo} />
                 </div>
                 <div className="post-template mt-5 bg-white">
-                    <div className="container-lg">
+                    <div className="container-lg max-w-650">
                         <PostTemplate
                             post={post}
                             content={content}

--- a/src/pages/code-insights.tsx
+++ b/src/pages/code-insights.tsx
@@ -360,7 +360,12 @@ const CodeInsightsPage: FunctionComponent = () => {
                         </p>
                     </div>
                     <div className="col-lg-7 ml-lg-6 mb-md-4 d-flex align-items-center video-container">
-                        <Video filePath="code_insights/code-insights-720" />
+                        <Video
+                            source={{ webm: 'code_insights/code-insights-720', mp4: 'code_insights/code-insights-720' }}
+                            title="Code Insights"
+                            caption="Code Insights"
+                            loop={true}
+                        />
                     </div>
                 </div>
             </ContentSection>
@@ -463,12 +468,8 @@ const CodeInsightsPage: FunctionComponent = () => {
             <ContentSection className="py-7">
                 <h1 className="mb-3 text-center font-weight-bold">See Code Insights in action</h1>
                 <div className="row justify-content-center pt-md-4">
-                    <div className="col-lg-8 container video-embed embed-responsive embed-responsive-16by9 ">
-                        <YouTube
-                            className="embed-responsive-item"
-                            id="fMCUJQHfbUA"
-                            title="Sourcegraph Code Insights demo"
-                        />
+                    <div className="col-lg-8">
+                        <YouTube id="fMCUJQHfbUA" title="Sourcegraph Code Insights demo" />
                     </div>
                 </div>
             </ContentSection>

--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -3,7 +3,14 @@ import React, { FunctionComponent } from 'react'
 import ArrowRightBoxIcon from 'mdi-react/ArrowRightBoxIcon'
 import Link from 'next/link'
 
-import { ContentSection, BlockquoteWithBorder, IntegrationsSection, Layout, SelfHostedSection } from '@components'
+import {
+    ContentSection,
+    BlockquoteWithBorder,
+    IntegrationsSection,
+    Layout,
+    SelfHostedSection,
+    YouTube,
+} from '@components'
 import { buttonStyle, buttonLocation } from '@data'
 
 export const CodeSearchPage: FunctionComponent = () => (
@@ -59,15 +66,8 @@ export const CodeSearchPage: FunctionComponent = () => (
         {/* A search engine built for code */}
         <ContentSection>
             <div className="row">
-                <div className="col-lg-6 container video-embed embed-responsive embed-responsive-16by9 ">
-                    <iframe
-                        className="embed-responsive-item"
-                        src="https://www.youtube-nocookie.com/embed/aDU4C9j-hYA?autoplay=0&amp;cc_load_policy=0&amp;start=0&amp;end=0&amp;loop=0&amp;controls=1&amp;modestbranding=1&amp;rel=0"
-                        allowFullScreen={true}
-                        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-                        frameBorder={0}
-                        title="AND/OR operators for universal code search"
-                    />
+                <div className="col-lg-6">
+                    <YouTube title="AND/OR operators for universal code search" id="aDU4C9j-hYA" />
                 </div>
                 <div className="col-lg-6">
                     <h2 className="display-3 font-weight-bold mb-3 mt-lg-0 mt-3">A search engine built for code</h2>
@@ -182,15 +182,8 @@ export const CodeSearchPage: FunctionComponent = () => (
         <ContentSection className="pb-7">
             <h2 className="display-3 font-weight-bold mt-5 mb-4">How developers are using Sourcegraph</h2>
             <div className="row">
-                <div className="col-lg-6 container video-embed embed-responsive embed-responsive-16by9 border">
-                    <iframe
-                        className="embed-responsive-item"
-                        src="https://www.youtube-nocookie.com/embed/r2CpLe1h89I?autoplay=0&amp;cc_load_policy=0&amp;start=0&amp;end=0&amp;loop=0&amp;controls=1&amp;modestbranding=1&amp;rel=0"
-                        allowFullScreen={true}
-                        allow="accelerometer; autoplay; encrypted-media; gyroscope; picture-in-picture"
-                        frameBorder={0}
-                        title="How developers are using Sourcegraph"
-                    />
+                <div className="col-lg-6">
+                    <YouTube title="How developers are using Sourcegraph" id="r2CpLe1h89I" />
                 </div>
                 <div className="col-lg-6">
                     <p>

--- a/src/pages/community.tsx
+++ b/src/pages/community.tsx
@@ -3,7 +3,7 @@ import { FunctionComponent } from 'react'
 import Tab from 'react-bootstrap/Tab'
 import Tabs from 'react-bootstrap/Tabs'
 
-import { ContentSection, Layout } from '@components'
+import { ContentSection, Layout, YouTube } from '@components'
 import { buttonStyle, buttonLocation } from '@data'
 
 export const Community: FunctionComponent = () => (
@@ -103,7 +103,7 @@ export const Community: FunctionComponent = () => (
             <Tabs defaultActiveKey="sgEvents" id="use-cases" className="justify-content-center">
                 <Tab eventKey="sgEvents" title="Events">
                     <div className="row mt-5 justify-content-center">
-                        <div className="col-lg-8">
+                        <div className="col-lg-6">
                             <p>
                                 Keynote speakers. Job opportunities and partnerships. You can find us in every major
                                 industry event. Give us an air-hug if you see us.
@@ -119,16 +119,8 @@ export const Community: FunctionComponent = () => (
                 <Tab eventKey="devToolTime" title="Dev Tool Time">
                     <div className="row mt-5 justify-content-center">
                         <div className="col-lg-6">
-                            <iframe
-                                width="560"
-                                height="315"
-                                src="https://www.youtube.com/embed/QNYoOCLocAI"
-                                title="YouTube video player"
-                                frameBorder="0"
-                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                allowFullScreen={true}
-                            />
-                            <p>
+                            <YouTube title="Dev Tool Time" id="QNYoOCLocAI" />
+                            <p className="pt-3">
                                 Cool hardware. Most-wanted guests. And hot topics. Check our{' '}
                                 <a href="https://srcgr.ph/dev-tool-time-playlist">YouTube channel</a> and subscribe to
                                 keep up with new episodes.
@@ -136,33 +128,27 @@ export const Community: FunctionComponent = () => (
                         </div>
                     </div>
                 </Tab>
-                <Tab eventKey="podcast" title="Podcast">
+                <Tab eventKey="podcast" title="Sourcegraph Podcast">
                     <div className="row mt-5 justify-content-center">
                         <div className="col-lg-6">
-                            <iframe
-                                width="560"
-                                height="315"
-                                src="https://www.youtube.com/embed/VgVDMd2VlaU"
-                                title="YouTube video player"
-                                frameBorder="0"
-                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                allowFullScreen={true}
-                            />
-                            <strong>Subscribe:</strong>&nbsp;
-                            <a href="https://www.youtube.com/playlist?list=PL6zLuuRVa1_jf5GDl61SvEOXvwvKS1IXA">
-                                YouTube
-                            </a>
-                            &nbsp;
-                            <a href="https://podcasts.apple.com/us/podcast/the-sourcegraph-podcast/id1516219009">
-                                Apple
-                            </a>
-                            &nbsp;
-                            <a href="https://open.spotify.com/show/1YlDYvCxNB7jAndbZPt5a6">Spotify</a>&nbsp;
-                            <a href="https://podcasts.google.com/?feed=aHR0cHM6Ly9mZWVkcy5idXp6c3Byb3V0LmNvbS8xMDk3OTc4LnJzcw==">
-                                Google
-                            </a>
-                            &nbsp;
-                            <a href="https://feeds.buzzsprout.com/1097978.rss">RSS</a>
+                            <YouTube title="Sourcegraph Podcast" id="VgVDMd2VlaU" />
+                            <p className="pt-3">
+                                <strong>Subscribe:</strong>&nbsp;
+                                <a href="https://www.youtube.com/playlist?list=PL6zLuuRVa1_jf5GDl61SvEOXvwvKS1IXA">
+                                    YouTube
+                                </a>
+                                &nbsp;
+                                <a href="https://podcasts.apple.com/us/podcast/the-sourcegraph-podcast/id1516219009">
+                                    Apple
+                                </a>
+                                &nbsp;
+                                <a href="https://open.spotify.com/show/1YlDYvCxNB7jAndbZPt5a6">Spotify</a>&nbsp;
+                                <a href="https://podcasts.google.com/?feed=aHR0cHM6Ly9mZWVkcy5idXp6c3Byb3V0LmNvbS8xMDk3OTc4LnJzcw==">
+                                    Google
+                                </a>
+                                &nbsp;
+                                <a href="https://feeds.buzzsprout.com/1097978.rss">RSS</a>
+                            </p>
                         </div>
                     </div>
                 </Tab>

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -1,6 +1,6 @@
 import React, { FunctionComponent } from 'react'
 
-import { Layout } from '@components'
+import { Layout, YouTube } from '@components'
 import { useHubSpot, useChiliPiper } from '@hooks'
 
 const Demo: FunctionComponent = () => {
@@ -34,16 +34,11 @@ const Demo: FunctionComponent = () => {
                         <h2 className="font-weight-bold">Let us show you around</h2>
                         <p>Watch this quick video to see what Sourcegraph can do</p>
 
-                        <div className="embed-responsive embed-responsive-16by9 my-5">
-                            <iframe
-                                src="https://www.youtube-nocookie.com/embed/E2QYIwKlMac"
-                                frameBorder={0}
-                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                allowFullScreen={true}
-                                title="Sourcegraph Product Tour"
-                                className="embed-responsive-item"
-                            />
-                        </div>
+                        <YouTube
+                            title="Sourcegraph Product Tour"
+                            id="E2QYIwKlMac"
+                            className="embed-responsive-item my-5"
+                        />
 
                         <h2 className="font-weight-bold">Like what you see?</h2>
                         <p>Get a live demo in your environment! Just fill out the form to request a demo.</p>

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -34,11 +34,7 @@ const Demo: FunctionComponent = () => {
                         <h2 className="font-weight-bold">Let us show you around</h2>
                         <p>Watch this quick video to see what Sourcegraph can do</p>
 
-                        <YouTube
-                            title="Sourcegraph Product Tour"
-                            id="E2QYIwKlMac"
-                            className="my-5"
-                        />
+                        <YouTube title="Sourcegraph Product Tour" id="E2QYIwKlMac" className="my-5" />
 
                         <h2 className="font-weight-bold">Like what you see?</h2>
                         <p>Get a live demo in your environment! Just fill out the form to request a demo.</p>

--- a/src/pages/fixing-vulnerabilities.tsx
+++ b/src/pages/fixing-vulnerabilities.tsx
@@ -2,7 +2,7 @@ import { FunctionComponent } from 'react'
 
 import Link from 'next/link'
 
-import { Layout, FormLegal } from '@components'
+import { Layout, FormLegal, YouTube } from '@components'
 import { buttonStyle, buttonLocation } from '@data'
 import { useHubSpot, useChiliPiper } from '@hooks'
 
@@ -40,16 +40,12 @@ const FixingVulnerabilities: FunctionComponent = () => {
                         </div>
                     </div>
 
-                    <div className="col-lg-6 mt-4 mt-lg-0">
-                        <div className="embed-responsive embed-responsive-16by9">
-                            <iframe
-                                src="https://www.youtube.com/embed/13OqKPXqZXo"
-                                title="Finding and fixing vulnerabilities with Sourcegraph"
-                                allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
-                                allowFullScreen={true}
-                                className="embed-responsive-item"
-                            />
-                        </div>
+                    <div className="col-lg-6">
+                        <YouTube
+                            title="Finding and fixing vulnerabilities with Sourcegraph"
+                            id="13OqKPXqZXo"
+                            className="mt-4 mt-lg-0"
+                        />
                     </div>
                 </div>
             </div>

--- a/src/pages/podcast/[...slug].tsx
+++ b/src/pages/podcast/[...slug].tsx
@@ -42,7 +42,7 @@ const PodcastPage: NextPage<PageProps> = ({ post, content }) => {
                     <BlogHeader {...podcastInfo} />
                 </div>
                 <div className="post-template mt-5 bg-white">
-                    <div className="container-lg">
+                    <div className="container-lg max-w-650">
                         <PostTemplate
                             post={post}
                             content={content}

--- a/src/pages/press/[...slug].tsx
+++ b/src/pages/press/[...slug].tsx
@@ -42,7 +42,7 @@ const PressReleasePage: NextPage<PageProps> = ({ post, content }) => {
                     <BlogHeader {...pressReleaseInfo} />
                 </div>
                 <div className="post-template mt-5 bg-white">
-                    <div className="container-lg">
+                    <div className="container-lg max-w-650">
                         <PostTemplate
                             post={post}
                             content={content}

--- a/src/styles/components/blog/_BlogPost.scss
+++ b/src/styles/components/blog/_BlogPost.scss
@@ -5,7 +5,6 @@
         // Gif-like videos
         video[autoplay][loop][muted]:not([controls]) {
             width: 100%;
-            max-width: 650px;
             max-height: 100vh;
             box-shadow: 0 2px 18px 0 #0000001a, 0 6px 20px 0 #00000017;
             margin: 3rem auto 2rem auto;

--- a/src/styles/components/blog/_BlogPost.scss
+++ b/src/styles/components/blog/_BlogPost.scss
@@ -5,9 +5,10 @@
         // Gif-like videos
         video[autoplay][loop][muted]:not([controls]) {
             width: 100%;
+            max-width: 650px;
             max-height: 100vh;
             box-shadow: 0 2px 18px 0 #0000001a, 0 6px 20px 0 #00000017;
-            margin: 3rem auto;
+            margin: 3rem auto 2rem auto;
             display: block;
             border-style: none;
             height: auto; // Allow providing the media width and height as HTML attributes for aspect-ratio calculation to avoid layout shift
@@ -25,15 +26,11 @@
         }
 
         figcaption {
-            margin-top: 2rem;
+            margin: 1rem auto 3rem auto;
             text-align: center;
             font-style: italic;
         }
 
-        // Make sure margin for figures with caption is applied after the caption, not before.
-        figure > :is(img, object, video) {
-            margin-bottom: 0;
-        }
         figure {
             margin-bottom: 3rem;
         }


### PR DESCRIPTION
This closes #5418. It creates the blogpost entitled "Shift left: What does it mean?" 

### Changelog

1. Added markdown
2. Added images to GCP

### Notes
- This is created from the copy in the [Google doc](https://docs.google.com/document/d/1BnppxB4Ofhmp1cFOmMCcwj_Gm5QgHa2qFxh6f1IKuFU/edit#)
- Draft copy needs to be finalized
- Hero image is used as thumbnail and social image until final images are decided
- Adds `figcaption` to `Video` and `YouTube` components (from review)
- Implements `Video` and `YouTube` components in blog (from review)

### Test

1. Ensure prettier has standardized the proposed changes.
3. Please check that copy is transcribed accurately from the Google Docs
4. Please ensure images render correctly and links are active
