### PR TITLE
Fix Shift Left Video

### DIFF
--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -63,7 +63,7 @@ In order to take full advantage of existing libraries, you need to be able to un
 Investing in great documentation helps, but this is a hard change to make if your codebase isn't already well-documented. The best way to learn is by example. A single real usage example can be worth a thousand words of documentation.
 
 <Video 
-  source={{webm: 'blog/shift-left/02-find-references', mp4: 'blog/shift-left/01-code-reuse'}} 
+  source={{webm: 'blog/shift-left/02-find-references', mp4: 'blog/shift-left/02-find-references'}} 
   loop={true}
   title="Find references" 
   caption="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it."

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -27,13 +27,13 @@ export const Video: FunctionComponent<Video> = ({ source, loop, caption, showCap
             data-cookieconsent="ignore"
         >
             <source
-                type="video/webm"
-                src={`https://storage.googleapis.com/sourcegraph-assets/${source.webm}.webm`}
+                type="video/mp4"
+                src={`https://storage.googleapis.com/sourcegraph-assets/${source.mp4}.mp4`}
                 data-cookieconsent="ignore"
             />
             <source
-                type="video/mp4"
-                src={`https://storage.googleapis.com/sourcegraph-assets/${source.mp4}.mp4`}
+                type="video/webm"
+                src={`https://storage.googleapis.com/sourcegraph-assets/${source.webm}.webm`}
                 data-cookieconsent="ignore"
             />
             {caption && caption}


### PR DESCRIPTION
This fixes a bug duplicating one of the videos in the blogpost. This was due to error transcribing the video path.

### Changelog
- Updates markdown with correct video

### Test

1. Ensure prettier has standardized the proposed changes.
2. Please check that the first and second videos are different.
