### PR TITLE
copy changes, add link to Cloudflare logo

### DIFF
--- a/src/components/CustomerLogos.tsx
+++ b/src/components/CustomerLogos.tsx
@@ -49,6 +49,7 @@ const logos: Logo[] = [
     {
         name: 'Cloudflare',
         src: '/external-logos/cloudflare-logo.svg',
+        link: '/case-studies/cloudflare-accelerates-debugging-and-improves-security',
     },
     {
         name: 'Mercado Libre',

--- a/src/pages/get-started/self-hosted.tsx
+++ b/src/pages/get-started/self-hosted.tsx
@@ -25,7 +25,7 @@ export const SelfHostedPage: FunctionComponent = () => {
                     <h1 className="display-1 mb-2">
                         <strong>Get started</strong>
                     </h1>
-                    <p>From Amazon to Uber, the world's best developers use Sourcegraph every day.</p>
+                    <p>The world's best developers use Sourcegraph every day.</p>
                 </div>
             }
             heroAndHeaderClassName={styles.hero}

--- a/src/pages/use-cases/index.tsx
+++ b/src/pages/use-cases/index.tsx
@@ -206,11 +206,10 @@ const UseCases: React.FunctionComponent = () => (
                         <h2 className="display-3 font-weight-bold mb-3">Resolve incidents faster</h2>
                         <h5>Identify the root cause in code and fix the issue everywhere.</h5>
                         <p>
-                            &ldquo;Every minute matters when responding to a business-critical incident. Downtime =
-                            revenue lost. Sourcegraph helps development teams identify the root cause in code,
-                            understand why the problem occurred and its potential impact on other services, fix the
-                            issue everywhere so it won't reoccur, and assure incident responders that all holes are
-                            plugged.&rdquo;
+                            Every minute matters when responding to a business-critical incident. Downtime = revenue
+                            lost. Sourcegraph helps development teams identify the root cause in code, understand why
+                            the problem occurred and its potential impact on other services, fix the issue everywhere so
+                            it won't reoccur, and assure incident responders that all holes are plugged.
                         </p>
                         <ul>
                             <li>

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -10,8 +10,8 @@
 
 /* ==================== Bootstrap Overrides ==================== */
 
-$font-family-sans-serif: "Source Sans Pro", sans-serif;
-$font-family-monospace: "Source Code Pro", monospace;
+$font-family-sans-serif: 'Source Sans Pro', sans-serif;
+$font-family-monospace: 'Source Code Pro', monospace;
 $font-family-base: $font-family-sans-serif;
 $headings-font-family: $font-family-base;
 
@@ -295,7 +295,7 @@ code.border {
 }
 
 code {
-    font-family: "Source Code Pro", monospace !important;
+    font-family: 'Source Code Pro', monospace !important;
 }
 
 /* ==================== Positioning ==================== */


### PR DESCRIPTION
This closes #5542. It does not require stakeholder review.

### Changelog
- Removes Amazon mention on `/get-started/self-hosted`
- Adds case study link to Cloudflare logo in `CustomerLogos`
- Fixes unneeded quotations on "Resolve incidents faster" section of `/use-cases`

### Notes
- Replacing the Amazon logo was initially scoped in the issue. It has been moved to #5552.

### Test
1. Ensure prettier has standardized the proposed changes.
2. Please test Cloudflare logo link to case study
3. Please ensure copy changes correct on `/get-started/self-hosted` and `/use-cases`