### PR TITLE
Blockquote/ Follow up cleanup

### DIFF
--- a/src/components/Blockquote.tsx
+++ b/src/components/Blockquote.tsx
@@ -1,5 +1,6 @@
 import { FunctionComponent, ReactFragment } from 'react'
 
+import classNames from 'classnames'
 import ArrowRightIcon from 'mdi-react/ArrowRightIcon'
 import Link from 'next/link'
 
@@ -50,22 +51,22 @@ export const Blockquote: FunctionComponent<{
     }
 
     return (
-        <blockquote className={getBorderStyle()}>
+        <blockquote className={classNames(getBorderStyle(), 'px-4')}>
             {headline ? (
                 largeText ? (
                     <h2 className="font-weight-bold">{headline}</h2>
                 ) : (
-                    <h4 className="font-weight-bold mb-4 px-4">{headline}</h4>
+                    <h4 className="font-weight-bold mb-4">{headline}</h4>
                 )
             ) : null}
 
             {largeText ? (
-                <h3 className="font-weight-normal text-3xl px-4">&ldquo;{quote}&rdquo;</h3>
+                <h3 className="font-weight-normal text-3xl">&ldquo;{quote}&rdquo;</h3>
             ) : (
-                <h5 className="font-weight-normal px-4">&ldquo;{quote}&rdquo;</h5>
+                <h5 className="font-weight-normal">&ldquo;{quote}&rdquo;</h5>
             )}
 
-            {author && <figcaption className="text-muted px-4 pt-3">&mdash; {author}</figcaption>}
+            {author && <figcaption className="text-muted pt-3">&mdash; {author}</figcaption>}
 
             {logo &&
                 (logo.href ? (
@@ -76,14 +77,13 @@ export const Blockquote: FunctionComponent<{
                         </a>
                     </Link>
                 ) : (
-                    <div className="d-flex justify-content-center pt-2">
-                        <img src={logo.src} width="110px" alt={logo.alt} />
-                    </div>
+                    <img src={logo.src} className="pt-2" width="110px" alt={logo.alt} />
                 ))}
 
             {link &&
                 (link?.href.includes('http') ? (
                     <a
+                        className={classNames('mt-3 d-flex', !border && 'justify-content-center')}
                         href={link.href}
                         target="_blank"
                         rel="nofollow noreferrer"
@@ -99,7 +99,7 @@ export const Blockquote: FunctionComponent<{
                     <Link href={link.href} passHref={true}>
                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                         <a
-                            className="d-flex justify-content-center mt-3"
+                            className={classNames('mt-3 d-flex', !border && 'justify-content-center')}
                             title={link.text}
                             data-button-style={buttonStyle.textWithArrow}
                             data-button-location={buttonLocation.body}

--- a/src/components/Blockquote.tsx
+++ b/src/components/Blockquote.tsx
@@ -72,12 +72,12 @@ export const Blockquote: FunctionComponent<{
                 (logo.href ? (
                     <Link href={logo.href} passHref={true}>
                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                        <a className="btn">
-                            <img src={logo.src} width="110px" alt={logo.alt} />
+                        <a>
+                            <img src={logo.src} className="pt-3" width="110px" alt={logo.alt} />
                         </a>
                     </Link>
                 ) : (
-                    <img src={logo.src} className="pt-2" width="110px" alt={logo.alt} />
+                    <img src={logo.src} className="pt-3" width="110px" alt={logo.alt} />
                 ))}
 
             {link &&

--- a/src/components/Blockquote.tsx
+++ b/src/components/Blockquote.tsx
@@ -27,7 +27,7 @@ export const Blockquote: FunctionComponent<{
     largeText?: boolean
     border?: boolean
     borderColor?: string
-    inline?: boolean
+    inline?: boolean // inline vs. col layout
 }> = ({ quote, author, logo, link, headline, largeText = false, border = true, borderColor, inline = true }) => {
     const windowWidth = useWindowWidth()
     const isMdOrDown = windowWidth < breakpoints.lg

--- a/src/components/Blockquote.tsx
+++ b/src/components/Blockquote.tsx
@@ -73,7 +73,7 @@ export const Blockquote: FunctionComponent<{
                     <Link href={logo.href} passHref={true}>
                         {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                         <a>
-                            <img src={logo.src} className="pt-3" width="110px" alt={logo.alt} />
+                            <img src={logo.src} className="mt-3" width="110px" alt={logo.alt} />
                         </a>
                     </Link>
                 ) : (

--- a/src/components/Blockquote.tsx
+++ b/src/components/Blockquote.tsx
@@ -77,7 +77,7 @@ export const Blockquote: FunctionComponent<{
                         </a>
                     </Link>
                 ) : (
-                    <img src={logo.src} className="pt-3" width="110px" alt={logo.alt} />
+                    <img src={logo.src} className="mt-3" width="110px" alt={logo.alt} />
                 ))}
 
             {link &&

--- a/src/components/Blockquote.tsx
+++ b/src/components/Blockquote.tsx
@@ -66,7 +66,7 @@ export const Blockquote: FunctionComponent<{
                 <h5 className="font-weight-normal">&ldquo;{quote}&rdquo;</h5>
             )}
 
-            {author && <figcaption className="text-muted pt-3">&mdash; {author}</figcaption>}
+            {author && <figcaption className="text-muted mt-3">&mdash; {author}</figcaption>}
 
             {logo &&
                 (logo.href ? (

--- a/src/styles/globals.scss
+++ b/src/styles/globals.scss
@@ -287,11 +287,6 @@ pre {
 code {
     font-family: 'Source Code Pro', monospace !important;
     background-color: $light-gray-4;
-    color: $curious-blue;
-    padding: 0.2em 0.4em;
-    margin: 0;
-    font-size: 85%;
-    border-radius: 3px;
 }
 
 /* ==================== Positioning ==================== */

--- a/src/styles/templates/_PostTemplate.scss
+++ b/src/styles/templates/_PostTemplate.scss
@@ -27,6 +27,16 @@
             margin-right: auto;
         }
 
+        code {
+            font-family: 'Source Code Pro', monospace !important;
+            background-color: $light-gray-4;
+            color: $curious-blue;
+            padding: 0.2em 0.4em;
+            margin: 0;
+            font-size: 85%;
+            border-radius: 3px;
+        }
+
         p {
             line-height: 1.8;
             margin-bottom: 1.25rem;


### PR DESCRIPTION
Closes #5625 

### Changelog

Moves inline code styling for blog > `.post-template` stylesheet to avoid global application.

Adjusts `Blockquote` to left align links & logos by default

BEFORE:
<img width="920" alt="image" src="https://user-images.githubusercontent.com/59381432/181631938-5a89d312-3d8e-4d38-96f1-ea1a268d7d62.png">
<img width="519" alt="image" src="https://user-images.githubusercontent.com/59381432/181639206-b62eb4a9-6ee6-4859-a443-8da3aac3488a.png">

NOW:
<img width="917" alt="image" src="https://user-images.githubusercontent.com/59381432/181632004-6a8a16dc-ef28-485d-8288-f83d60e83294.png">
<img width="468" alt="image" src="https://user-images.githubusercontent.com/59381432/181639253-9cb27360-8c7d-40a0-88be-fe83a0ab9ad8.png">


### Test

1. Ensure prettier has standardized the proposed changes.
2. Test Blockquote variations with logos and links (`/batch-changes`, `/accelerate-dev-onboarding`, `/use-cases`)
