### PR TITLE
Replace Amazon logo

### DIFF
--- a/src/components/CustomerLogos.tsx
+++ b/src/components/CustomerLogos.tsx
@@ -10,8 +10,8 @@ interface Logo {
 
 const logos: Logo[] = [
     {
-        name: 'Amazon',
-        src: '/external-logos/amazon-logo.svg',
+        name: 'Uber',
+        src: '/external-logos/uber-logo.svg',
     },
     {
         name: 'GE',
@@ -35,8 +35,8 @@ const logos: Logo[] = [
         src: '/external-logos/canva-logo.svg',
     },
     {
-        name: 'Uber',
-        src: '/external-logos/uber-logo.svg',
+        name: 'Indeed',
+        src: '/external-logos/indeed-logo.svg',
     },
     {
         name: 'Plaid',

--- a/src/pages/get-started/cloud.tsx
+++ b/src/pages/get-started/cloud.tsx
@@ -25,7 +25,7 @@ export const CloudPage: FunctionComponent = () => {
                     <h1 className="display-1 mb-2">
                         <strong>What's best for you?</strong>
                     </h1>
-                    <p>From Amazon to Uber, the world's best developers use Sourcegraph every day.</p>
+                    <p>From GE to Uber, the world's best developers use Sourcegraph every day.</p>
                 </div>
             }
             heroAndHeaderClassName={styles.hero}

--- a/src/pages/get-started/index.tsx
+++ b/src/pages/get-started/index.tsx
@@ -43,7 +43,7 @@ export const GetStartedPage: FunctionComponent = () => {
                     <h1 className="display-1 mb-2">
                         <strong>What's best for you?</strong>
                     </h1>
-                    <p>From Amazon to Uber, the world's best developers use Sourcegraph every day.</p>
+                    <p>From GE to Uber, the world's best developers use Sourcegraph every day.</p>
                 </div>
             }
             heroAndHeaderClassName={styles.hero}

--- a/src/pages/get-started/self-hosted.tsx
+++ b/src/pages/get-started/self-hosted.tsx
@@ -25,7 +25,7 @@ export const SelfHostedPage: FunctionComponent = () => {
                     <h1 className="display-1 mb-2">
                         <strong>Get started</strong>
                     </h1>
-                    <p>From Amazon to Uber, the world's best developers use Sourcegraph every day.</p>
+                    <p>From GE to Uber, the world's best developers use Sourcegraph every day.</p>
                 </div>
             }
             heroAndHeaderClassName={styles.hero}


### PR DESCRIPTION
Closes #5552 - Replaces Amazon logo with Indeed, swaps order, and changes out Amazon customer reference to GE.

### Test
1. Ensure prettier has standardized the proposed changes.
2. Ensure Customer Logos reflects accurate replacements.