### PR TITLE
Enable video / youtube components in release posts

### DIFF
--- a/content/blogposts/2022/release-3.42.md
+++ b/content/blogposts/2022/release-3.42.md
@@ -65,19 +65,15 @@ We have a new search type available experimentally, called "Lucky search." It im
 
 ## Code Insights load faster and include more historical datapoints
 
-<figure>
-  <video
-    className="w-100 h-auto shadow"
-    title="An example of code insights loading faster"
-    autoPlay
-    loop
-    muted
-    playsInline
-  >
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/3.42/3.42InsightsSpeedImprovements.mp4" type="video/mp4" data-cookieconsent="ignore"/>
-    <source src="https://storage.googleapis.com/sourcegraph-assets/blog/3.42/3.42InsightsSpeedImprovements.webm" type="video/webm" data-cookieconsent="ignore"/>
-  </video>
-</figure>
+<Video
+  title="Faster code insights"
+  caption="An example of code insights loading faster"
+  source={{
+    mp4: "blog/3.42/3.42InsightsSpeedImprovements",
+    webm: "blog/3.42/3.42InsightsSpeedImprovements"
+  }}
+  loop={true}
+/>
 
 Insights running over an explicit list of repos now behave like insights running over all repositories. 
 

--- a/src/components/Blog/ReleasePost.tsx
+++ b/src/components/Blog/ReleasePost.tsx
@@ -3,13 +3,13 @@ import { FunctionComponent } from 'react'
 import { MDXRemote } from 'next-mdx-remote'
 import Link from 'next/link'
 
-import { Alert, Figure } from '@components'
+import { Alert, Figure, Video, YouTube } from '@components'
 import { buttonStyle, buttonLocation } from '@data'
 import { PostComponentProps } from '@interfaces/posts'
 import { formatDate } from '@util'
 
 type ReleaseComponents = import('mdx/types').MDXComponents
-const components = { Alert, Figure }
+const components = { Alert, Figure, Video, YouTube }
 
 interface Props extends PostComponentProps {}
 


### PR DESCRIPTION
Closes #5599 and enables YouTube and Video components to be used in Release Posts.

### Changelog
- Adds YouTube and Video components in MDX parsing for Release Posts
- Updated the video on the 3.42 release post to use the new Video component/syntax

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure the video renders properly on `/blog/release/3.42`
