### PR TITLE
Cloudeflare case study link

### DIFF
--- a/src/components/CustomerLogos.tsx
+++ b/src/components/CustomerLogos.tsx
@@ -49,6 +49,7 @@ const logos: Logo[] = [
     {
         name: 'Cloudflare',
         src: '/external-logos/cloudflare-logo.svg',
+        link: '/case-studies/cloudflare-accelerates-debugging-and-improves-security',
     },
     {
         name: 'Mercado Libre',


### PR DESCRIPTION
Follow up to #5552, link Cloudfare link to it's case study.

### Test
1. Ensure prettier has standardized the proposed changes.
2. From Home page customer logos, confirm the Cloudflare logo links to it's case study (`/case-studies/cloudflare-accelerates-debugging-and-improves-security`).