### PR TITLE
Rm unneeded figcaption padding

### DIFF
--- a/src/styles/components/blog/_BlogPost.scss
+++ b/src/styles/components/blog/_BlogPost.scss
@@ -25,7 +25,6 @@
         }
 
         figcaption {
-            margin: 1rem auto 3rem auto;
             font-style: italic;
         }
 


### PR DESCRIPTION
Small patch fix. After the blockquote standardization merged with the new Blog Template, I noticed extra Blog `figcaption` styling that adds too much padding beneath the element.

Removes that margin style.
<img width="409" alt="Screen Shot 2022-07-28 at 1 24 03 PM" src="https://user-images.githubusercontent.com/59381432/181621550-15907b37-7203-4f57-8907-d3d9a9959a0f.png">


### Test
1. Ensure prettier has standardized the proposed changes.
2. Confirm blockquote UI on Blog `/starter-pack`
