### PR TITLE
release: sourcegraph@3.41.1

### DIFF
--- a/src/components/Install/index.tsx
+++ b/src/components/Install/index.tsx
@@ -9,7 +9,7 @@ import { ReactComponent as CopyIcon } from './copyIcon.svg'
 import styles from './install.module.scss'
 
 const installText =
-    'docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.41.0'
+    'docker run --publish 7080:7080 --publish 127.0.0.1:3370:3370 --rm --volume ~/.sourcegraph/config:/etc/sourcegraph --volume ~/.sourcegraph/data:/var/opt/sourcegraph sourcegraph/server:3.41.1'
 
 export const Install: FunctionComponent = () => {
     const [copied, setCopied] = useState(false)


### PR DESCRIPTION
This pull request is part of the Sourcegraph 3.41.1 release.


* [Release batch change](https://k8s.sgdev.org/organizations/sourcegraph/batch-changes/release-sourcegraph-3.41.1)
* [Tracking issue](https://github.com/sourcegraph/sourcegraph/issues/38644)

### Test plan

CI checks in this repository should pass, and a manual review should confirm if the generated changes are correct.