### PR TITLE
Mysterybox redirect

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -166,4 +166,8 @@
   from = "/get-started/cloud"
   to = "/get-started/self-hosted"
   force = true
+
+[[redirects]]
+  from = "/mysterybox"
+  to = "https://view.ceros.com/sourcegraph/mysterybox/p/1"
 # ========== END INDIVIDUAL REDIRECTS ==========


### PR DESCRIPTION
Adds redirect from `/mysterybox` to ceros page (`https://view.ceros.com/sourcegraph/mysterybox/p/1`)

### Test
1. Ensure prettier has standardized the proposed changes.
2. Nav to `/mysterybox` and ensure correct ceros page renders.
