### PR TITLE
Bug fix for 3.42 release post video

### DIFF
--- a/content/blogposts/2022/release-3.42.md
+++ b/content/blogposts/2022/release-3.42.md
@@ -61,15 +61,19 @@ We have a new search type available experimentally, called "Lucky search." It im
 
 ## Code Insights load faster and include more historical datapoints
 
-<Video
-  title="Faster code insights"
-  caption="An example of code insights loading faster"
-  source={{
-    mp4: "blog/3.42/3.42InsightsSpeedImprovements"
-    webm: "blog/3.42/3.42InsightsSpeedImprovements"
-  }}
-  loop={true}
-/>
+<figure>
+  <video
+    className="w-100 h-auto shadow"
+    title="An example of code insights loading faster"
+    autoPlay
+    loop
+    muted
+    playsInline
+  >
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/3.42/3.42InsightsSpeedImprovements.mp4" type="video/mp4" data-cookieconsent="ignore"/>
+    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/3.42/3.42InsightsSpeedImprovements.webm" type="video/webm" data-cookieconsent="ignore"/>
+  </video>
+</figure>
 
 Insights running over an explicit list of repos now behave like insights running over all repositories. 
 

--- a/content/blogposts/2022/release-3.42.md
+++ b/content/blogposts/2022/release-3.42.md
@@ -61,9 +61,15 @@ We have a new search type available experimentally, called "Lucky search." It im
 
 ## Code Insights load faster and include more historical datapoints
 
-<video className="blog-image" title="Faster code insights" alt="An example of code insights loading faster" autoplay loop muted playsinline>
-  <source src="https://storage.googleapis.com/sourcegraph-assets/blog/3.42/3.42InsightsSpeedImprovements.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-</video>
+<Video
+  title="Faster code insights"
+  caption="An example of code insights loading faster"
+  source={{
+    mp4: "blog/3.42/3.42InsightsSpeedImprovements"
+    webm: "blog/3.42/3.42InsightsSpeedImprovements"
+  }}
+  loop={true}
+/>
 
 Insights running over an explicit list of repos now behave like insights running over all repositories. 
 

--- a/src/components/Blog/ReleasePost.tsx
+++ b/src/components/Blog/ReleasePost.tsx
@@ -3,13 +3,13 @@ import { FunctionComponent } from 'react'
 import { MDXRemote } from 'next-mdx-remote'
 import Link from 'next/link'
 
-import { Alert, Figure, Video, YouTube } from '@components'
+import { Alert, Figure } from '@components'
 import { buttonStyle, buttonLocation } from '@data'
 import { PostComponentProps } from '@interfaces/posts'
 import { formatDate } from '@util'
 
 type ReleaseComponents = import('mdx/types').MDXComponents
-const components = { Alert, Figure, Video, YouTube }
+const components = { Alert, Figure }
 
 interface Props extends PostComponentProps {}
 

--- a/src/components/Blog/ReleasePost.tsx
+++ b/src/components/Blog/ReleasePost.tsx
@@ -3,13 +3,13 @@ import { FunctionComponent } from 'react'
 import { MDXRemote } from 'next-mdx-remote'
 import Link from 'next/link'
 
-import { Alert, Figure } from '@components'
+import { Alert, Figure, Video, YouTube } from '@components'
 import { buttonStyle, buttonLocation } from '@data'
 import { PostComponentProps } from '@interfaces/posts'
 import { formatDate } from '@util'
 
 type ReleaseComponents = import('mdx/types').MDXComponents
-const components = { Alert, Figure }
+const components = { Alert, Figure, Video, YouTube }
 
 interface Props extends PostComponentProps {}
 


### PR DESCRIPTION
Fixes a bug where the video wouldn't loop on our 3.42 release post due to `autoPlay playsInline` not being formatted with React camelCase syntax.

### Test
Ensure the video loops and autoplays as intended on the 3.42 release post
