### PR TITLE
Hotfix/ Long form content width & CtaSection text color

### DIFF
--- a/src/components/Background/index.tsx
+++ b/src/components/Background/index.tsx
@@ -178,8 +178,7 @@ export const Background: FunctionComponent<Background> = ({ variant, children, i
 
     const styleClasses = classNames(className, {
         [utilityBackground]: isUtilityBackground,
-        'tw-text-white':
-            (variant.includes('dark') || variant.includes('starship') || variant.includes('black')),
+        'tw-text-white': variant.includes('dark') || variant.includes('starship') || variant.includes('black'),
         'tw-text-black':
             (!variant.includes('dark') && !variant.includes('starship') && !variant.includes('black')) ||
             variant === 'transparent',

--- a/src/components/Background/index.tsx
+++ b/src/components/Background/index.tsx
@@ -179,10 +179,9 @@ export const Background: FunctionComponent<Background> = ({ variant, children, i
     const styleClasses = classNames(className, {
         [utilityBackground]: isUtilityBackground,
         'tw-text-white':
-            !isUtilityBackground &&
             (variant.includes('dark') || variant.includes('starship') || variant.includes('black')),
         'tw-text-black':
-            (!isUtilityBackground && !variant.includes('dark') && !variant.includes('starship')) ||
+            (!variant.includes('dark') && !variant.includes('starship') && !variant.includes('black')) ||
             variant === 'transparent',
     })
 

--- a/src/components/CaseStudies/CaseStudyLayout.tsx
+++ b/src/components/CaseStudies/CaseStudyLayout.tsx
@@ -104,7 +104,7 @@ export const CaseStudyLayout: FunctionComponent<Props> = ({
             </CaseStudyJumbotron>
 
             <ContentSection background="white">
-                <h1 className={`${titleClassName}`}>{title}</h1>
+                <h1 className={`tw-max-w-4xl tw-mx-auto ${titleClassName}`}>{title}</h1>
             </ContentSection>
 
             {children}

--- a/src/components/CaseStudies/CaseStudyLayout.tsx
+++ b/src/components/CaseStudies/CaseStudyLayout.tsx
@@ -103,8 +103,8 @@ export const CaseStudyLayout: FunctionComponent<Props> = ({
                 )}
             </CaseStudyJumbotron>
 
-            <ContentSection background="white">
-                <h1 className={`tw-max-w-4xl tw-mx-auto ${titleClassName}`}>{title}</h1>
+            <ContentSection background="white" slimWidth={true}>
+                <h1 className={titleClassName}>{title}</h1>
             </ContentSection>
 
             {children}

--- a/src/components/ContentSection.tsx
+++ b/src/components/ContentSection.tsx
@@ -8,6 +8,7 @@ export interface ContentSection {
     id?: string
     background?: Background['variant']
     illustration?: Background['illustration']
+    slimWidth?: boolean // For long form content (Blog, Case studies, etc)
     parentClassName?: string
     className?: string
     children: ReactNode
@@ -17,6 +18,7 @@ export const ContentSection: FunctionComponent<ContentSection> = ({
     id,
     background = 'transparent',
     illustration,
+    slimWidth = false,
     parentClassName,
     className = '',
     children,
@@ -27,7 +29,7 @@ export const ContentSection: FunctionComponent<ContentSection> = ({
             illustration={illustration}
             className={classNames('tw-px-sm tw-py-3xl md:tw-py-5xl', parentClassName)}
         >
-            <section className={`tw-max-w-screen-xl tw-mx-auto ${className}`}>{children}</section>
+            <section className={`tw-mx-auto ${slimWidth ? 'tw-max-w-[840px]' : 'tw-max-w-screen-xl'} ${className}`}>{children}</section>
         </Background>
     </div>
 )

--- a/src/components/ContentSection.tsx
+++ b/src/components/ContentSection.tsx
@@ -29,7 +29,7 @@ export const ContentSection: FunctionComponent<ContentSection> = ({
             illustration={illustration}
             className={classNames('tw-px-sm tw-py-3xl md:tw-py-5xl', parentClassName)}
         >
-            <section className={`tw-mx-auto ${slimWidth ? 'tw-max-w-[840px]' : 'tw-max-w-screen-xl'} ${className}`}>{children}</section>
+            <section className={classNames('tw-mx-auto', className, slimWidth ? 'tw-max-w-[840px]' : 'tw-max-w-screen-xl')}>{children}</section>
         </Background>
     </div>
 )

--- a/src/components/CtaSection.tsx
+++ b/src/components/CtaSection.tsx
@@ -122,12 +122,12 @@ export const CtaSection: FunctionComponent<CtaSection> = ({
     cta1,
     cta2,
 }) => (
-    <ContentSection background={background}>
+    <ContentSection background={background} slimWidth={slimWidth}>
         <div
             className={classNames({
                 'tw-max-w-xl tw-mx-auto tw-text-center': centerContent,
                 'tw-grid tw-grid-cols-5': !centerContent && !slimWidth,
-                'tw-max-w-4xl tw-mx-auto tw-grid tw-grid-cols-2 tw-items-center': slimWidth,
+                'tw-mx-auto tw-grid tw-grid-cols-2 tw-items-center': slimWidth,
             })}
         >
             <div

--- a/src/components/CtaSection.tsx
+++ b/src/components/CtaSection.tsx
@@ -127,7 +127,7 @@ export const CtaSection: FunctionComponent<CtaSection> = ({
             className={classNames({
                 'tw-max-w-xl tw-mx-auto tw-text-center': centerContent,
                 'tw-grid tw-grid-cols-5': !centerContent && !slimWidth,
-                'tw-max-w-[846px] tw-mx-auto tw-grid tw-grid-cols-2 tw-items-center': slimWidth,
+                'tw-max-w-4xl tw-mx-auto tw-grid tw-grid-cols-2 tw-items-center': slimWidth,
             })}
         >
             <div

--- a/src/pages/blog/[...slug].tsx
+++ b/src/pages/blog/[...slug].tsx
@@ -47,7 +47,7 @@ const BlogPage: NextPage<PageProps> = ({ post, content }) => {
                             post={post}
                             content={content}
                             url={urlToPost(post)}
-                            className="tw-mx-auto post-template__post blog-post tw-max-w-4xl"
+                            className="tw-mx-auto post-template__post blog-post tw-max-w-[840px]"
                             headerClassName="card-header bg-white border-bottom-0 tw-text-center tw-pt-md"
                         />
                     </div>

--- a/src/pages/blog/[...slug].tsx
+++ b/src/pages/blog/[...slug].tsx
@@ -47,7 +47,7 @@ const BlogPage: NextPage<PageProps> = ({ post, content }) => {
                             post={post}
                             content={content}
                             url={urlToPost(post)}
-                            className="tw-mx-auto post-template__post blog-post tw-max-w-[846px]"
+                            className="tw-mx-auto post-template__post blog-post tw-max-w-4xl"
                             headerClassName="card-header bg-white border-bottom-0 tw-text-center tw-pt-md"
                         />
                     </div>

--- a/src/pages/case-studies/cern-reduces-technical-debt.tsx
+++ b/src/pages/case-studies/cern-reduces-technical-debt.tsx
@@ -21,83 +21,81 @@ export const CaseStudy: FunctionComponent = () => (
                 author: 'Vito Baggiolini, Senior Software Engineer, CERN',
             }}
         >
-            <ContentSection background="white" className="col-md-6 tw-pb-md">
-                <div className="container tw-max-w-4xl">
-                    <p>
-                        Physicists at CERN use some of the world's most powerful particle accelerators to discover what
-                        the universe is made of and how it works. Over the last 18 years, the organization's Java
-                        codebase for accelerator controls has grown to roughly 15 million lines of code. CERN operates
-                        within a self-contained software system that is developed and maintained by nearly 300 people,
-                        with all of its code in Sourcegraph. To achieve efficient development and safe upgrades,
-                        developers require a tool that lets them quickly and effectively search through their entire
-                        codebase so they can easily change and reuse code where necessary.{' '}
-                    </p>
-                    <div className="row md:tw-justify-center tw-pt-xs">
-                        <div className="col-md-8">
-                            <Figure
-                                src="/case-studies/cern-image-lhc-cc.jpg"
-                                alt="Large Hadron Collider, image by CERN"
-                                caption="Large Hadron Collider, image by CERN"
-                            />
-                        </div>
+            <ContentSection background="white" slimWidth={true} className="tw-col-md-6 tw-pb-md">
+                <p>
+                    Physicists at CERN use some of the world's most powerful particle accelerators to discover what
+                    the universe is made of and how it works. Over the last 18 years, the organization's Java
+                    codebase for accelerator controls has grown to roughly 15 million lines of code. CERN operates
+                    within a self-contained software system that is developed and maintained by nearly 300 people,
+                    with all of its code in Sourcegraph. To achieve efficient development and safe upgrades,
+                    developers require a tool that lets them quickly and effectively search through their entire
+                    codebase so they can easily change and reuse code where necessary.{' '}
+                </p>
+                <div className="row md:tw-justify-center tw-pt-xs">
+                    <div className="col-md-8">
+                        <Figure
+                            src="/case-studies/cern-image-lhc-cc.jpg"
+                            alt="Large Hadron Collider, image by CERN"
+                            caption="Large Hadron Collider, image by CERN"
+                        />
                     </div>
-                    <h2 className="tw-pt-md tw-pb-1">Avoiding reinventing the wheel with universal code search</h2>
-                    <p>
-                        Sourcegraph empowers developers at CERN to reuse code that already exists, avoiding duplication
-                        and saving developers countless hours redoing work that has already been done. It takes search
-                        one step further by &quot;understanding&quot; the structure of the code (as opposed to just
-                        &quot;seeing&quot; it as raw text), enabling the organization to do semantic searches that yield
-                        accurate results.
-                    </p>
-                    <Blockquote
-                        quote="I was recently tasked with something that I, admittedly, had no idea how to do, but I was sure that someone at CERN must've already done it at some point. Sourcegraph universal code search took me directly to the code I was looking for so I could repurpose it. It's also an invaluable tool for enabling our developers to learn from one another."
-                        author="Vito Baggiolini"
-                    />
-                    <div className="row tw-pt-xs">
-                        <div className="col-md-3 tw-pt-md">
-                            <img
-                                src="/case-studies/chris-roderick-cern.jpg"
-                                alt="Chris Roderick, Applications and Services Section Leader, CERN"
-                                title="Chris Roderick, Applications and Services Section Leader, CERN"
-                                className="w-100 tw-rounded-full img-fluid tw-mx-auto tw-block mb-3"
-                            />
-                        </div>
-                        <div className="col-md-9">
-                            <Blockquote
-                                quote="Sourcegraph helps us with technical debt reduction and the consolidation of our codebase by letting us avoid duplication, spot the usage of deprecated APIs or internal (non-API) library code, and identify general purpose code in specific projects (such as utility classes) that can be factored out and shared in a core library."
-                                author="Chris Roderick, Applications and Services Section Leader, CERN"
-                            />
-                        </div>
-                    </div>
-                    <h2 className="tw-pt-md tw-pb-1">Tackling mission-critical code changes with ease</h2>
-                    <Blockquote
-                        quote="Sourcegraph lets us make informed decisions on how to evolve our codebase. For example, a library owner knows exactly how all other developers use their API, and can therefore make educated decisions on how to evolve it."
-                        author="Chris Roderick"
-                    />
-                    <p>
-                        The Large Hadron Collider (LHC) at CERN features five-year operational periods and the software
-                        must be stable during this time. Sourcegraph helps developers make small, backward-compatible
-                        changes and ensures that any change made by a given team to one part of the codebase doesn't
-                        break (or require adaptations of) dependent code written by other people. It's essential that
-                        these changes are done correctly, as mistakes can stop the operation of the CERN accelerators
-                        and waste precious time for physics research.
-                    </p>
-                    <p>
-                        The LHC also features upgrade periods of 1-2 years, during which developers typically make more
-                        radical changes. During these periods, Sourcegraph lets users identify redundant code (e.g.,
-                        utility methods) and assess the cost/benefit of doing breaking API changes.
-                    </p>
-                    <Blockquote
-                        quote="Our solution prior to Sourcegraph didn't let us do detailed and precise searches on how and where a method of a specific class is used. As a result, we were unable to measure the impact that a planned API change would have on the rest of our huge codebase. This put us in a position where we weren't making necessary changes because we were unsure of the effect they would have."
-                        author="Vito Baggiolini"
-                    />
-                    <p>
-                        Universal code search lets developers at CERN make changes to their code, including those with
-                        potentially costly implications if done incorrectly, with ease and confidence. As the
-                        organization continues to uncover fascinating insights into how our universe works, Sourcegraph
-                        serves as its go-to tool for code reuse and code change management.{' '}
-                    </p>
                 </div>
+                <h2 className="tw-pt-md tw-pb-1">Avoiding reinventing the wheel with universal code search</h2>
+                <p>
+                    Sourcegraph empowers developers at CERN to reuse code that already exists, avoiding duplication
+                    and saving developers countless hours redoing work that has already been done. It takes search
+                    one step further by &quot;understanding&quot; the structure of the code (as opposed to just
+                    &quot;seeing&quot; it as raw text), enabling the organization to do semantic searches that yield
+                    accurate results.
+                </p>
+                <Blockquote
+                    quote="I was recently tasked with something that I, admittedly, had no idea how to do, but I was sure that someone at CERN must've already done it at some point. Sourcegraph universal code search took me directly to the code I was looking for so I could repurpose it. It's also an invaluable tool for enabling our developers to learn from one another."
+                    author="Vito Baggiolini"
+                />
+                <div className="row tw-pt-xs">
+                    <div className="col-md-3 tw-pt-md">
+                        <img
+                            src="/case-studies/chris-roderick-cern.jpg"
+                            alt="Chris Roderick, Applications and Services Section Leader, CERN"
+                            title="Chris Roderick, Applications and Services Section Leader, CERN"
+                            className="w-100 tw-rounded-full img-fluid tw-mx-auto tw-block mb-3"
+                        />
+                    </div>
+                    <div className="col-md-9">
+                        <Blockquote
+                            quote="Sourcegraph helps us with technical debt reduction and the consolidation of our codebase by letting us avoid duplication, spot the usage of deprecated APIs or internal (non-API) library code, and identify general purpose code in specific projects (such as utility classes) that can be factored out and shared in a core library."
+                            author="Chris Roderick, Applications and Services Section Leader, CERN"
+                        />
+                    </div>
+                </div>
+                <h2 className="tw-pt-md tw-pb-1">Tackling mission-critical code changes with ease</h2>
+                <Blockquote
+                    quote="Sourcegraph lets us make informed decisions on how to evolve our codebase. For example, a library owner knows exactly how all other developers use their API, and can therefore make educated decisions on how to evolve it."
+                    author="Chris Roderick"
+                />
+                <p>
+                    The Large Hadron Collider (LHC) at CERN features five-year operational periods and the software
+                    must be stable during this time. Sourcegraph helps developers make small, backward-compatible
+                    changes and ensures that any change made by a given team to one part of the codebase doesn't
+                    break (or require adaptations of) dependent code written by other people. It's essential that
+                    these changes are done correctly, as mistakes can stop the operation of the CERN accelerators
+                    and waste precious time for physics research.
+                </p>
+                <p>
+                    The LHC also features upgrade periods of 1-2 years, during which developers typically make more
+                    radical changes. During these periods, Sourcegraph lets users identify redundant code (e.g.,
+                    utility methods) and assess the cost/benefit of doing breaking API changes.
+                </p>
+                <Blockquote
+                    quote="Our solution prior to Sourcegraph didn't let us do detailed and precise searches on how and where a method of a specific class is used. As a result, we were unable to measure the impact that a planned API change would have on the rest of our huge codebase. This put us in a position where we weren't making necessary changes because we were unsure of the effect they would have."
+                    author="Vito Baggiolini"
+                />
+                <p>
+                    Universal code search lets developers at CERN make changes to their code, including those with
+                    potentially costly implications if done incorrectly, with ease and confidence. As the
+                    organization continues to uncover fascinating insights into how our universe works, Sourcegraph
+                    serves as its go-to tool for code reuse and code change management.{' '}
+                </p>
             </ContentSection>
         </CaseStudyLayout>
     </Layout>

--- a/src/pages/case-studies/cern-reduces-technical-debt.tsx
+++ b/src/pages/case-studies/cern-reduces-technical-debt.tsx
@@ -22,7 +22,7 @@ export const CaseStudy: FunctionComponent = () => (
             }}
         >
             <ContentSection background="white" className="col-md-6 tw-pb-md">
-                <div className="container">
+                <div className="container tw-max-w-4xl">
                     <p>
                         Physicists at CERN use some of the world's most powerful particle accelerators to discover what
                         the universe is made of and how it works. Over the last 18 years, the organization's Java

--- a/src/pages/case-studies/cloudflare-accelerates-debugging-and-improves-security.tsx
+++ b/src/pages/case-studies/cloudflare-accelerates-debugging-and-improves-security.tsx
@@ -23,122 +23,120 @@ export const CaseStudy: FunctionComponent = () => {
                     image: '/case-studies/terin-stock-cloudflare.jpg',
                 }}
             >
-                <ContentSection background="white">
-                    <div className="container tw-max-w-4xl">
-                        <p>
-                            A web performance and security company, Cloudflare offers CDN, DNS, DDoS protection, and
-                            security products and services to millions of customers worldwide. The company has
-                            approximately 2,000 employees, a quarter of which are engineers.
-                        </p>
+                <ContentSection background="white" slimWidth={true}>
+                    <p>
+                        A web performance and security company, Cloudflare offers CDN, DNS, DDoS protection, and
+                        security products and services to millions of customers worldwide. The company has
+                        approximately 2,000 employees, a quarter of which are engineers.
+                    </p>
 
-                        <h2 className="tw-pt-md tw-pb-1">Looking for a new code search tool</h2>
+                    <h2 className="tw-pt-md tw-pb-1">Looking for a new code search tool</h2>
 
-                        <p>
-                            Cloudflare's engineering team builds and runs the software that powers and protects
-                            approximately 25 million Internet properties around the world. When performance and security
-                            issues arise, it's critical that Cloudflare engineers can find and fix code quickly.
-                        </p>
+                    <p>
+                        Cloudflare's engineering team builds and runs the software that powers and protects
+                        approximately 25 million Internet properties around the world. When performance and security
+                        issues arise, it's critical that Cloudflare engineers can find and fix code quickly.
+                    </p>
 
-                        <p>
-                            But using their code host's native code search functionality wasn't cutting it. For example,
-                            it would take ASCII characters and run them through ElasticSearch. Special characters,
-                            including spaces, were completely ignored and there was no way to filter results based on
-                            file types, folder names, or code logic.
-                        </p>
-                        <Blockquote
-                            quote="We were trying to answer questions like who was using specific dependencies and different libraries and where are 
-                            these lines of code or log lines coming from. We needed to be able to search thousands of repos to find them."
-                            author={terinStock}
-                        />
+                    <p>
+                        But using their code host's native code search functionality wasn't cutting it. For example,
+                        it would take ASCII characters and run them through ElasticSearch. Special characters,
+                        including spaces, were completely ignored and there was no way to filter results based on
+                        file types, folder names, or code logic.
+                    </p>
+                    <Blockquote
+                        quote="We were trying to answer questions like who was using specific dependencies and different libraries and where are 
+                        these lines of code or log lines coming from. We needed to be able to search thousands of repos to find them."
+                        author={terinStock}
+                    />
 
-                        <p>
-                            For a while, the team worked around this by cloning all the repos onto their machines and
-                            using their local system's search functionality. But with over 2,600 repositories, the
-                            process proved slow and unwieldy.
-                        </p>
+                    <p>
+                        For a while, the team worked around this by cloning all the repos onto their machines and
+                        using their local system's search functionality. But with over 2,600 repositories, the
+                        process proved slow and unwieldy.
+                    </p>
 
-                        <p>
-                            “It would take two days just to copy the repos onto a laptop, so I could search them,” said
-                            Stock. Meanwhile, if the code base was updated during the time it took to copy the repos,
-                            then the engineer wouldn't be searching the latest codebase. Further, once team members
-                            cloned the repos, they wouldn't have space left on their machine for other work.
-                        </p>
+                    <p>
+                        “It would take two days just to copy the repos onto a laptop, so I could search them,” said
+                        Stock. Meanwhile, if the code base was updated during the time it took to copy the repos,
+                        then the engineer wouldn't be searching the latest codebase. Further, once team members
+                        cloned the repos, they wouldn't have space left on their machine for other work.
+                    </p>
 
-                        <h2 className="tw-pt-md tw-pb-1">Finding Sourcegraph</h2>
+                    <h2 className="tw-pt-md tw-pb-1">Finding Sourcegraph</h2>
 
-                        <p>
-                            Stock, who was then on the Dev Tools team, and has since moved to Service Automation, knew
-                            there had to be a better solution. He discovered the open source version of Sourcegraph, a
-                            universal code search and intelligence tool for developers.
-                        </p>
+                    <p>
+                        Stock, who was then on the Dev Tools team, and has since moved to Service Automation, knew
+                        there had to be a better solution. He discovered the open source version of Sourcegraph, a
+                        universal code search and intelligence tool for developers.
+                    </p>
 
-                        <p>
-                            Sourcegraph integrates with all code repos, programming languages, and file formats. It also
-                            provides advanced code navigation features that let developers explore source code on any
-                            branch, commit, or PR.
-                        </p>
+                    <p>
+                        Sourcegraph integrates with all code repos, programming languages, and file formats. It also
+                        provides advanced code navigation features that let developers explore source code on any
+                        branch, commit, or PR.
+                    </p>
 
-                        <p>
-                            "Sourcegraph is the only code search tool that natively integrates with our code and
-                            understands how our code works," said Stock.
-                        </p>
+                    <p>
+                        "Sourcegraph is the only code search tool that natively integrates with our code and
+                        understands how our code works," said Stock.
+                    </p>
 
-                        <h3 className="tw-pt-md tw-pb-1">Expanding throughout the team</h3>
+                    <h3 className="tw-pt-md tw-pb-1">Expanding throughout the team</h3>
 
-                        <p>
-                            Once Stock downloaded and began using the open source version of Sourcegraph, he started
-                            sharing search result URLs with engineers. Soon, Sourcegraph spread organically throughout
-                            the organization and the internal DevOps team decided to deploy Sourcegraph for all
-                            Cloudflare engineers.
-                        </p>
+                    <p>
+                        Once Stock downloaded and began using the open source version of Sourcegraph, he started
+                        sharing search result URLs with engineers. Soon, Sourcegraph spread organically throughout
+                        the organization and the internal DevOps team decided to deploy Sourcegraph for all
+                        Cloudflare engineers.
+                    </p>
 
-                        <p>
-                            Now, with Sourcegraph universal code search, Cloudflare engineers can solve the big code
-                            problems they face every day. For example, engineers can quickly identify out-of-date code
-                            libraries by only searching certain repositories, while excluding specific file types. And
-                            it's easier to search for error logs. As a result, the team can refactor and debug faster
-                            and feel confident they've addressed each issue.
-                        </p>
+                    <p>
+                        Now, with Sourcegraph universal code search, Cloudflare engineers can solve the big code
+                        problems they face every day. For example, engineers can quickly identify out-of-date code
+                        libraries by only searching certain repositories, while excluding specific file types. And
+                        it's easier to search for error logs. As a result, the team can refactor and debug faster
+                        and feel confident they've addressed each issue.
+                    </p>
 
-                        <h3 className="tw-pt-md tw-pb-1">Finding and addressing security risks</h3>
+                    <h3 className="tw-pt-md tw-pb-1">Finding and addressing security risks</h3>
 
-                        <p>
-                            Sourcegraph has also become essential to how the Cloudflare security team can quickly
-                            address security risks and root-cause incidents.
-                        </p>
+                    <p>
+                        Sourcegraph has also become essential to how the Cloudflare security team can quickly
+                        address security risks and root-cause incidents.
+                    </p>
 
-                        <Blockquote
-                            quote="When a potential security issue comes up, I often have to go into another engineer's project to quickly 
-                                    understand how the code works to understand the critical functions, where the data is flowing, what sort
-                                    of controls or checks are happening. With Sourcegraph, I can jump into another engineer's project and 
-                                    quickly explore and better understand the code faster."
-                            author="David Haynes, Security Engineer"
-                        />
+                    <Blockquote
+                        quote="When a potential security issue comes up, I often have to go into another engineer's project to quickly 
+                                understand how the code works to understand the critical functions, where the data is flowing, what sort
+                                of controls or checks are happening. With Sourcegraph, I can jump into another engineer's project and 
+                                quickly explore and better understand the code faster."
+                        author="David Haynes, Security Engineer"
+                    />
 
-                        <p>
-                            Another plus, according to Haynes, “it's the best way to prove we're not vulnerable to a
-                            particular CVE, if and when we get asked by an auditor.”
-                        </p>
+                    <p>
+                        Another plus, according to Haynes, “it's the best way to prove we're not vulnerable to a
+                        particular CVE, if and when we get asked by an auditor.”
+                    </p>
 
-                        <h3 className="tw-pt-md tw-pb-1">Saving time, from days to minutes</h3>
+                    <h3 className="tw-pt-md tw-pb-1">Saving time, from days to minutes</h3>
 
-                        <p>
-                            Whether searching for instances of a library or refactoring an entire application, it's hard
-                            to put exact numbers on how much time the organization saves as a result of using
-                            Sourcegraph, because it's a 'death by a thousand paper cuts' scenario.
-                        </p>
+                    <p>
+                        Whether searching for instances of a library or refactoring an entire application, it's hard
+                        to put exact numbers on how much time the organization saves as a result of using
+                        Sourcegraph, because it's a 'death by a thousand paper cuts' scenario.
+                    </p>
 
-                        <p>
-                            Each time an engineer uses the tool to search and understand code, instead of cloning the
-                            repo, he or she saves time and feels more confident in the results. When you have 500
-                            engineers searching code repos, multiple times a day, throughout each day, that's a huge
-                            time savings.
-                        </p>
+                    <p>
+                        Each time an engineer uses the tool to search and understand code, instead of cloning the
+                        repo, he or she saves time and feels more confident in the results. When you have 500
+                        engineers searching code repos, multiple times a day, throughout each day, that's a huge
+                        time savings.
+                    </p>
 
-                        <p>In the end, it all adds up to increased developer productivity -- and better code.</p>
+                    <p>In the end, it all adds up to increased developer productivity -- and better code.</p>
 
-                        <br />
-                    </div>
+                    <br />
                 </ContentSection>
             </CaseStudyLayout>
         </Layout>

--- a/src/pages/case-studies/cloudflare-accelerates-debugging-and-improves-security.tsx
+++ b/src/pages/case-studies/cloudflare-accelerates-debugging-and-improves-security.tsx
@@ -24,7 +24,7 @@ export const CaseStudy: FunctionComponent = () => {
                 }}
             >
                 <ContentSection background="white">
-                    <div className="container">
+                    <div className="container tw-max-w-4xl">
                         <p>
                             A web performance and security company, Cloudflare offers CDN, DNS, DDoS protection, and
                             security products and services to millions of customers worldwide. The company has

--- a/src/pages/case-studies/codecov-uses-sourcegraph-to-resolve-incidents-faster.tsx
+++ b/src/pages/case-studies/codecov-uses-sourcegraph-to-resolve-incidents-faster.tsx
@@ -49,8 +49,8 @@ export const CaseStudy: FunctionComponent = () => (
         }
     >
         <NewCaseStudyLayout customer="Codecov">
-            <ContentSection background="white">
-                <div className="tw-max-w-4xl tw-mx-auto">
+            <ContentSection background="white" slimWidth={true}>
+                <div className="tw-mx-auto">
                     <Blockquote
                         quote="Sourcegraph allows us to be more efficient with our time, whether it's code review, answering security-related questions from clients, or searching for things in the code much more easily than we could through our code host's native search functionality."
                         author="Jeff Holland, Lead Security Engineer at Codecov"
@@ -105,8 +105,8 @@ export const CaseStudy: FunctionComponent = () => (
                 />
             </ContentSection>
 
-            <ContentSection background="white">
-                <div className="tw-max-w-4xl tw-mx-auto tw-pt-5xl">
+            <ContentSection background="white" slimWidth={true}>
+                <div className="tw-mx-auto tw-pt-5xl">
                     <p className="tw-pt-3xl sm:tw-mt-0 tw-mt-5xl">
                         In 2021, security engineers Mitchell Borrego and Jeff Holland joined Codecov with the goal of
                         creating a cutting-edge security program. Their responsibilities include security tooling,
@@ -235,8 +235,8 @@ export const CaseStudy: FunctionComponent = () => (
                 <ThreeUpText items={threeUpTextItems} />
             </ContentSection>
 
-            <ContentSection background="white">
-                <div className="tw-max-w-4xl tw-mx-auto">
+            <ContentSection background="white" slimWidth={true}>
+                <div className="tw-mx-auto">
                     <h3 className="mb-4 max-w-650">Sourcegraph Cloud was the right fit for a growing team</h3>
                     <p>
                         Codecov wanted something they could get up and running quickly, so they turned to Sourcegraph

--- a/src/pages/case-studies/codecov-uses-sourcegraph-to-resolve-incidents-faster.tsx
+++ b/src/pages/case-studies/codecov-uses-sourcegraph-to-resolve-incidents-faster.tsx
@@ -106,7 +106,7 @@ export const CaseStudy: FunctionComponent = () => (
             </ContentSection>
 
             <ContentSection background="white">
-                <div className="tw-max-w-2xl tw-mx-auto tw-pt-5xl">
+                <div className="tw-max-w-4xl tw-mx-auto tw-pt-5xl">
                     <p className="tw-pt-3xl sm:tw-mt-0 tw-mt-5xl">
                         In 2021, security engineers Mitchell Borrego and Jeff Holland joined Codecov with the goal of
                         creating a cutting-edge security program. Their responsibilities include security tooling,
@@ -236,7 +236,7 @@ export const CaseStudy: FunctionComponent = () => (
             </ContentSection>
 
             <ContentSection background="white">
-                <div className="tw-max-w-2xl tw-mx-auto">
+                <div className="tw-max-w-4xl tw-mx-auto">
                     <h3 className="mb-4 max-w-650">Sourcegraph Cloud was the right fit for a growing team</h3>
                     <p>
                         Codecov wanted something they could get up and running quickly, so they turned to Sourcegraph

--- a/src/pages/case-studies/convoy-improved-on-boarding.tsx
+++ b/src/pages/case-studies/convoy-improved-on-boarding.tsx
@@ -22,59 +22,57 @@ export const CaseStudy: FunctionComponent = () => (
                 image: '/case-studies/brandon-bloom-convoy.jpg',
             }}
         >
-            <ContentSection background="white">
-                <div className="container tw-max-w-4xl">
-                    <p>
-                        Founded in 2015, Convoy has quickly grown to over 500 employees. However, their accelerated team
-                        growth comes with challenges: new hires have to quickly learn how to contribute to a dynamic
-                        system of microservices.
-                    </p>
-                    <h2 className="tw-pt-md tw-pb-1">Onboarding new hires</h2>
-                    <p>
-                        For Brandon Bloom, a new hire who was eager to start contributing, using GitHub's native search
-                        across Convoy's voluminous repositories rarely gave him the results he needed. His frustration
-                        led him to Sourcegraph. As an{' '}
-                        <a
-                            href="https://about.sourcegraph.com/blog/from-saas-to-on-premises"
-                            title="on-prem and self-hosted product"
-                            data-button-style={buttonStyle.text}
-                            data-button-location={buttonLocation.body}
-                            data-button-type="cta"
-                        >
-                            on-prem and self-hosted product
-                        </a>
-                        , he could safely and independently set up a Sourcegraph instance locally, and was able to get
-                        everything up and running within a matter of minutes. Suddenly, searching across hundreds of
-                        repositories returned exact results and code affected by any changes became fully traceable
-                    </p>
-                    <p>
-                        It didn't take long for other engineers in his team to realize the immense benefits Sourcegraph
-                        provided when it came to understanding Convoy's growing code base.
-                    </p>
-                    <Blockquote
-                        quote="It's helped me out a lot. Made going through other people's code much easier and was better for learning different patterns used in other repos."
-                        author="Aamir Jawaid, Software Engineer, Convoy"
-                    />
-                    <Blockquote
-                        quote="For our new developers, Sourcegraph has been invaluable to get to know the repository structure, to track down where code lives, and self-service during their investigations."
-                        author="Owen Kim, Senior Software Engineer, Convoy"
-                    />
-                    <p>
-                        The usage grew organically and so did the speed in which they were able to ship solutions for
-                        complex logistical problems.
-                    </p>
+            <ContentSection background="white" slimWidth={true}>
+                <p>
+                    Founded in 2015, Convoy has quickly grown to over 500 employees. However, their accelerated team
+                    growth comes with challenges: new hires have to quickly learn how to contribute to a dynamic
+                    system of microservices.
+                </p>
+                <h2 className="tw-pt-md tw-pb-1">Onboarding new hires</h2>
+                <p>
+                    For Brandon Bloom, a new hire who was eager to start contributing, using GitHub's native search
+                    across Convoy's voluminous repositories rarely gave him the results he needed. His frustration
+                    led him to Sourcegraph. As an{' '}
+                    <a
+                        href="https://about.sourcegraph.com/blog/from-saas-to-on-premises"
+                        title="on-prem and self-hosted product"
+                        data-button-style={buttonStyle.text}
+                        data-button-location={buttonLocation.body}
+                        data-button-type="cta"
+                    >
+                        on-prem and self-hosted product
+                    </a>
+                    , he could safely and independently set up a Sourcegraph instance locally, and was able to get
+                    everything up and running within a matter of minutes. Suddenly, searching across hundreds of
+                    repositories returned exact results and code affected by any changes became fully traceable
+                </p>
+                <p>
+                    It didn't take long for other engineers in his team to realize the immense benefits Sourcegraph
+                    provided when it came to understanding Convoy's growing code base.
+                </p>
+                <Blockquote
+                    quote="It's helped me out a lot. Made going through other people's code much easier and was better for learning different patterns used in other repos."
+                    author="Aamir Jawaid, Software Engineer, Convoy"
+                />
+                <Blockquote
+                    quote="For our new developers, Sourcegraph has been invaluable to get to know the repository structure, to track down where code lives, and self-service during their investigations."
+                    author="Owen Kim, Senior Software Engineer, Convoy"
+                />
+                <p>
+                    The usage grew organically and so did the speed in which they were able to ship solutions for
+                    complex logistical problems.
+                </p>
 
-                    <Blockquote
-                        quote="Fast, org-wide code search is a necessity in any organization, and tooling for this is especially necessary when we've chosen a multi-repo approach to code organization.
-                        The time I would otherwise spend using either GitHub's slow search or finding and cloning repos is worth a lot."
-                        author="James Reggio, Principal Engineer, Convoy"
-                    />
-                    <Blockquote
-                        quote="It's fast, which is super nice. It's faster than any other tool I've ever used for code search. I've become more productive with Sourcegraph."
-                        author="Ethan Hall, Senior Software Engineer, Convoy"
-                    />
-                    <br />
-                </div>
+                <Blockquote
+                    quote="Fast, org-wide code search is a necessity in any organization, and tooling for this is especially necessary when we've chosen a multi-repo approach to code organization.
+                    The time I would otherwise spend using either GitHub's slow search or finding and cloning repos is worth a lot."
+                    author="James Reggio, Principal Engineer, Convoy"
+                />
+                <Blockquote
+                    quote="It's fast, which is super nice. It's faster than any other tool I've ever used for code search. I've become more productive with Sourcegraph."
+                    author="Ethan Hall, Senior Software Engineer, Convoy"
+                />
+                <br />
             </ContentSection>
         </CaseStudyLayout>
     </Layout>

--- a/src/pages/case-studies/convoy-improved-on-boarding.tsx
+++ b/src/pages/case-studies/convoy-improved-on-boarding.tsx
@@ -23,7 +23,7 @@ export const CaseStudy: FunctionComponent = () => (
             }}
         >
             <ContentSection background="white">
-                <div className="container">
+                <div className="container tw-max-w-4xl">
                     <p>
                         Founded in 2015, Convoy has quickly grown to over 500 employees. However, their accelerated team
                         growth comes with challenges: new hires have to quickly learn how to contribute to a dynamic

--- a/src/pages/case-studies/criteo-tackles-big-code.tsx
+++ b/src/pages/case-studies/criteo-tackles-big-code.tsx
@@ -20,92 +20,90 @@ export const CaseStudy: FunctionComponent = () => (
                 author: 'François Jehl, Senior Engineering Manager, Criteo',
             }}
         >
-            <ContentSection background="white" className="col-md-6 tw-pb-md">
-                <div className="container tw-max-w-4xl">
-                    <p>
-                        Founded in France in 2005, Criteo partners with retailers to recommend products to potential
-                        customers through ad retargeting. The company has massive volumes of data stored in its
-                        on-premise servers, along with millions of lines of code that developers work on in both Paris
-                        and the U.S.
-                    </p>
-                    <p>
-                        Criteo has a heterogeneous ecosystem with thousands of repositories. When working on a single
-                        repository, developers use their IDE for code search. But for teams that are cross-functional or
-                        work in multiple repositories, this small-scale search strategy isn't sufficient and can be a
-                        major time sink.
-                    </p>
-                    <div className="row md:tw-justify-center tw-pt-xs">
-                        <div className="col-md-4">
-                            <figure>
-                                <img
-                                    src="/case-studies/francois-jehl-criteo.jpg"
-                                    alt="François Jehl, Senior Engineering Manager, Criteo"
-                                    title="François Jehl, Senior Engineering Manager, Criteo"
-                                    className="w-100 tw-rounded-full img-fluid tw-mx-auto tw-block mb-3"
-                                />
-                                <figcaption>François Jehl, Senior Engineering Manager, Criteo</figcaption>
-                            </figure>
-                        </div>
-                        <div className="col-md-4">
-                            <figure>
-                                <img
-                                    src="/case-studies/loic-teikiteetini-vaysse-criteo.jpg"
-                                    alt="Loic Teikiteetini-Vaysse, Software Development Engineer, Criteo"
-                                    title="Loic Teikiteetini-Vaysse, Software Development Engineer, Criteo"
-                                    className="w-100 tw-rounded-full img-fluid tw-mx-auto tw-block mb-3"
-                                />
-                                <figcaption>Loic Teikiteetini-Vaysse, Software Development Engineer, Criteo</figcaption>
-                            </figure>
-                        </div>
+            <ContentSection background="white" slimWidth={true} className="tw-col-md-6 tw-pb-md">
+                <p>
+                    Founded in France in 2005, Criteo partners with retailers to recommend products to potential
+                    customers through ad retargeting. The company has massive volumes of data stored in its
+                    on-premise servers, along with millions of lines of code that developers work on in both Paris
+                    and the U.S.
+                </p>
+                <p>
+                    Criteo has a heterogeneous ecosystem with thousands of repositories. When working on a single
+                    repository, developers use their IDE for code search. But for teams that are cross-functional or
+                    work in multiple repositories, this small-scale search strategy isn't sufficient and can be a
+                    major time sink.
+                </p>
+                <div className="row md:tw-justify-center tw-pt-xs">
+                    <div className="col-md-4">
+                        <figure>
+                            <img
+                                src="/case-studies/francois-jehl-criteo.jpg"
+                                alt="François Jehl, Senior Engineering Manager, Criteo"
+                                title="François Jehl, Senior Engineering Manager, Criteo"
+                                className="w-100 tw-rounded-full img-fluid tw-mx-auto tw-block mb-3"
+                            />
+                            <figcaption>François Jehl, Senior Engineering Manager, Criteo</figcaption>
+                        </figure>
                     </div>
-                    <Blockquote
-                        quote="Before Sourcegraph, we were struggling to search code in an accurate and timely manner. The legacy text-based search we relied on had security issues, and its performance was poor in terms of the quality of searches and response times."
-                        author="Loic Teikiteetini-Vaysse"
-                    />
-                    <Blockquote
-                        quote="When looking for alternatives, the general consensus was 'If you're a giant like Google, you can simply build your own code search engine. If that's not you, then buy Sourcegraph."
-                        author="François Jehl"
-                    />
-                    <h2 className="tw-pt-md tw-pb-1">Prioritize developer happiness and productivity follows</h2>
-                    <Blockquote
-                        quote="At Criteo, developer happiness is our top priority—not just productivity. We want to tackle the things that developers see as hurdles in their day-to-day life. By providing them with the right tools, like Sourcegraph, we've found that increased productivity is a natural byproduct."
-                        author="François Jehl"
-                    />
-                    <p>
-                        Sourcegraph serves as Criteo's one-stop shop for searching across all of its codebases, making
-                        its employees' lives that much easier. Criteo relies on many different ecosystems for different
-                        teams, and Sourcegraph now provides the ability to cross boundaries of different codebases and
-                        different languages authored by different people with different tools.
-                    </p>
-                    <p>
-                        Developers start with a query, then use the recommended filters to narrow their search until
-                        they locate the piece of code that is of interest. “Sometimes they don't even know what they're
-                        looking for—perhaps just patterns that need to be deprecated. With our previous tools, the
-                        results were not good,” said François Jehl.
-                    </p>
-                    <h2 className="tw-pt-md tw-pb-1">Survey says Sourcegraph is the ultimate time-saver</h2>
-                    <p>
-                        Criteo conducted an internal survey with Sourcegraph early adopters to determine how Sourcegraph
-                        has impacted its developers' workflows. The survey found that 83 percent of those developers
-                        used Sourcegraph every single day, and nearly two-thirds used it several times per day.
-                    </p>
-                    <p>
-                        55 percent of respondents said Sourcegraph saved them a few dozen minutes per day, while 18
-                        percent stated they saved over an hour per day.
-                    </p>
-                    <Blockquote
-                        quote="The feedback we received was overwhelmingly positive. We had employees saying 'I've dreamt of a tool like Sourcegraph!', 'Please buy it!', 'It saved my life!', 'It literally saved me hours per day!' We're thrilled that it's given us the ability to make our developers happier and more productive in their roles."
-                        author="François Jehl"
-                    />
-                    <p>
-                        As codebases grow larger, Sourcegraph will continue to serve as the backbone to help developers
-                        at Criteo quickly search through code to understand what's happening within its ecosystem.
-                    </p>
-                    <Blockquote
-                        quote="The quality of the Sourcegraph UI and its code intelligence are two game-changer features for us. It's like having an online IDE for browsing code."
-                        author="Loic Teikiteetini-Vaysse"
-                    />
+                    <div className="col-md-4">
+                        <figure>
+                            <img
+                                src="/case-studies/loic-teikiteetini-vaysse-criteo.jpg"
+                                alt="Loic Teikiteetini-Vaysse, Software Development Engineer, Criteo"
+                                title="Loic Teikiteetini-Vaysse, Software Development Engineer, Criteo"
+                                className="w-100 tw-rounded-full img-fluid tw-mx-auto tw-block mb-3"
+                            />
+                            <figcaption>Loic Teikiteetini-Vaysse, Software Development Engineer, Criteo</figcaption>
+                        </figure>
+                    </div>
                 </div>
+                <Blockquote
+                    quote="Before Sourcegraph, we were struggling to search code in an accurate and timely manner. The legacy text-based search we relied on had security issues, and its performance was poor in terms of the quality of searches and response times."
+                    author="Loic Teikiteetini-Vaysse"
+                />
+                <Blockquote
+                    quote="When looking for alternatives, the general consensus was 'If you're a giant like Google, you can simply build your own code search engine. If that's not you, then buy Sourcegraph."
+                    author="François Jehl"
+                />
+                <h2 className="tw-pt-md tw-pb-1">Prioritize developer happiness and productivity follows</h2>
+                <Blockquote
+                    quote="At Criteo, developer happiness is our top priority—not just productivity. We want to tackle the things that developers see as hurdles in their day-to-day life. By providing them with the right tools, like Sourcegraph, we've found that increased productivity is a natural byproduct."
+                    author="François Jehl"
+                />
+                <p>
+                    Sourcegraph serves as Criteo's one-stop shop for searching across all of its codebases, making
+                    its employees' lives that much easier. Criteo relies on many different ecosystems for different
+                    teams, and Sourcegraph now provides the ability to cross boundaries of different codebases and
+                    different languages authored by different people with different tools.
+                </p>
+                <p>
+                    Developers start with a query, then use the recommended filters to narrow their search until
+                    they locate the piece of code that is of interest. “Sometimes they don't even know what they're
+                    looking for—perhaps just patterns that need to be deprecated. With our previous tools, the
+                    results were not good,” said François Jehl.
+                </p>
+                <h2 className="tw-pt-md tw-pb-1">Survey says Sourcegraph is the ultimate time-saver</h2>
+                <p>
+                    Criteo conducted an internal survey with Sourcegraph early adopters to determine how Sourcegraph
+                    has impacted its developers' workflows. The survey found that 83 percent of those developers
+                    used Sourcegraph every single day, and nearly two-thirds used it several times per day.
+                </p>
+                <p>
+                    55 percent of respondents said Sourcegraph saved them a few dozen minutes per day, while 18
+                    percent stated they saved over an hour per day.
+                </p>
+                <Blockquote
+                    quote="The feedback we received was overwhelmingly positive. We had employees saying 'I've dreamt of a tool like Sourcegraph!', 'Please buy it!', 'It saved my life!', 'It literally saved me hours per day!' We're thrilled that it's given us the ability to make our developers happier and more productive in their roles."
+                    author="François Jehl"
+                />
+                <p>
+                    As codebases grow larger, Sourcegraph will continue to serve as the backbone to help developers
+                    at Criteo quickly search through code to understand what's happening within its ecosystem.
+                </p>
+                <Blockquote
+                    quote="The quality of the Sourcegraph UI and its code intelligence are two game-changer features for us. It's like having an online IDE for browsing code."
+                    author="Loic Teikiteetini-Vaysse"
+                />
             </ContentSection>
         </CaseStudyLayout>
     </Layout>

--- a/src/pages/case-studies/criteo-tackles-big-code.tsx
+++ b/src/pages/case-studies/criteo-tackles-big-code.tsx
@@ -21,7 +21,7 @@ export const CaseStudy: FunctionComponent = () => (
             }}
         >
             <ContentSection background="white" className="col-md-6 tw-pb-md">
-                <div className="container">
+                <div className="container tw-max-w-4xl">
                     <p>
                         Founded in France in 2005, Criteo partners with retailers to recommend products to potential
                         customers through ad retargeting. The company has massive volumes of data stored in its

--- a/src/pages/case-studies/f5-streamlines-collaboration-globally.tsx
+++ b/src/pages/case-studies/f5-streamlines-collaboration-globally.tsx
@@ -21,42 +21,40 @@ export const CaseStudy: FunctionComponent = () => (
                 image: '/case-studies/satish-surapaneni-f5.jpg',
             }}
         >
-            <ContentSection background="white" className="col-md-6 tw-pb-md">
-                <div className="container tw-max-w-4xl">
-                    <p>
-                        F5 focuses on the development, delivery, security, performance, and availability of web
-                        applications across any multi-cloud environment. The team behind its next-gen software
-                        infrastructure project started with zero code a year and a half ago, and now has more than 350
-                        repositories, multiple programming languages, and 125 developers across six different time
-                        zones. This project will live for 10+ years, and the code will inevitably grow by orders of
-                        magnitude during that time.
-                    </p>
-                    <h2 className="tw-pt-md tw-pb-1">Knocking down silos</h2>
-                    <Blockquote quote="Before Sourcegraph, each of our teams was siloed. Developers could understand their own codebase, but it was difficult for them to see and understand other team members' code." />
-                    <p>
-                        Sourcegraph supports collaboration across F5's teams by indexing code so that developers can
-                        easily find what they're looking for across the entire codebase.
-                    </p>
-                    <Blockquote quote="If I want to have a dialogue with a developer on a different team, it's as simple as pulling up Sourcegraph and walking through the code." />
-                    <h2 className="tw-pt-md tw-pb-1">Overcoming API boundaries</h2>
-                    <p>
-                        Sourcegraph empowers teams across different API boundaries to communicate and work together more
-                        effectively. Developers at F5 now have a common way to discuss their code, understand
-                        dependencies, and see how one team is using the other team's APIs.
-                    </p>
-                    <Blockquote quote="When implementing a feature and testing an API, we use Sourcegraph to go through the API and how it's implemented, see different parameters, read through the code around that API, and understand it better so that we can be better testers. If there are bugs, it's easy to understand the conditions around the error message and give meaningful feedback to our developers." />
-                    <h2 className="tw-pt-md tw-pb-1">Bringing teams together</h2>
-                    <p>
-                        F5 is comprised of teams that work more than 12 hours apart in different time zones. Sourcegraph
-                        makes communication simple by enabling developers to read and understand each others' code.
-                    </p>
-                    <Blockquote quote="When I work with remote teams and I want to give them an example of a piece or pattern of code, I use Sourcegraph to find the code snippets I need and simply send them the links. This is especially helpful because I can see who wrote the code and find out their thinking behind it." />
-                    <Blockquote quote="We are developing software faster than ever, with aggressive schedules, and across boundaries. Things that used to be worked out in a closed room now need to be done while teams are spread out across the globe. Sourcegraph is essential in this environment, and I can't imagine being proficient at my job without it." />
-                    <p>
-                        With Sourcegraph, F5's global workforce can stay better connected and quickly solve problems
-                        across the entire codebase.
-                    </p>
-                </div>
+            <ContentSection background="white" slimWidth={true} className="tw-col-md-6 tw-pb-md">
+                <p>
+                    F5 focuses on the development, delivery, security, performance, and availability of web
+                    applications across any multi-cloud environment. The team behind its next-gen software
+                    infrastructure project started with zero code a year and a half ago, and now has more than 350
+                    repositories, multiple programming languages, and 125 developers across six different time
+                    zones. This project will live for 10+ years, and the code will inevitably grow by orders of
+                    magnitude during that time.
+                </p>
+                <h2 className="tw-pt-md tw-pb-1">Knocking down silos</h2>
+                <Blockquote quote="Before Sourcegraph, each of our teams was siloed. Developers could understand their own codebase, but it was difficult for them to see and understand other team members' code." />
+                <p>
+                    Sourcegraph supports collaboration across F5's teams by indexing code so that developers can
+                    easily find what they're looking for across the entire codebase.
+                </p>
+                <Blockquote quote="If I want to have a dialogue with a developer on a different team, it's as simple as pulling up Sourcegraph and walking through the code." />
+                <h2 className="tw-pt-md tw-pb-1">Overcoming API boundaries</h2>
+                <p>
+                    Sourcegraph empowers teams across different API boundaries to communicate and work together more
+                    effectively. Developers at F5 now have a common way to discuss their code, understand
+                    dependencies, and see how one team is using the other team's APIs.
+                </p>
+                <Blockquote quote="When implementing a feature and testing an API, we use Sourcegraph to go through the API and how it's implemented, see different parameters, read through the code around that API, and understand it better so that we can be better testers. If there are bugs, it's easy to understand the conditions around the error message and give meaningful feedback to our developers." />
+                <h2 className="tw-pt-md tw-pb-1">Bringing teams together</h2>
+                <p>
+                    F5 is comprised of teams that work more than 12 hours apart in different time zones. Sourcegraph
+                    makes communication simple by enabling developers to read and understand each others' code.
+                </p>
+                <Blockquote quote="When I work with remote teams and I want to give them an example of a piece or pattern of code, I use Sourcegraph to find the code snippets I need and simply send them the links. This is especially helpful because I can see who wrote the code and find out their thinking behind it." />
+                <Blockquote quote="We are developing software faster than ever, with aggressive schedules, and across boundaries. Things that used to be worked out in a closed room now need to be done while teams are spread out across the globe. Sourcegraph is essential in this environment, and I can't imagine being proficient at my job without it." />
+                <p>
+                    With Sourcegraph, F5's global workforce can stay better connected and quickly solve problems
+                    across the entire codebase.
+                </p>
             </ContentSection>
         </CaseStudyLayout>
     </Layout>

--- a/src/pages/case-studies/f5-streamlines-collaboration-globally.tsx
+++ b/src/pages/case-studies/f5-streamlines-collaboration-globally.tsx
@@ -22,7 +22,7 @@ export const CaseStudy: FunctionComponent = () => (
             }}
         >
             <ContentSection background="white" className="col-md-6 tw-pb-md">
-                <div className="container">
+                <div className="container tw-max-w-4xl">
                     <p>
                         F5 focuses on the development, delivery, security, performance, and availability of web
                         applications across any multi-cloud environment. The team behind its next-gen software

--- a/src/pages/case-studies/factset-migrates-from-perforce-to-github.tsx
+++ b/src/pages/case-studies/factset-migrates-from-perforce-to-github.tsx
@@ -24,132 +24,130 @@ export const CaseStudy: FunctionComponent = () => {
                     image: '/case-studies/derrick-faunce.png',
                 }}
             >
-                <ContentSection background="white">
-                    <div className="container tw-max-w-4xl">
-                        <div className="row">
-                            <div className="col">
-                                <h3 className="tw-pb-1">Before Sourcegraph</h3>
-                                <ul>
-                                    <li>
-                                        Inability to search across repositories after monolith to microservices
-                                        migration
-                                    </li>
-                                    <li>Lack of understanding of existing code led to unnecessary or redundant code</li>
-                                    <li>Difficult to ensure consistency across the organization</li>
-                                </ul>
+                <ContentSection background="white" slimWidth={true}>
+                    <div className="row">
+                        <div className="col">
+                            <h3 className="tw-pb-1">Before Sourcegraph</h3>
+                            <ul>
+                                <li>
+                                    Inability to search across repositories after monolith to microservices
+                                    migration
+                                </li>
+                                <li>Lack of understanding of existing code led to unnecessary or redundant code</li>
+                                <li>Difficult to ensure consistency across the organization</li>
+                            </ul>
 
-                                <h3 className="tw-pt-md tw-pb-1">After Sourcegraph</h3>
-                                <ul>
-                                    <li>
-                                        Able to search all code in any language, including C++, across all 12,000+
-                                        repositories
-                                    </li>
-                                    <li>Eliminated duplicative efforts across the engineering team</li>
-                                    <li>Able to find and reuse examples from codebase for increased consistency</li>
-                                </ul>
-                            </div>
-
-                            <div className="col">
-                                <table>
-                                    <tbody>
-                                        <tr>
-                                            <th className="bg-light">Languages</th>
-                                            <td>C++, Javascript, and Python</td>
-                                        </tr>
-                                        <tr>
-                                            <th className="bg-light">Developers</th>
-                                            <td>500+</td>
-                                        </tr>
-                                        <tr>
-                                            <th className="bg-light">Code Host</th>
-                                            <td>GitHub</td>
-                                        </tr>
-                                        <tr>
-                                            <th className="bg-light"># Repos</th>
-                                            <td>12,000</td>
-                                        </tr>
-                                        <tr>
-                                            <th className="bg-light">Extensions</th>
-                                            <td>Lightstep, VS Code, Code Ownership</td>
-                                        </tr>
-                                    </tbody>
-                                </table>
-                            </div>
+                            <h3 className="tw-pt-md tw-pb-1">After Sourcegraph</h3>
+                            <ul>
+                                <li>
+                                    Able to search all code in any language, including C++, across all 12,000+
+                                    repositories
+                                </li>
+                                <li>Eliminated duplicative efforts across the engineering team</li>
+                                <li>Able to find and reuse examples from codebase for increased consistency</li>
+                            </ul>
                         </div>
 
-                        <Blockquote
-                            quote="With Sourcegraph, we were able to make a smooth transition from Perforce to GitHub."
-                            author={derrickFaunce}
-                        />
-
-                        <h2 className="tw-pt-md tw-pb-1">Migrating from monolith to microservices</h2>
-                        <p>
-                            In 2019, FactSet's engineering team started a huge code migration project to transition from
-                            a monolithic code repository in Perforce to microservices in GitHub. Part of the reason for
-                            migrating involved recruiting and onboarding—new developers often hadn't even heard of
-                            Perforce and didn't know how to use it. In addition, moving to a git-based system had
-                            technical benefits for FactSet, including increased code stability, fewer failed deployments
-                            and broken builds, and a more agile, incremental approach to software engineering.
-                        </p>
-
-                        <p>
-                            The developer services team spearheaded the transition to GitHub and met weekly with
-                            developers to provide updates and address issues. Soon after migrating the first 20+
-                            repositories, the team responsible for FactSet's market data platform, which ingests a huge
-                            amount of data from different stock exchanges, brought a major problem to their attention:
-                            the team could no longer search the code.
-                        </p>
-
-                        <p>
-                            The market data application is structured with approximately 100 different children classes
-                            of the same templates, repeated over and over. That structure is part of why the team relies
-                            so heavily on code search, just to see exactly which instance of a class is being called and
-                            what it is doing.
-                        </p>
-
-                        <p>
-                            “Mid-migration, it became very clear that we had to find an efficient way to search code.
-                            Thankfully, we discovered Sourcegraph,” said Derrick Faunce, Associate Director of Developer
-                            Services at FactSet.
-                        </p>
-
-                        <h2 className="tw-pt-md tw-pb-1">Expanding throughout the organization</h2>
-                        <p>
-                            Initially, the developer services team deployed Sourcegraph to the engineers responsible for
-                            the real-time news and quotes engine. But after receiving positive feedback, the team gave
-                            another 200+ developers access to Sourcegraph. A month later, they surveyed Sourcegraph
-                            users to see how engaged they were with the product.
-                        </p>
-
-                        <p>
-                            “The responses were heavily biased towards, ‘I'm using this every day, or even multiple
-                            times in any given day,'” Faunce said. Now, over 500 FactSet developers use Sourcegraph.
-                        </p>
-
-                        <Blockquote
-                            quote="For developers, Sourcegraph is a must-have tool一we need it at arm's length at all times."
-                            author={derrickFaunce}
-                        />
-
-                        <p>
-                            For a large, fast-paced organization like FactSet, code search capabilities are essential to
-                            ensuring consistency as well as eliminating duplicative efforts.
-                        </p>
-
-                        <p>
-                            “If I'm developing code for a library that might draw charts, for example, we don't want 30
-                            different ways to draw a chart at FactSet. With Sourcegraph, I can search the code to find
-                            other chart examples, and simply copy the code. This saves us time and ensures consistency.”
-                        </p>
-
-                        <p>
-                            “Being able to have code exploration is a base requirement of efficient development,” said
-                            Joseph Majesky, Software Engineer at FactSet.” Majesky was one of the developers who
-                            discovered Sourcegraph during the transition from Perforce to GitHub.
-                        </p>
-
-                        <br />
+                        <div className="col">
+                            <table>
+                                <tbody>
+                                    <tr>
+                                        <th className="bg-light">Languages</th>
+                                        <td>C++, Javascript, and Python</td>
+                                    </tr>
+                                    <tr>
+                                        <th className="bg-light">Developers</th>
+                                        <td>500+</td>
+                                    </tr>
+                                    <tr>
+                                        <th className="bg-light">Code Host</th>
+                                        <td>GitHub</td>
+                                    </tr>
+                                    <tr>
+                                        <th className="bg-light"># Repos</th>
+                                        <td>12,000</td>
+                                    </tr>
+                                    <tr>
+                                        <th className="bg-light">Extensions</th>
+                                        <td>Lightstep, VS Code, Code Ownership</td>
+                                    </tr>
+                                </tbody>
+                            </table>
+                        </div>
                     </div>
+
+                    <Blockquote
+                        quote="With Sourcegraph, we were able to make a smooth transition from Perforce to GitHub."
+                        author={derrickFaunce}
+                    />
+
+                    <h2 className="tw-pt-md tw-pb-1">Migrating from monolith to microservices</h2>
+                    <p>
+                        In 2019, FactSet's engineering team started a huge code migration project to transition from
+                        a monolithic code repository in Perforce to microservices in GitHub. Part of the reason for
+                        migrating involved recruiting and onboarding—new developers often hadn't even heard of
+                        Perforce and didn't know how to use it. In addition, moving to a git-based system had
+                        technical benefits for FactSet, including increased code stability, fewer failed deployments
+                        and broken builds, and a more agile, incremental approach to software engineering.
+                    </p>
+
+                    <p>
+                        The developer services team spearheaded the transition to GitHub and met weekly with
+                        developers to provide updates and address issues. Soon after migrating the first 20+
+                        repositories, the team responsible for FactSet's market data platform, which ingests a huge
+                        amount of data from different stock exchanges, brought a major problem to their attention:
+                        the team could no longer search the code.
+                    </p>
+
+                    <p>
+                        The market data application is structured with approximately 100 different children classes
+                        of the same templates, repeated over and over. That structure is part of why the team relies
+                        so heavily on code search, just to see exactly which instance of a class is being called and
+                        what it is doing.
+                    </p>
+
+                    <p>
+                        “Mid-migration, it became very clear that we had to find an efficient way to search code.
+                        Thankfully, we discovered Sourcegraph,” said Derrick Faunce, Associate Director of Developer
+                        Services at FactSet.
+                    </p>
+
+                    <h2 className="tw-pt-md tw-pb-1">Expanding throughout the organization</h2>
+                    <p>
+                        Initially, the developer services team deployed Sourcegraph to the engineers responsible for
+                        the real-time news and quotes engine. But after receiving positive feedback, the team gave
+                        another 200+ developers access to Sourcegraph. A month later, they surveyed Sourcegraph
+                        users to see how engaged they were with the product.
+                    </p>
+
+                    <p>
+                        “The responses were heavily biased towards, ‘I'm using this every day, or even multiple
+                        times in any given day,'” Faunce said. Now, over 500 FactSet developers use Sourcegraph.
+                    </p>
+
+                    <Blockquote
+                        quote="For developers, Sourcegraph is a must-have tool一we need it at arm's length at all times."
+                        author={derrickFaunce}
+                    />
+
+                    <p>
+                        For a large, fast-paced organization like FactSet, code search capabilities are essential to
+                        ensuring consistency as well as eliminating duplicative efforts.
+                    </p>
+
+                    <p>
+                        “If I'm developing code for a library that might draw charts, for example, we don't want 30
+                        different ways to draw a chart at FactSet. With Sourcegraph, I can search the code to find
+                        other chart examples, and simply copy the code. This saves us time and ensures consistency.”
+                    </p>
+
+                    <p>
+                        “Being able to have code exploration is a base requirement of efficient development,” said
+                        Joseph Majesky, Software Engineer at FactSet.” Majesky was one of the developers who
+                        discovered Sourcegraph during the transition from Perforce to GitHub.
+                    </p>
+
+                    <br />
                 </ContentSection>
             </CaseStudyLayout>
         </Layout>

--- a/src/pages/case-studies/factset-migrates-from-perforce-to-github.tsx
+++ b/src/pages/case-studies/factset-migrates-from-perforce-to-github.tsx
@@ -25,10 +25,10 @@ export const CaseStudy: FunctionComponent = () => {
                 }}
             >
                 <ContentSection background="white">
-                    <div className="container">
+                    <div className="container tw-max-w-4xl">
                         <div className="row">
                             <div className="col">
-                                <h3 className="tw-pt-md tw-pb-1">Before Sourcegraph</h3>
+                                <h3 className="tw-pb-1">Before Sourcegraph</h3>
                                 <ul>
                                     <li>
                                         Inability to search across repositories after monolith to microservices
@@ -50,7 +50,7 @@ export const CaseStudy: FunctionComponent = () => {
                             </div>
 
                             <div className="col">
-                                <table className="mt-5">
+                                <table>
                                     <tbody>
                                         <tr>
                                             <th className="bg-light">Languages</th>

--- a/src/pages/case-studies/hashicorp-uses-sourcegraph-to-streamline-cross-repository-code-search.tsx
+++ b/src/pages/case-studies/hashicorp-uses-sourcegraph-to-streamline-cross-repository-code-search.tsx
@@ -48,8 +48,8 @@ export const CaseStudy: FunctionComponent = () => (
         }
     >
         <NewCaseStudyLayout customer="HashiCorp">
-            <ContentSection background="white">
-                <div className="tw-max-w-4xl tw-mx-auto">
+            <ContentSection background="white" slimWidth={true}>
+                <div className="tw-mx-auto">
                     <Blockquote
                         quote="By its nature and capabilities, Sourcegraph can be a tool to reduce friction, speed up feedback loops, and improve developer velocity."
                         author="Bryce Kalow, Senior Web Engineer, HashiCorp"
@@ -105,8 +105,8 @@ export const CaseStudy: FunctionComponent = () => (
                 />
             </ContentSection>
 
-            <ContentSection background="white">
-                <div className="tw-max-w-4xl tw-mx-auto tw-pt-5xl">
+            <ContentSection background="white" slimWidth={true}>
+                <div className="tw-mx-auto tw-pt-5xl">
                     <p className="tw-pt-3xl sm:tw-pt-5xl sm:tw-mt-0 tw-mt-5xl">
                         Every day, millions of developers and DevOps engineers rely on HashiCorp to efficiently
                         provision, manage, and secure their cloud infrastructure. HashiCorp is a company that has

--- a/src/pages/case-studies/hashicorp-uses-sourcegraph-to-streamline-cross-repository-code-search.tsx
+++ b/src/pages/case-studies/hashicorp-uses-sourcegraph-to-streamline-cross-repository-code-search.tsx
@@ -106,7 +106,7 @@ export const CaseStudy: FunctionComponent = () => (
             </ContentSection>
 
             <ContentSection background="white">
-                <div className="tw-max-w-2xl tw-mx-auto tw-pt-5xl">
+                <div className="tw-max-w-4xl tw-mx-auto tw-pt-5xl">
                     <p className="tw-pt-3xl sm:tw-pt-5xl sm:tw-mt-0 tw-mt-5xl">
                         Every day, millions of developers and DevOps engineers rely on HashiCorp to efficiently
                         provision, manage, and secure their cloud infrastructure. HashiCorp is a company that has
@@ -247,7 +247,7 @@ export const CaseStudy: FunctionComponent = () => (
             </ContentSection>
 
             <ContentSection background="white">
-                <div className="tw-max-w-2xl tw-mx-auto">
+                <div className="tw-max-w-4xl tw-mx-auto">
                     <StaffSpotlight
                         customer="HashiCorp"
                         about="HashiCorp (NASDAQ: HCP) is a provider of open-core software that developers use to manage cloud infrastructure. Based in San Francisco, Calif., the company offers solutions including Terraform, an infrastructure-as-code tool for managing cloud services, and Vault, a tool for securing, storing, and controlling access to tokens, passwords, and API keys. HashiCorp’s tools are downloaded tens of millions of times each year and are broadly adopted by the Global 2000."

--- a/src/pages/case-studies/indeed-accelerates-development-velocity.tsx
+++ b/src/pages/case-studies/indeed-accelerates-development-velocity.tsx
@@ -27,129 +27,127 @@ export const CaseStudy: FunctionComponent = () => {
                     image: '/case-studies/jared-hodge-indeed.jpg',
                 }}
             >
-                <ContentSection background="white">
-                    <div className="container tw-max-w-4xl">
-                        <p>
-                            Indeed is a multinational job search website with over 11,000 employees and approximately
-                            2,000 engineers. Indeed's employment search features are available in 28 languages and 60
-                            countries.
-                        </p>
+                <ContentSection background="white" slimWidth={true}>
+                    <p>
+                        Indeed is a multinational job search website with over 11,000 employees and approximately
+                        2,000 engineers. Indeed's employment search features are available in 28 languages and 60
+                        countries.
+                    </p>
 
-                        <h2 className="tw-pt-md tw-pb-1">Finding and fixing problematic code</h2>
+                    <h2 className="tw-pt-md tw-pb-1">Finding and fixing problematic code</h2>
 
-                        <p>
-                            Developers at Indeed often need to either remove or update specific code patterns or
-                            libraries that appear throughout the entire codebase and across code owned by different
-                            teams. Making these updates requires first identifying every instance that needs to be
-                            changed and then communicating with the relevant teams to ask them to make the updates.
-                        </p>
+                    <p>
+                        Developers at Indeed often need to either remove or update specific code patterns or
+                        libraries that appear throughout the entire codebase and across code owned by different
+                        teams. Making these updates requires first identifying every instance that needs to be
+                        changed and then communicating with the relevant teams to ask them to make the updates.
+                    </p>
 
-                        <p>
-                            Whether it is five or 500 instances, these aren't frivolous requests: they are changes that
-                            need to happen. One of the most common — and often most urgent — reasons is for security. If
-                            a CVE or potential privacy issue is discovered in a particular library, the team needs to
-                            not only find out quickly where the issue is but also make sure that service owners act on
-                            that information.
-                        </p>
+                    <p>
+                        Whether it is five or 500 instances, these aren't frivolous requests: they are changes that
+                        need to happen. One of the most common — and often most urgent — reasons is for security. If
+                        a CVE or potential privacy issue is discovered in a particular library, the team needs to
+                        not only find out quickly where the issue is but also make sure that service owners act on
+                        that information.
+                    </p>
 
-                        <p>
-                            When Jared Hodge, Senior Manager of Developer Experience, needed to facilitate an update
-                            across the engineering organization, his team would send a generic email broadcast with the
-                            hope that the relevant engineers would take action. “We had an older change mechanism, where
-                            we just sent out a broadcast email to everybody in product and engineering who is
-                            potentially interested in these things,” Hodge said. “Inevitably, a few people don't get to
-                            it,” Hodge said. “There's a lot of manual work to herding cats.”
-                        </p>
+                    <p>
+                        When Jared Hodge, Senior Manager of Developer Experience, needed to facilitate an update
+                        across the engineering organization, his team would send a generic email broadcast with the
+                        hope that the relevant engineers would take action. “We had an older change mechanism, where
+                        we just sent out a broadcast email to everybody in product and engineering who is
+                        potentially interested in these things,” Hodge said. “Inevitably, a few people don't get to
+                        it,” Hodge said. “There's a lot of manual work to herding cats.”
+                    </p>
 
-                        <p>
-                            After adopting Sourcegraph Universal Code Search, Hodge's team was able to quickly identify
-                            every instance that needed to be updated. Instead of sending a generic request, such as
-                            ‘please update this library to the latest version,' his team was able to include a link to a
-                            Sourcegraph search to enable product and engineering to see what needed to be updated.
-                        </p>
+                    <p>
+                        After adopting Sourcegraph Universal Code Search, Hodge's team was able to quickly identify
+                        every instance that needed to be updated. Instead of sending a generic request, such as
+                        ‘please update this library to the latest version,' his team was able to include a link to a
+                        Sourcegraph search to enable product and engineering to see what needed to be updated.
+                    </p>
 
-                        <p>
-                            “We're the source of a lot of these requests. Before, we didn't really have any idea how
-                            much work we were injecting to the product teams,” Hodge said. Once they started using
-                            Sourcegraph Universal Code Search, the internal platforms team would at least know if there
-                            were five instances or 500 and if the work would take a few minutes or a few days to
-                            accomplish.
-                        </p>
+                    <p>
+                        “We're the source of a lot of these requests. Before, we didn't really have any idea how
+                        much work we were injecting to the product teams,” Hodge said. Once they started using
+                        Sourcegraph Universal Code Search, the internal platforms team would at least know if there
+                        were five instances or 500 and if the work would take a few minutes or a few days to
+                        accomplish.
+                    </p>
 
-                        <h2 className="tw-pt-md tw-pb-1">
-                            Reducing the manual work required for large-scale code updates by 90%
-                        </h2>
+                    <h2 className="tw-pt-md tw-pb-1">
+                        Reducing the manual work required for large-scale code updates by 90%
+                    </h2>
 
-                        <p>
-                            In most cases, the Sourcegraph searches were being done because something in the code needed
-                            to be changed, but the internal platforms team had no real power to ensure the changes
-                            happened or to even nudge them towards completion. “I actually did a bit of prototyping to
-                            see if I could create JIRA issues based on the code searches,” Hodge said, as part of a
-                            search for a way to help other team members actually make the changes that need to happen.
-                            When Sourcegraph's{' '}
-                            <Link href="/blog/introducing-batch-changes/" passHref={true}>
-                                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                <a
-                                    title="Batch Changes"
-                                    data-button-style={buttonStyle.text}
-                                    data-button-location={buttonLocation.body}
-                                    data-button-type="cta"
-                                >
-                                    Batch Changes
-                                </a>
-                            </Link>{' '}
-                            came out, Hodge immediately saw the value in further removing friction by letting one person
-                            update all versions of a library across the codebase and then notify all the service owners
-                            so they could review.
-                        </p>
+                    <p>
+                        In most cases, the Sourcegraph searches were being done because something in the code needed
+                        to be changed, but the internal platforms team had no real power to ensure the changes
+                        happened or to even nudge them towards completion. “I actually did a bit of prototyping to
+                        see if I could create JIRA issues based on the code searches,” Hodge said, as part of a
+                        search for a way to help other team members actually make the changes that need to happen.
+                        When Sourcegraph's{' '}
+                        <Link href="/blog/introducing-batch-changes/" passHref={true}>
+                            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                            <a
+                                title="Batch Changes"
+                                data-button-style={buttonStyle.text}
+                                data-button-location={buttonLocation.body}
+                                data-button-type="cta"
+                            >
+                                Batch Changes
+                            </a>
+                        </Link>{' '}
+                        came out, Hodge immediately saw the value in further removing friction by letting one person
+                        update all versions of a library across the codebase and then notify all the service owners
+                        so they could review.
+                    </p>
 
-                        <Blockquote
-                            quote="If I can reduce the amount of work a product team has to do by 90%, that is a huge win. Not only do they have to do less work — we're asking them to spend 10 minutes on a code review as opposed to spending the next six hours doing this change — they also don't have to spend time figuring out how to prioritize the different requests they're getting."
-                            author={jaredHodge}
-                        />
+                    <Blockquote
+                        quote="If I can reduce the amount of work a product team has to do by 90%, that is a huge win. Not only do they have to do less work — we're asking them to spend 10 minutes on a code review as opposed to spending the next six hours doing this change — they also don't have to spend time figuring out how to prioritize the different requests they're getting."
+                        author={jaredHodge}
+                    />
 
-                        <p>
-                            While Batch Changes still requires service owners to review the code, that process is much
-                            easier and faster than making the change manually.
-                        </p>
+                    <p>
+                        While Batch Changes still requires service owners to review the code, that process is much
+                        easier and faster than making the change manually.
+                    </p>
 
-                        <h3 className="tw-pt-md tw-pb-1">Saving engineering time</h3>
+                    <h3 className="tw-pt-md tw-pb-1">Saving engineering time</h3>
 
-                        <p>
-                            There's quite a bit of variability in the amount of work required to remove every instance
-                            of a library or code pattern. In some cases it would only take a few minutes but in others
-                            it would take days.
-                        </p>
+                    <p>
+                        There's quite a bit of variability in the amount of work required to remove every instance
+                        of a library or code pattern. In some cases it would only take a few minutes but in others
+                        it would take days.
+                    </p>
 
-                        <Blockquote
-                            quote="On average, I'd say that for every automated merge request that we're able to merge we save an hour. That's a rough but conservative estimate. It shows, though, that if we are doing several thousand automated merges in a year, we're saving several employee's worth of time."
-                            author={jaredHodge}
-                        />
+                    <Blockquote
+                        quote="On average, I'd say that for every automated merge request that we're able to merge we save an hour. That's a rough but conservative estimate. It shows, though, that if we are doing several thousand automated merges in a year, we're saving several employee's worth of time."
+                        author={jaredHodge}
+                    />
 
-                        <h3 className="tw-pt-md tw-pb-1">Reducing invisible taxes</h3>
+                    <h3 className="tw-pt-md tw-pb-1">Reducing invisible taxes</h3>
 
-                        <p>
-                            “There's all these little hidden things that tax the velocity of the teams,” Hodge said.
-                            “Earlier this month I was using Sourcegraph to find code and things we needed to replace,
-                            related to updating our build system, and we've seen an improvement in the build times as a
-                            result. But I feel like the summation of all these little things actually adds up to way
-                            more than just speeding up the build time.”
-                        </p>
+                    <p>
+                        “There's all these little hidden things that tax the velocity of the teams,” Hodge said.
+                        “Earlier this month I was using Sourcegraph to find code and things we needed to replace,
+                        related to updating our build system, and we've seen an improvement in the build times as a
+                        result. But I feel like the summation of all these little things actually adds up to way
+                        more than just speeding up the build time.”
+                    </p>
 
-                        <p>
-                            For example, Sourcegraph Universal Code Search and Batch Changes have made it easier to
-                            fully retire technology that was still being supported because it continued to be used by a
-                            very small percentage of the team, putting a drag on the entire system.
-                        </p>
+                    <p>
+                        For example, Sourcegraph Universal Code Search and Batch Changes have made it easier to
+                        fully retire technology that was still being supported because it continued to be used by a
+                        very small percentage of the team, putting a drag on the entire system.
+                    </p>
 
-                        <p>
-                            The ability to automate downstream changes across every team and repository helps Hodge and
-                            his team reduce the hidden burden of updates pushed across teams and will ultimately enable
-                            Indeed to increase its engineering velocity.
-                        </p>
+                    <p>
+                        The ability to automate downstream changes across every team and repository helps Hodge and
+                        his team reduce the hidden burden of updates pushed across teams and will ultimately enable
+                        Indeed to increase its engineering velocity.
+                    </p>
 
-                        <br />
-                    </div>
+                    <br />
                 </ContentSection>
             </CaseStudyLayout>
         </Layout>

--- a/src/pages/case-studies/indeed-accelerates-development-velocity.tsx
+++ b/src/pages/case-studies/indeed-accelerates-development-velocity.tsx
@@ -28,7 +28,7 @@ export const CaseStudy: FunctionComponent = () => {
                 }}
             >
                 <ContentSection background="white">
-                    <div className="container">
+                    <div className="container tw-max-w-4xl">
                         <p>
                             Indeed is a multinational job search website with over 11,000 employees and approximately
                             2,000 engineers. Indeed's employment search features are available in 28 languages and 60

--- a/src/pages/case-studies/lyft-monolith-to-microservices.tsx
+++ b/src/pages/case-studies/lyft-monolith-to-microservices.tsx
@@ -26,89 +26,87 @@ export const CaseStudy: FunctionComponent = () => {
                 }}
                 pdf="https://sourcegraphstatic.com/Lyft-Sourcegraph-case-study.pdf"
             >
-                <ContentSection background="white">
-                    <div className="container tw-max-w-4xl">
-                        <p>
-                            Lyft's mission is to improve people's lives with the world's best transportation. With over
-                            30 million riders in 2018, Lyft's business is growing, as are the numbers of engineers,
-                            repositories, and microservices. Effectively scaling and managing a large engineering
-                            organization requires an elite set of development tools and practices to preserve
-                            efficiency, while protecting, and enhancing code quality.
-                        </p>
+                <ContentSection background="white" slimWidth={true}>
+                    <p>
+                        Lyft's mission is to improve people's lives with the world's best transportation. With over
+                        30 million riders in 2018, Lyft's business is growing, as are the numbers of engineers,
+                        repositories, and microservices. Effectively scaling and managing a large engineering
+                        organization requires an elite set of development tools and practices to preserve
+                        efficiency, while protecting, and enhancing code quality.
+                    </p>
 
-                        <Blockquote
-                            quote="Decomposition or migrating a service is a high-risk endeavor, often involving changes in hundreds of repositories, so a high level of accuracy is needed."
-                            author={justinPhilips}
-                        />
+                    <Blockquote
+                        quote="Decomposition or migrating a service is a high-risk endeavor, often involving changes in hundreds of repositories, so a high level of accuracy is needed."
+                        author={justinPhilips}
+                    />
 
-                        <h2 className="tw-pt-md tw-pb-1">From monolith to microservices</h2>
+                    <h2 className="tw-pt-md tw-pb-1">From monolith to microservices</h2>
 
-                        <p>
-                            The largest refactoring effort in Lyft's 10-year history came in 2018 when the number one
-                            company priority was the decomposition of the PHP monolith to microservices.
-                        </p>
+                    <p>
+                        The largest refactoring effort in Lyft's 10-year history came in 2018 when the number one
+                        company priority was the decomposition of the PHP monolith to microservices.
+                    </p>
 
-                        <p>
-                            Performing such significant and wide-ranging code changes meant extensive analysis was
-                            required to verify all call sites and references to the monolith had been updated. This
-                            meant transforming monolith code to consuming the new microservice API endpoints, which in
-                            many cases, meant altering an API schema.
-                        </p>
+                    <p>
+                        Performing such significant and wide-ranging code changes meant extensive analysis was
+                        required to verify all call sites and references to the monolith had been updated. This
+                        meant transforming monolith code to consuming the new microservice API endpoints, which in
+                        many cases, meant altering an API schema.
+                    </p>
 
-                        <p>
-                            This wasn't simply slicing up the monolith by domain into separate services—it was also a
-                            crucial opportunity to eliminate tech debt by removing dead code, deprecated libraries, and
-                            unused API and database fields.
-                        </p>
+                    <p>
+                        This wasn't simply slicing up the monolith by domain into separate services—it was also a
+                        crucial opportunity to eliminate tech debt by removing dead code, deprecated libraries, and
+                        unused API and database fields.
+                    </p>
 
-                        <Blockquote
-                            quote={
-                                <>
-                                    During our decomp efforts, we also spent time to refactor our APIs. Many of these
-                                    APIs were undocumented and lacked a formalized contract.
-                                    <br />
-                                    <br />
-                                    With the help of Sourcegraph, we were able to quickly look at all clients of an API
-                                    and remove unused attributes that lived in different repositories, ultimately
-                                    simplifying our APIs and speeding up developer iteration time.
-                                </>
-                            }
-                            author={justinPhilips}
-                        />
+                    <Blockquote
+                        quote={
+                            <>
+                                During our decomp efforts, we also spent time to refactor our APIs. Many of these
+                                APIs were undocumented and lacked a formalized contract.
+                                <br />
+                                <br />
+                                With the help of Sourcegraph, we were able to quickly look at all clients of an API
+                                and remove unused attributes that lived in different repositories, ultimately
+                                simplifying our APIs and speeding up developer iteration time.
+                            </>
+                        }
+                        author={justinPhilips}
+                    />
 
-                        <h2 className="tw-pt-md tw-pb-1">
-                            The refactoring and the decomposition of legacy applications is constant
-                        </h2>
+                    <h2 className="tw-pt-md tw-pb-1">
+                        The refactoring and the decomposition of legacy applications is constant
+                    </h2>
 
-                        <p>
-                            With the confidence gained from the successful PHP monolith decomposition, new projects are
-                            underway to reduce tech debt by more aggressively tackling migrations and the deprecation of
-                            systems.
-                        </p>
+                    <p>
+                        With the confidence gained from the successful PHP monolith decomposition, new projects are
+                        underway to reduce tech debt by more aggressively tackling migrations and the deprecation of
+                        systems.
+                    </p>
 
-                        <Blockquote
-                            quote={
-                                <>
-                                    Lyft teams are constantly innovating and building new systems, necessitating
-                                    decomposing and migrating off of older ones. Sourcegraph gives us the ability to
-                                    search for and refactor references to deprecated services, libraries, URL patterns,
-                                    and more across our 2000+ repositories, and the confidence that we're not leaving
-                                    anyone behind.
-                                    <br />
-                                    <br />
-                                    Sourcegraph makes it easy to survey and understand existing use cases to make sure
-                                    we build the right thing.
-                                </>
-                            }
-                            author="Aneesh Agrawal, Software Engineer, Lyft"
-                        />
+                    <Blockquote
+                        quote={
+                            <>
+                                Lyft teams are constantly innovating and building new systems, necessitating
+                                decomposing and migrating off of older ones. Sourcegraph gives us the ability to
+                                search for and refactor references to deprecated services, libraries, URL patterns,
+                                and more across our 2000+ repositories, and the confidence that we're not leaving
+                                anyone behind.
+                                <br />
+                                <br />
+                                Sourcegraph makes it easy to survey and understand existing use cases to make sure
+                                we build the right thing.
+                            </>
+                        }
+                        author="Aneesh Agrawal, Software Engineer, Lyft"
+                    />
 
-                        <p className="tw-pb-md">
-                            Using Sourcegraph code search, Lyft software engineers were able to verify the migration and
-                            deprecation of code from their monolith to microservices at scale, significantly reducing
-                            the risk to production stability during deployment of the new microservices.
-                        </p>
-                    </div>
+                    <p className="tw-pb-md">
+                        Using Sourcegraph code search, Lyft software engineers were able to verify the migration and
+                        deprecation of code from their monolith to microservices at scale, significantly reducing
+                        the risk to production stability during deployment of the new microservices.
+                    </p>
                 </ContentSection>
             </CaseStudyLayout>
         </Layout>

--- a/src/pages/case-studies/lyft-monolith-to-microservices.tsx
+++ b/src/pages/case-studies/lyft-monolith-to-microservices.tsx
@@ -27,7 +27,7 @@ export const CaseStudy: FunctionComponent = () => {
                 pdf="https://sourcegraphstatic.com/Lyft-Sourcegraph-case-study.pdf"
             >
                 <ContentSection background="white">
-                    <div className="container">
+                    <div className="container tw-max-w-4xl">
                         <p>
                             Lyft's mission is to improve people's lives with the world's best transportation. With over
                             30 million riders in 2018, Lyft's business is growing, as are the numbers of engineers,

--- a/src/pages/case-studies/nutanix-fixed-log4j-with-sourcegraph.tsx
+++ b/src/pages/case-studies/nutanix-fixed-log4j-with-sourcegraph.tsx
@@ -98,8 +98,8 @@ export const CaseStudy: FunctionComponent = () => (
                 />
             </ContentSection>
 
-            <ContentSection background="white">
-                <div className="tw-max-w-4xl tw-mx-auto tw-pt-5xl">
+            <ContentSection background="white" slimWidth={true}>
+                <div className="tw-mx-auto tw-pt-5xl">
                     <p className="tw-pt-3xl sm:tw-mt-0 tw-mt-5xl">
                         As the Technical Director of Solution Engineering at Nutanix, Jon Kohler understands the
                         complexity involved in securing the multitude of applications and solutions required to power
@@ -249,8 +249,8 @@ export const CaseStudy: FunctionComponent = () => (
                 <ThreeUpText items={threeUpTextItems} />
             </ContentSection>
 
-            <ContentSection background="white">
-                <div className="tw-max-w-4xl tw-mx-auto">
+            <ContentSection background="white" slimWidth={true}>
+                <div className="tw-mx-auto">
                     <h3 className="mb-4">Log4j is the tip of the open-source vulnerability iceberg</h3>
                     <p>
                         <b>With Sourcegraph's help,</b> Nutanix was able to transform a trust-threatening risk into a

--- a/src/pages/case-studies/nutanix-fixed-log4j-with-sourcegraph.tsx
+++ b/src/pages/case-studies/nutanix-fixed-log4j-with-sourcegraph.tsx
@@ -99,7 +99,7 @@ export const CaseStudy: FunctionComponent = () => (
             </ContentSection>
 
             <ContentSection background="white">
-                <div className="tw-max-w-2xl tw-mx-auto tw-pt-5xl">
+                <div className="tw-max-w-4xl tw-mx-auto tw-pt-5xl">
                     <p className="tw-pt-3xl sm:tw-mt-0 tw-mt-5xl">
                         As the Technical Director of Solution Engineering at Nutanix, Jon Kohler understands the
                         complexity involved in securing the multitude of applications and solutions required to power
@@ -250,7 +250,7 @@ export const CaseStudy: FunctionComponent = () => (
             </ContentSection>
 
             <ContentSection background="white">
-                <div className="tw-max-w-2xl tw-mx-auto">
+                <div className="tw-max-w-4xl tw-mx-auto">
                     <h3 className="mb-4">Log4j is the tip of the open-source vulnerability iceberg</h3>
                     <p>
                         <b>With Sourcegraph's help,</b> Nutanix was able to transform a trust-threatening risk into a

--- a/src/pages/case-studies/quantcast-large-scale-refactoring.tsx
+++ b/src/pages/case-studies/quantcast-large-scale-refactoring.tsx
@@ -22,99 +22,97 @@ export const CaseStudy: FunctionComponent = () => (
             }}
             pdf="https://sourcegraphstatic.com/Quantcast-Sourcegraph-case-study.pdf"
         >
-            <ContentSection background="white">
-                <div className="container tw-max-w-4xl">
-                    <p>
-                        Quantcast uses machine-learning-driven, real-time audience insights to radically simplify
-                        advertising for brands and customers such as BuzzFeed, Dell, and Fiat Chrysler. Quantcast is the
-                        pulse of the open Internet, measuring billions of pseudonymized interactions per day so brands
-                        can deeply understand and reach their audiences, all while protecting consumer privacy.
-                    </p>
+            <ContentSection background="white" slimWidth={true}>
+                <p>
+                    Quantcast uses machine-learning-driven, real-time audience insights to radically simplify
+                    advertising for brands and customers such as BuzzFeed, Dell, and Fiat Chrysler. Quantcast is the
+                    pulse of the open Internet, measuring billions of pseudonymized interactions per day so brands
+                    can deeply understand and reach their audiences, all while protecting consumer privacy.
+                </p>
 
-                    <p>
-                        Founded in 2006, Quantcast's engineering team had amassed thousands of repositories. This growth
-                        made refactoring a difficult and time-consuming task for an unaided engineer to tackle. After
-                        discovering and deploying Sourcegraph, Quantcast was able to do major refactors with confidence.
-                    </p>
+                <p>
+                    Founded in 2006, Quantcast's engineering team had amassed thousands of repositories. This growth
+                    made refactoring a difficult and time-consuming task for an unaided engineer to tackle. After
+                    discovering and deploying Sourcegraph, Quantcast was able to do major refactors with confidence.
+                </p>
 
-                    <h2 className="tw-pt-md tw-pb-1">GDPR readiness though organization-wide code search</h2>
-                    <p>
-                        May 2018 was the deadline for the EU General Data Protection Regulation, a law that provides
-                        widespread protections for users and their personal data. Quantcast saw it as an opportunity to
-                        strengthen their position as a privacy-first organization.
-                    </p>
+                <h2 className="tw-pt-md tw-pb-1">GDPR readiness though organization-wide code search</h2>
+                <p>
+                    May 2018 was the deadline for the EU General Data Protection Regulation, a law that provides
+                    widespread protections for users and their personal data. Quantcast saw it as an opportunity to
+                    strengthen their position as a privacy-first organization.
+                </p>
 
-                    <p>
-                        Quantcast created a tiger-team to not only meet GDPR compliance, but exceed the requirements.
-                        They analyzed what services ought to handle GDPR-defined personal data, and used Sourcegraph to
-                        discover which actually did. Personal data, such as IP addresses, can be identified within
-                        source code by using Sourcegraph's regular expression search. Searching for{' '}
-                        <code className="language-text">"ip"</code> would return too many results.
-                    </p>
+                <p>
+                    Quantcast created a tiger-team to not only meet GDPR compliance, but exceed the requirements.
+                    They analyzed what services ought to handle GDPR-defined personal data, and used Sourcegraph to
+                    discover which actually did. Personal data, such as IP addresses, can be identified within
+                    source code by using Sourcegraph's regular expression search. Searching for{' '}
+                    <code className="language-text">"ip"</code> would return too many results.
+                </p>
 
-                    <div>
-                        Instead, Sourcegraph can search for fields within objects with:
-                        <br />
-                        <br />
-                        <pre className="language-regex tw-border-gray-200 tw-border">
-                            <code className="language-regex">{'\\w+\\.ip(addr)?\\b'}</code>
-                        </pre>
-                        or addresses themselves with:
-                        <br />
-                        <br />
-                        <pre className="language-regex tw-border-gray-200 tw-border">
-                            <code className="language-regex">{'\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b'}</code>
-                        </pre>
-                    </div>
-
-                    <Blockquote quote="Unlike other tools, Sourcegraph doesn't just search for keywords, it searches for regular expressions. This familiar query language allowed us to zero-in on exactly what we wanted and filter out false matches." />
-
-                    <p>
-                        For every project, the team created a burndown list of issues and provided links to Sourcegraph
-                        search results to the code owners. Since Sourcegraph searches every repository, a single
-                        engineer took only a few days to analyze thousands of them, which would have taken months if
-                        they were each examined individually.
-                    </p>
-
-                    <Blockquote quote="Sourcegraph's search gave us confidence because we knew we wouldn't overlook anything: Sourcegraph returns all search results, it doesn't drop or elide them, unlike GitHub Enterprise." />
-
-                    <p>
-                        Each team was able to use the Sourcegraph searches to confirm that all of their outstanding
-                        issues were addressed. Because Sourcegraph uses regular-expressions, familiar to most engineers,
-                        these engineers easily adopted Sourcegraph to learn more about how their projects interacted
-                        with other projects. As they fixed or addressed each issue, these Sourcegraph searches returned
-                        fewer and fewer results.
-                    </p>
-
-                    <h2 className="tw-pt-md tw-pb-1">
-                        Preventing future issues with code monitoring and notifications
-                    </h2>
-
-                    <p>
-                        With more data privacy laws on the horizon (such as California's Consumer Privacy Act),
-                        Quantcast can navigate the shifting regulatory landscape. Using Sourcegraph's saved searches,
-                        senior engineers have an easy way to define patterns, set up ownership, and get early warning
-                        alerts before any changes that affect personal data are merged.
-                    </p>
-
-                    <Blockquote quote="Saved searches allow us to constantly monitor code that manages personal data, organization wide, before changes land in production." />
-
-                    <h2 className="tw-pt-md tw-pb-1">
-                        Large scale refactoring is now possible without risking production stability
-                    </h2>
-
-                    <p>
-                        Multi-repository code search makes large scale refactoring at Quantcast systematic, safe, and
-                        efficient: enabling massive projects like GDPR compliance while saving hundreds of developer
-                        hours without risking production stability.
-                    </p>
-
-                    <p className="tw-pb-md">
-                        Saved searches with email notifications empower teams to continuously monitor changes to code
-                        handling personal information which mitigates compliance risk without distracting developers
-                        from delivering business value.
-                    </p>
+                <div>
+                    Instead, Sourcegraph can search for fields within objects with:
+                    <br />
+                    <br />
+                    <pre className="language-regex tw-border-gray-200 tw-border">
+                        <code className="language-regex">{'\\w+\\.ip(addr)?\\b'}</code>
+                    </pre>
+                    or addresses themselves with:
+                    <br />
+                    <br />
+                    <pre className="language-regex tw-border-gray-200 tw-border">
+                        <code className="language-regex">{'\\b\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\.\\d{1,3}\\b'}</code>
+                    </pre>
                 </div>
+
+                <Blockquote quote="Unlike other tools, Sourcegraph doesn't just search for keywords, it searches for regular expressions. This familiar query language allowed us to zero-in on exactly what we wanted and filter out false matches." />
+
+                <p>
+                    For every project, the team created a burndown list of issues and provided links to Sourcegraph
+                    search results to the code owners. Since Sourcegraph searches every repository, a single
+                    engineer took only a few days to analyze thousands of them, which would have taken months if
+                    they were each examined individually.
+                </p>
+
+                <Blockquote quote="Sourcegraph's search gave us confidence because we knew we wouldn't overlook anything: Sourcegraph returns all search results, it doesn't drop or elide them, unlike GitHub Enterprise." />
+
+                <p>
+                    Each team was able to use the Sourcegraph searches to confirm that all of their outstanding
+                    issues were addressed. Because Sourcegraph uses regular-expressions, familiar to most engineers,
+                    these engineers easily adopted Sourcegraph to learn more about how their projects interacted
+                    with other projects. As they fixed or addressed each issue, these Sourcegraph searches returned
+                    fewer and fewer results.
+                </p>
+
+                <h2 className="tw-pt-md tw-pb-1">
+                    Preventing future issues with code monitoring and notifications
+                </h2>
+
+                <p>
+                    With more data privacy laws on the horizon (such as California's Consumer Privacy Act),
+                    Quantcast can navigate the shifting regulatory landscape. Using Sourcegraph's saved searches,
+                    senior engineers have an easy way to define patterns, set up ownership, and get early warning
+                    alerts before any changes that affect personal data are merged.
+                </p>
+
+                <Blockquote quote="Saved searches allow us to constantly monitor code that manages personal data, organization wide, before changes land in production." />
+
+                <h2 className="tw-pt-md tw-pb-1">
+                    Large scale refactoring is now possible without risking production stability
+                </h2>
+
+                <p>
+                    Multi-repository code search makes large scale refactoring at Quantcast systematic, safe, and
+                    efficient: enabling massive projects like GDPR compliance while saving hundreds of developer
+                    hours without risking production stability.
+                </p>
+
+                <p className="tw-pb-md">
+                    Saved searches with email notifications empower teams to continuously monitor changes to code
+                    handling personal information which mitigates compliance risk without distracting developers
+                    from delivering business value.
+                </p>
             </ContentSection>
         </CaseStudyLayout>
     </Layout>

--- a/src/pages/case-studies/quantcast-large-scale-refactoring.tsx
+++ b/src/pages/case-studies/quantcast-large-scale-refactoring.tsx
@@ -23,7 +23,7 @@ export const CaseStudy: FunctionComponent = () => (
             pdf="https://sourcegraphstatic.com/Quantcast-Sourcegraph-case-study.pdf"
         >
             <ContentSection background="white">
-                <div className="container">
+                <div className="container tw-max-w-4xl">
                     <p>
                         Quantcast uses machine-learning-driven, real-time audience insights to radically simplify
                         advertising for brands and customers such as BuzzFeed, Dell, and Fiat Chrysler. Quantcast is the

--- a/src/pages/case-studies/sofi-moves-fast-on-hundreds-of-microservices.tsx
+++ b/src/pages/case-studies/sofi-moves-fast-on-hundreds-of-microservices.tsx
@@ -26,7 +26,7 @@ export const CaseStudy: FunctionComponent = () => (
             pdf="https://sourcegraphstatic.com/sofi_case_study.pdf"
         >
             <ContentSection background="white">
-                <div className="container">
+                <div className="container tw-max-w-4xl">
                     <p>
                         SoFi (Social Finance Inc.) helps its over 900,000 members achieve financial independence to
                         realize their ambitions with products for borrowing, saving, spending, investing, and protecting

--- a/src/pages/case-studies/sofi-moves-fast-on-hundreds-of-microservices.tsx
+++ b/src/pages/case-studies/sofi-moves-fast-on-hundreds-of-microservices.tsx
@@ -25,51 +25,49 @@ export const CaseStudy: FunctionComponent = () => (
             }}
             pdf="https://sourcegraphstatic.com/sofi_case_study.pdf"
         >
-            <ContentSection background="white">
-                <div className="container tw-max-w-4xl">
-                    <p>
-                        SoFi (Social Finance Inc.) helps its over 900,000 members achieve financial independence to
-                        realize their ambitions with products for borrowing, saving, spending, investing, and protecting
-                        their money. With Sourcegraph, SoFi can innovate and move quickly while keeping up with hundreds
-                        of microservices.
-                    </p>
-                    <h2 className="tw-pt-md tw-pb-1">The need for cross-repository code search</h2>
-                    <p>
-                        When SoFi decided to switch their code host from Bitbucket to GitLab they quickly realized they
-                        would need a more powerful code search tool to search over their hundreds of repositories. They
-                        also saw an increase in issues due to overlooked code interdependencies when newer engineers
-                        committed their code changes. The need for fast and accurate code search and cross-repository
-                        code navigation led the engineering team to install Sourcegraph. As a FinTech company that
-                        contains highly sensitive data from their customers, SoFi emphasizes on security and appreciated
-                        Sourcegraph's{' '}
-                        <Link href="/blog/from-saas-to-on-premises" passHref={true}>
-                            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a
-                                title="on-prem solution"
-                                data-button-style={buttonStyle.text}
-                                data-button-location={buttonLocation.body}
-                                data-button-type="cta"
-                            >
-                                on-prem solution
-                            </a>
-                        </Link>
-                        .
-                    </p>
-                    <h2 className="tw-pt-md tw-pb-1">Move fast and don't break things</h2>
-                    <p>
-                        As a financial institution, SoFi needs to avoid downtime—but they also need to continuously
-                        innovate to compete. SoFi runs hundreds of microservices. Their fast growth makes it difficult
-                        to maintain a complete list of the published APIs showing the interdependencies of their
-                        services. A common use case for Sourcegraph is to find which microservice is referenced by
-                        another. This ability safeguards against breaking production with code changes and avoids code
-                        duplications. SoFi's codebase is updated hundreds of times a day making Sourcegraph's real time
-                        code investigation features with “go to definition” and “find all references” across all
-                        microservices indispensable for SoFi engineers' daily coding activities, mentoring and stack
-                        trace investigations. With Sourcegraph, SoFi engineers fully understand the scope and breadth of
-                        how their code changes impact other microservices.
-                    </p>
-                    <br />
-                </div>
+            <ContentSection background="white" slimWidth={true}>
+                <p>
+                    SoFi (Social Finance Inc.) helps its over 900,000 members achieve financial independence to
+                    realize their ambitions with products for borrowing, saving, spending, investing, and protecting
+                    their money. With Sourcegraph, SoFi can innovate and move quickly while keeping up with hundreds
+                    of microservices.
+                </p>
+                <h2 className="tw-pt-md tw-pb-1">The need for cross-repository code search</h2>
+                <p>
+                    When SoFi decided to switch their code host from Bitbucket to GitLab they quickly realized they
+                    would need a more powerful code search tool to search over their hundreds of repositories. They
+                    also saw an increase in issues due to overlooked code interdependencies when newer engineers
+                    committed their code changes. The need for fast and accurate code search and cross-repository
+                    code navigation led the engineering team to install Sourcegraph. As a FinTech company that
+                    contains highly sensitive data from their customers, SoFi emphasizes on security and appreciated
+                    Sourcegraph's{' '}
+                    <Link href="/blog/from-saas-to-on-premises" passHref={true}>
+                        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                        <a
+                            title="on-prem solution"
+                            data-button-style={buttonStyle.text}
+                            data-button-location={buttonLocation.body}
+                            data-button-type="cta"
+                        >
+                            on-prem solution
+                        </a>
+                    </Link>
+                    .
+                </p>
+                <h2 className="tw-pt-md tw-pb-1">Move fast and don't break things</h2>
+                <p>
+                    As a financial institution, SoFi needs to avoid downtime—but they also need to continuously
+                    innovate to compete. SoFi runs hundreds of microservices. Their fast growth makes it difficult
+                    to maintain a complete list of the published APIs showing the interdependencies of their
+                    services. A common use case for Sourcegraph is to find which microservice is referenced by
+                    another. This ability safeguards against breaking production with code changes and avoids code
+                    duplications. SoFi's codebase is updated hundreds of times a day making Sourcegraph's real time
+                    code investigation features with “go to definition” and “find all references” across all
+                    microservices indispensable for SoFi engineers' daily coding activities, mentoring and stack
+                    trace investigations. With Sourcegraph, SoFi engineers fully understand the scope and breadth of
+                    how their code changes impact other microservices.
+                </p>
+                <br />
             </ContentSection>
         </CaseStudyLayout>
     </Layout>

--- a/src/pages/case-studies/we-are-thorn.tsx
+++ b/src/pages/case-studies/we-are-thorn.tsx
@@ -23,7 +23,7 @@ export const CaseStudy: FunctionComponent = () => (
             pdf="https://sourcegraphstatic.com/Thorn%20Sourcegraph%20case%20study%20v2.pdf"
         >
             <ContentSection background="white">
-                <div className="container">
+                <div className="container tw-max-w-4xl">
                     <h2>Thorn defends children</h2>
 
                     <p>

--- a/src/pages/case-studies/we-are-thorn.tsx
+++ b/src/pages/case-studies/we-are-thorn.tsx
@@ -22,72 +22,70 @@ export const CaseStudy: FunctionComponent = () => (
             }}
             pdf="https://sourcegraphstatic.com/Thorn%20Sourcegraph%20case%20study%20v2.pdf"
         >
-            <ContentSection background="white">
-                <div className="container tw-max-w-4xl">
-                    <h2>Thorn defends children</h2>
+            <ContentSection background="white" slimWidth={true}>
+                <h2>Thorn defends children</h2>
 
-                    <p>
-                        Thorn builds technology to defend children from sexual abuse. Their work focuses on finding
-                        victims of child sex trafficking quickly and eliminating child sexual abuse from the internet.
-                        Thorn partners with tech companies, law enforcement, and other NGOs to build products to find
-                        vulnerable child victims faster. Thorn's software has helped law enforcement reduce
-                        investigation times by 60%, ensuring that more children are found, faster.
-                    </p>
+                <p>
+                    Thorn builds technology to defend children from sexual abuse. Their work focuses on finding
+                    victims of child sex trafficking quickly and eliminating child sexual abuse from the internet.
+                    Thorn partners with tech companies, law enforcement, and other NGOs to build products to find
+                    vulnerable child victims faster. Thorn's software has helped law enforcement reduce
+                    investigation times by 60%, ensuring that more children are found, faster.
+                </p>
 
-                    <h2 className="tw-pt-md tw-pb-1">
-                        Sunsetting deprecated systems was costly and risked production stability
-                    </h2>
-                    <p>
-                        Determining which code relied on legacy architecture was difficult. Developers took too long to
-                        ensure that changes to legacy systems didn't affect production stability.
-                    </p>
-                    <Blockquote quote="Ensuring that changes to legacy systems didn't affect production stability was taking too long." />
+                <h2 className="tw-pt-md tw-pb-1">
+                    Sunsetting deprecated systems was costly and risked production stability
+                </h2>
+                <p>
+                    Determining which code relied on legacy architecture was difficult. Developers took too long to
+                    ensure that changes to legacy systems didn't affect production stability.
+                </p>
+                <Blockquote quote="Ensuring that changes to legacy systems didn't affect production stability was taking too long." />
 
-                    <p>
-                        Over 9,000 officers in 38 countries rely on Thorn to identify child victims of sexual abuse. Any
-                        downtime reduced Thorn's ability to identify these children.
-                    </p>
+                <p>
+                    Over 9,000 officers in 38 countries rely on Thorn to identify child victims of sexual abuse. Any
+                    downtime reduced Thorn's ability to identify these children.
+                </p>
 
-                    <h2 className="tw-pt-md tw-pb-1">Existing tooling was not sufficient</h2>
+                <h2 className="tw-pt-md tw-pb-1">Existing tooling was not sufficient</h2>
 
-                    <p>
-                        Tech debt and upkeep of legacy code were problematic. Previous attempts, such as cloning all
-                        repositories locally and using grep to find references, were inadequate when considering
-                        simultaneous development by multiple teams across many different projects, repositories, and
-                        branches. Determining if all the different microservices were properly in sync when removing
-                        legacy application code was painful.
-                    </p>
+                <p>
+                    Tech debt and upkeep of legacy code were problematic. Previous attempts, such as cloning all
+                    repositories locally and using grep to find references, were inadequate when considering
+                    simultaneous development by multiple teams across many different projects, repositories, and
+                    branches. Determining if all the different microservices were properly in sync when removing
+                    legacy application code was painful.
+                </p>
 
-                    <h2 className="tw-pt-md tw-pb-1">
-                        Sourcegraph's multi-repository code search proved that no code referencing legacy systems
-                        existed across the organization
-                    </h2>
+                <h2 className="tw-pt-md tw-pb-1">
+                    Sourcegraph's multi-repository code search proved that no code referencing legacy systems
+                    existed across the organization
+                </h2>
 
-                    <p>
-                        Thorn Software Engineer Jacob Gillespie deployed Sourcegraph and synced Thorn's entire list of
-                        repositories within minutes. With Sourcegraph, Thorn could search over the contents of every
-                        repository, in any or all branches in seconds. Sourcegraph code search gives Thorn the ability
-                        to find references to deprecated systems.
-                    </p>
+                <p>
+                    Thorn Software Engineer Jacob Gillespie deployed Sourcegraph and synced Thorn's entire list of
+                    repositories within minutes. With Sourcegraph, Thorn could search over the contents of every
+                    repository, in any or all branches in seconds. Sourcegraph code search gives Thorn the ability
+                    to find references to deprecated systems.
+                </p>
 
-                    <p>Sourcegraph is now essential to their code review process. </p>
+                <p>Sourcegraph is now essential to their code review process. </p>
 
-                    <Blockquote quote="In pull requests, team members include links to Sourcegraph code search to prove all references to a deprecated system have been removed, giving the reviewer confidence that the code is safe to merge." />
+                <Blockquote quote="In pull requests, team members include links to Sourcegraph code search to prove all references to a deprecated system have been removed, giving the reviewer confidence that the code is safe to merge." />
 
-                    <h2 className="tw-pt-md tw-pb-1">Deprecated systems were taken offline without downtime</h2>
-                    <p>
-                        Thorn's developers removed or modified deprecated systems, eliminating huge amounts of tech
-                        debt. This benefited all areas of the architecture, including not only application code, but
-                        also build, deployment, logging, and monitoring systems—any tool that supported the deployment
-                        and uptime of the application.
-                    </p>
+                <h2 className="tw-pt-md tw-pb-1">Deprecated systems were taken offline without downtime</h2>
+                <p>
+                    Thorn's developers removed or modified deprecated systems, eliminating huge amounts of tech
+                    debt. This benefited all areas of the architecture, including not only application code, but
+                    also build, deployment, logging, and monitoring systems—any tool that supported the deployment
+                    and uptime of the application.
+                </p>
 
-                    <p className="tw-pb-md">
-                        Using Sourcegraph provides critical support to Thorn's mission. Every start-up has to make
-                        choices about when to rebuild their systems and when to move forward accruing technical debt.
-                        Modern microservice architecture makes the application deprecation process challenging.
-                    </p>
-                </div>
+                <p className="tw-pb-md">
+                    Using Sourcegraph provides critical support to Thorn's mission. Every start-up has to make
+                    choices about when to rebuild their systems and when to move forward accruing technical debt.
+                    Modern microservice architecture makes the application deprecation process challenging.
+                </p>
             </ContentSection>
         </CaseStudyLayout>
     </Layout>

--- a/src/pages/case-studies/workiva-automates-large-scale-code-changes.tsx
+++ b/src/pages/case-studies/workiva-automates-large-scale-code-changes.tsx
@@ -27,112 +27,110 @@ export const CaseStudy: FunctionComponent = () => {
                     image: '/case-studies/trent-grover-workiva.jpg',
                 }}
             >
-                <ContentSection background="white">
-                    <div className="container tw-max-w-4xl">
-                        <p>
-                            Founded in 2008, Workiva's platform enables thousands of enterprises around the world to
-                            manage and report business data. Over 3,000 businesses use Workiva to bring together
-                            everything their business needs—teammates, datasets, and data sources—so they can work
-                            better in the cloud.
-                        </p>
+                <ContentSection background="white" slimWidth={true}>
+                    <p>
+                        Founded in 2008, Workiva's platform enables thousands of enterprises around the world to
+                        manage and report business data. Over 3,000 businesses use Workiva to bring together
+                        everything their business needs—teammates, datasets, and data sources—so they can work
+                        better in the cloud.
+                    </p>
 
-                        <h2 className="tw-pt-md tw-pb-1">Paying down tech debt</h2>
+                    <h2 className="tw-pt-md tw-pb-1">Paying down tech debt</h2>
 
-                        <p>
-                            The Client Platform Team at Workiva is responsible for developing and maintaining the
-                            frameworks and shared libraries that all other products are built on. This includes a shared
-                            UI widget library and maintaining dozens of Dart packages to support Workiva's entire
-                            engineering team.
-                        </p>
+                    <p>
+                        The Client Platform Team at Workiva is responsible for developing and maintaining the
+                        frameworks and shared libraries that all other products are built on. This includes a shared
+                        UI widget library and maintaining dozens of Dart packages to support Workiva's entire
+                        engineering team.
+                    </p>
 
-                        <p>
-                            Any time they shipped a release for one of their packages, they'd also have to propagate it
-                            across 70+ repositories used by other teams to avoid breaking changes. While they developed
-                            their own internal tool to automate these changes, it required ongoing maintenance and
-                            didn't provide end-to-end visibility into the path to completion.
-                        </p>
+                    <p>
+                        Any time they shipped a release for one of their packages, they'd also have to propagate it
+                        across 70+ repositories used by other teams to avoid breaking changes. While they developed
+                        their own internal tool to automate these changes, it required ongoing maintenance and
+                        didn't provide end-to-end visibility into the path to completion.
+                    </p>
 
-                        <Blockquote
-                            quote="Every time I used [our internal tool], I had to fiddle with something just to get it to work."
-                            author="Corwin Sheahan, Senior Software Engineer, Workiva"
-                        />
+                    <Blockquote
+                        quote="Every time I used [our internal tool], I had to fiddle with something just to get it to work."
+                        author="Corwin Sheahan, Senior Software Engineer, Workiva"
+                    />
 
-                        <p>
-                            Whenever a new version of a library came out, they'd either have to manually make the change
-                            across dozens of repositories, spend time improving their internal tool to help automate the
-                            process, or add the update to their backlog.
-                        </p>
+                    <p>
+                        Whenever a new version of a library came out, they'd either have to manually make the change
+                        across dozens of repositories, spend time improving their internal tool to help automate the
+                        process, or add the update to their backlog.
+                    </p>
 
-                        <Blockquote
-                            quote="We fell into the habit of letting tech debt accumulate to the point where all of the sudden we'd have to bring everything to a screeching halt and do nothing for a month or sprint or even a quarter and clean up tech debt around a certain area. The easier the tooling, the faster we can release breaking changes."
-                            author={trentGrover}
-                        />
+                    <Blockquote
+                        quote="We fell into the habit of letting tech debt accumulate to the point where all of the sudden we'd have to bring everything to a screeching halt and do nothing for a month or sprint or even a quarter and clean up tech debt around a certain area. The easier the tooling, the faster we can release breaking changes."
+                        author={trentGrover}
+                    />
 
-                        <h2 className="tw-pt-md tw-pb-1">Automating large-scale updates with Batch Changes</h2>
+                    <h2 className="tw-pt-md tw-pb-1">Automating large-scale updates with Batch Changes</h2>
 
-                        <p>
-                            As an organization that values paying down tech debt, Workiva's Client Platform team started
-                            using Sourcegraph{' '}
-                            <Link href="/batch-changes" passHref={true}>
-                                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                                <a
-                                    title="Batch Changes"
-                                    data-button-style={buttonStyle.text}
-                                    data-button-location={buttonLocation.body}
-                                    data-button-type="cta"
-                                >
-                                    Batch Changes
-                                </a>
-                            </Link>{' '}
-                            to help them efficiently propagate updates to dependencies across all of their repositories
-                            without any ongoing maintenance. The team has already used Batch Changes to:
-                        </p>
+                    <p>
+                        As an organization that values paying down tech debt, Workiva's Client Platform team started
+                        using Sourcegraph{' '}
+                        <Link href="/batch-changes" passHref={true}>
+                            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                            <a
+                                title="Batch Changes"
+                                data-button-style={buttonStyle.text}
+                                data-button-location={buttonLocation.body}
+                                data-button-type="cta"
+                            >
+                                Batch Changes
+                            </a>
+                        </Link>{' '}
+                        to help them efficiently propagate updates to dependencies across all of their repositories
+                        without any ongoing maintenance. The team has already used Batch Changes to:
+                    </p>
 
-                        <ul className="mt-3">
-                            <li>Propagate a new version of React to all frontend repositories</li>
-                            <li>Update API versions of Kubernetes resources</li>
-                            <li>Migrate to a new CDN while updating all code references</li>
-                            <li>
-                                Update UI component syntax as necessary to support a new version of the Dart language
-                            </li>
-                            <li>
-                                Run test batch changes to ensure that new Chrome web browser releases wouldn't result in
-                                any software failures
-                            </li>
-                        </ul>
+                    <ul className="mt-3">
+                        <li>Propagate a new version of React to all frontend repositories</li>
+                        <li>Update API versions of Kubernetes resources</li>
+                        <li>Migrate to a new CDN while updating all code references</li>
+                        <li>
+                            Update UI component syntax as necessary to support a new version of the Dart language
+                        </li>
+                        <li>
+                            Run test batch changes to ensure that new Chrome web browser releases wouldn't result in
+                            any software failures
+                        </li>
+                    </ul>
 
-                        <Blockquote
-                            quote="The fact that Batch Changes runs each step via Docker is super powerful. As long as there's a tool out there that does what you need, you can incorporate it into Batch Changes with minimal effort, and that's been awesome for us."
-                            author="Evan Weible, Staff Software Engineer, Workiva"
-                        />
+                    <Blockquote
+                        quote="The fact that Batch Changes runs each step via Docker is super powerful. As long as there's a tool out there that does what you need, you can incorporate it into Batch Changes with minimal effort, and that's been awesome for us."
+                        author="Evan Weible, Staff Software Engineer, Workiva"
+                    />
 
-                        <h2 className="tw-pt-md tw-pb-1">
-                            Workiva reduces the time it takes to make large-scale code changes by 80%
-                        </h2>
+                    <h2 className="tw-pt-md tw-pb-1">
+                        Workiva reduces the time it takes to make large-scale code changes by 80%
+                    </h2>
 
-                        <p>
-                            The Client Platform team has already used Batch Changes numerous times to propagate
-                            large-scale updates to the frameworks and shared libraries they maintain. In comparison to
-                            manually making these changes, Batch Changes reduces the time it takes to make large-scale
-                            code changes by 80%.
-                        </p>
+                    <p>
+                        The Client Platform team has already used Batch Changes numerous times to propagate
+                        large-scale updates to the frameworks and shared libraries they maintain. In comparison to
+                        manually making these changes, Batch Changes reduces the time it takes to make large-scale
+                        code changes by 80%.
+                    </p>
 
-                        <Blockquote
-                            quote="Updating all of our repositories with Batch Changes saves time, is less error-prone, and gives us confidence that everything is going to plan."
-                            author="Joe Bingham, Software Engineer, Workiva"
-                        />
+                    <Blockquote
+                        quote="Updating all of our repositories with Batch Changes saves time, is less error-prone, and gives us confidence that everything is going to plan."
+                        author="Joe Bingham, Software Engineer, Workiva"
+                    />
 
-                        <p>
-                            Instead of spending time maintaining their internal tool, the Workiva team will be using
-                            Batch Changes going forward.
-                        </p>
+                    <p>
+                        Instead of spending time maintaining their internal tool, the Workiva team will be using
+                        Batch Changes going forward.
+                    </p>
 
-                        <Blockquote
-                            quote="Using a tool that isn't maintained by us saves us time and drives better adoption. In comparison to the tool we built internally, it's much easier to work with, more feature complete, and well documented."
-                            author="Evan Weible, Staff Software Engineer, Workiva"
-                        />
-                        <br />
-                    </div>
+                    <Blockquote
+                        quote="Using a tool that isn't maintained by us saves us time and drives better adoption. In comparison to the tool we built internally, it's much easier to work with, more feature complete, and well documented."
+                        author="Evan Weible, Staff Software Engineer, Workiva"
+                    />
+                    <br />
                 </ContentSection>
             </CaseStudyLayout>
         </Layout>

--- a/src/pages/case-studies/workiva-automates-large-scale-code-changes.tsx
+++ b/src/pages/case-studies/workiva-automates-large-scale-code-changes.tsx
@@ -28,7 +28,7 @@ export const CaseStudy: FunctionComponent = () => {
                 }}
             >
                 <ContentSection background="white">
-                    <div className="container">
+                    <div className="container tw-max-w-4xl">
                         <p>
                             Founded in 2008, Workiva's platform enables thousands of enterprises around the world to
                             manage and report business data. Over 3,000 businesses use Workiva to bring together


### PR DESCRIPTION
Hot fix:
- Adds a uniform max-width for long form text sections according to [DLS](https://www.figma.com/file/o1QRtdQI0ozKq0n7ATrKlx/Marketing-DLS?node-id=9002%3A38609) (Follow up to #5682)
- Fixes UI bug where text color wasn't being applied correctly to CtaSections ([thread](https://sourcegraph.slack.com/archives/C02PHT4RQDC/p1662482319725079))

### Changelog
""
- Long form max-width unit needs confirmation on Figma
- All CtaSections apply the correct colors now

### Test
1. Ensure prettier has standardized the proposed changes.
2. Smoke test widths on all long form text pages (Older Case Studies should conform to new layout soon, so other UI quirks should be ignored here).
3. Smoke test all CtaSections
