### PR TITLE
UTM Source for demo CTAs on blog pages

### DIFF
--- a/src/components/Layout/Header/DesktopNav.tsx
+++ b/src/components/Layout/Header/DesktopNav.tsx
@@ -1,4 +1,4 @@
-import { FunctionComponent } from 'react'
+import { FunctionComponent, useEffect, useState } from 'react'
 
 import { camelCase } from 'lodash'
 import Nav from 'react-bootstrap/Nav'
@@ -13,43 +13,21 @@ interface Props {
     hideGetStartedButton: boolean | undefined
 }
 
-const DesktopNav: FunctionComponent<Props> = ({ navLinks, hideGetStartedButton }) => (
-    <>
-        <Nav className="mr-auto left-nav ml-lg-5">
-            {navLinks.map(navLink =>
-                navLink.items.length === 1 ? (
-                    navLink.items.map((item: { href: string; title: string }) =>
-                        item.href.includes('http') ? (
-                            <Nav.Link
-                                key={camelCase(item.title)}
-                                href={item.href}
-                                target="_blank"
-                                rel="noreferrer"
-                                title={item.title}
-                                data-button-style={buttonStyle.text}
-                                data-button-location={buttonLocation.nav}
-                                data-button-type="cta"
-                            >
-                                {item.title}
-                            </Nav.Link>
-                        ) : (
-                            <Nav.Link
-                                key={camelCase(item.title)}
-                                href={item.href}
-                                title={item.title}
-                                data-button-style={buttonStyle.text}
-                                data-button-location={buttonLocation.nav}
-                                data-button-type="cta"
-                            >
-                                {item.title}
-                            </Nav.Link>
-                        )
-                    )
-                ) : (
-                    <NavDropdown key={navLink.section} id={camelCase(navLink.section)} title={navLink.section}>
-                        {navLink.items.map(item =>
+const DesktopNav: FunctionComponent<Props> = ({ navLinks, hideGetStartedButton }) => {
+    const [isBlog, setIsBlog] = useState(false)
+
+    useEffect(() => {
+        setIsBlog(window.location.pathname.includes('/blog'))
+    }, [])
+
+    return (
+        <>
+            <Nav className="mr-auto left-nav ml-lg-5">
+                {navLinks.map(navLink =>
+                    navLink.items.length === 1 ? (
+                        navLink.items.map((item: { href: string; title: string }) =>
                             item.href.includes('http') ? (
-                                <NavDropdown.Item
+                                <Nav.Link
                                     key={camelCase(item.title)}
                                     href={item.href}
                                     target="_blank"
@@ -60,9 +38,9 @@ const DesktopNav: FunctionComponent<Props> = ({ navLinks, hideGetStartedButton }
                                     data-button-type="cta"
                                 >
                                     {item.title}
-                                </NavDropdown.Item>
+                                </Nav.Link>
                             ) : (
-                                <NavDropdown.Item
+                                <Nav.Link
                                     key={camelCase(item.title)}
                                     href={item.href}
                                     title={item.title}
@@ -71,53 +49,83 @@ const DesktopNav: FunctionComponent<Props> = ({ navLinks, hideGetStartedButton }
                                     data-button-type="cta"
                                 >
                                     {item.title}
-                                </NavDropdown.Item>
+                                </Nav.Link>
                             )
-                        )}
-                    </NavDropdown>
-                )
-            )}
-        </Nav>
+                        )
+                    ) : (
+                        <NavDropdown key={navLink.section} id={camelCase(navLink.section)} title={navLink.section}>
+                            {navLink.items.map(item =>
+                                item.href.includes('http') ? (
+                                    <NavDropdown.Item
+                                        key={camelCase(item.title)}
+                                        href={item.href}
+                                        target="_blank"
+                                        rel="noreferrer"
+                                        title={item.title}
+                                        data-button-style={buttonStyle.text}
+                                        data-button-location={buttonLocation.nav}
+                                        data-button-type="cta"
+                                    >
+                                        {item.title}
+                                    </NavDropdown.Item>
+                                ) : (
+                                    <NavDropdown.Item
+                                        key={camelCase(item.title)}
+                                        href={item.href}
+                                        title={item.title}
+                                        data-button-style={buttonStyle.text}
+                                        data-button-location={buttonLocation.nav}
+                                        data-button-type="cta"
+                                    >
+                                        {item.title}
+                                    </NavDropdown.Item>
+                                )
+                            )}
+                        </NavDropdown>
+                    )
+                )}
+            </Nav>
 
-        <Nav className="right-nav lg:tw-justify-end">
-            {!hideGetStartedButton && (
+            <Nav className="right-nav lg:tw-justify-end">
+                {!hideGetStartedButton && (
+                    <Nav.Link
+                        className="px-2 py-2 btn tw-text-blurple-400 font-weight-bold"
+                        href="https://sourcegraph.com/search"
+                        title="Search code"
+                        data-button-style={buttonStyle.text}
+                        data-button-location={buttonLocation.nav}
+                        data-button-type="cta"
+                    >
+                        Search code
+                    </Nav.Link>
+                )}
+
                 <Nav.Link
-                    className="px-2 py-2 btn tw-text-blurple-400 font-weight-bold"
-                    href="https://sourcegraph.com/search"
-                    title="Search code"
-                    data-button-style={buttonStyle.text}
+                    className="px-5 py-2 ml-3 btn btn-outline-primary font-weight-bold"
+                    href={`/demo${isBlog ? '?utm_source=blog-integrations-update' : ''}`}
+                    title="Request a demo"
+                    data-button-style={buttonStyle.outline}
                     data-button-location={buttonLocation.nav}
                     data-button-type="cta"
                 >
-                    Search code
+                    Request a demo
                 </Nav.Link>
-            )}
 
-            <Nav.Link
-                className="px-5 py-2 ml-3 btn btn-outline-primary font-weight-bold"
-                href="/demo"
-                title="Request a demo"
-                data-button-style={buttonStyle.outline}
-                data-button-location={buttonLocation.nav}
-                data-button-type="cta"
-            >
-                Request a demo
-            </Nav.Link>
-
-            {!hideGetStartedButton && (
-                <Nav.Link
-                    className="px-5 py-2 ml-3 btn btn-primary font-weight-bold"
-                    href="/get-started/self-hosted"
-                    title="Get started"
-                    data-button-style={buttonStyle.primary}
-                    data-button-location={buttonLocation.nav}
-                    data-button-type="cta"
-                >
-                    Get Started
-                </Nav.Link>
-            )}
-        </Nav>
-    </>
-)
+                {!hideGetStartedButton && (
+                    <Nav.Link
+                        className="px-5 py-2 ml-3 btn btn-primary font-weight-bold"
+                        href="/get-started/self-hosted"
+                        title="Get started"
+                        data-button-style={buttonStyle.primary}
+                        data-button-location={buttonLocation.nav}
+                        data-button-type="cta"
+                    >
+                        Get Started
+                    </Nav.Link>
+                )}
+            </Nav>
+        </>
+    )
+}
 
 export default DesktopNav

--- a/src/pages/blog/[...slug].tsx
+++ b/src/pages/blog/[...slug].tsx
@@ -66,7 +66,7 @@ const BlogPage: NextPage<PageProps> = ({ post, content }) => {
                 }}
                 cta2={{
                     text: 'Schedule a demo',
-                    link: '/demo',
+                    link: '/demo?utm_source=blog-integrations-update',
                     ctaStyle: 'outlineButton',
                 }}
             />


### PR DESCRIPTION
This closes #5707 by adding UTM sources to our demo CTAs on blog pages.

### Changelog
- added UTM source on the blog `CtaSection` demo CTA button
- added UTM source on our demo CTA in the top nav for blog pages only

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure demo CTAs in the `CtaSection` and top nav have UTM sources applied for blog pages only