### PR TITLE
Guide/How Companies Fix Vulnerabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,11 +55,13 @@ git config core.hooksPath .githooks
 We use [Cypress](https://www.cypress.io/) as our test suite and currently have end to end tests configured.
 
 To run tests visually, run:
+
 ```sh
 yarn test
 ```
 
 To run tests headlessly in the CLI, run:
+
 ```sh
 yarn test:ci
 ```

--- a/content/blogposts/2022/shift-left-wtf-does-it-mean.md
+++ b/content/blogposts/2022/shift-left-wtf-does-it-mean.md
@@ -63,7 +63,7 @@ In order to take full advantage of existing libraries, you need to be able to un
 Investing in great documentation helps, but this is a hard change to make if your codebase isn't already well-documented. The best way to learn is by example. A single real usage example can be worth a thousand words of documentation.
 
 <Video 
-  source={{webm: 'blog/shift-left/02-find-references', mp4: 'blog/shift-left/01-code-reuse'}} 
+  source={{webm: 'blog/shift-left/02-find-references', mp4: 'blog/shift-left/02-find-references'}} 
   loop={true}
   title="Find references" 
   caption="Usage examples are critical to lowering the friction of code reuse. Validate the prototype first by using existing functions and components. You can always go back and build a better wheel if user feedback demands it."

--- a/src/pages/guides/how-google-fixes-vulnerabilities.tsx
+++ b/src/pages/guides/how-google-fixes-vulnerabilities.tsx
@@ -1,0 +1,48 @@
+import { FunctionComponent } from 'react'
+
+import { Layout, GatedResourceLayout } from '@components'
+
+export const Guide: FunctionComponent = () => (
+    <Layout
+        meta={{
+            title: 'How Google and Others and Fix Vulnerabilities | Sourcegraph',
+            description:
+                'See how tech companies large and small address code security. In this post, we explore how Google, Microsoft, Lyft, GitLab, and Atlassian find and fix vulnerabilities.',
+        }}
+        className="navbar-white"
+    >
+        <GatedResourceLayout
+            title="How Google, Microsoft, Lyft, GitLab, and Atlassian find and fix vulnerabilities"
+            formLabel="Download the e-book"
+            form={{
+                formId: '610debf1-bbce-45d6-a492-6858b5b3db18',
+                onFormSubmitted: () => window.open('/guides/sg-how-companies-fix-vulnerabilities.pdf'),
+            }}
+            description={
+                <section className="col-md-6 col-12 pr-lg-6">
+                    <p>
+                        Your organization's ability to find and fix vulnerabilities within the codebase has significant
+                        financial implications, not to mention brand impact. Most companies have invested in security
+                        scanning tools to find known vulnerabilities, but these do not help patch them quickly. They
+                        also do not help mitigate zero-day vulnerabilities.
+                    </p>
+                    <p>
+                        <strong>Download this guide to learn:</strong>
+                    </p>
+                    <ul>
+                        <li className="mb-2">
+                            How Google, Microsoft, Lyft, GitLab, and Atlassian find and fix vulnerabilities throughout
+                            their respective codebases
+                        </li>
+                        <li className="mb-2">
+                            Which capabilities are necessary to mitigate a known vulnerability quickly
+                        </li>
+                        <li className="mb-2">How do these companies respond to zero-day vulnerabilities</li>
+                    </ul>
+                </section>
+            }
+        />
+    </Layout>
+)
+
+export default Guide

--- a/src/pages/guides/how-google-fixes-vulnerabilities.tsx
+++ b/src/pages/guides/how-google-fixes-vulnerabilities.tsx
@@ -5,7 +5,7 @@ import { Layout, GatedResourceLayout } from '@components'
 export const Guide: FunctionComponent = () => (
     <Layout
         meta={{
-            title: 'How Google and Others and Fix Vulnerabilities | Sourcegraph',
+            title: 'How Google and others find and fix vulnerabilities | Sourcegraph',
             description:
                 'See how tech companies large and small address code security. In this post, we explore how Google, Microsoft, Lyft, GitLab, and Atlassian find and fix vulnerabilities.',
         }}


### PR DESCRIPTION
This closes #5473. It adds the gated page for the "How Companies Fix Vulnerabilities" e-book.

### Changelog
- Adds `guides/how-google-fixes-vulnerabilities.tsx`
- Adds `sg-how-companies-fix-vulnerabilities.pdf` for download

### Notes
- This guide page will be updated with the new Hubspot form syntax in #5483

### Test

1. Ensure prettier has standardized the proposed changes.
2. Navigate to `/guides/how-google-fixes-vulnerabilities.tsx`
3. Please check that the copy aligns with the doc
4. Please check that the guide downloads properly on form submission