### PR TITLE
Link fix in Blockquote component

### DIFF
--- a/src/components/Blockquote.tsx
+++ b/src/components/Blockquote.tsx
@@ -98,38 +98,32 @@ export const Blockquote: FunctionComponent<{
 
             {link?.href &&
                 (link?.href.includes('http') ? (
-                    <>
-                        <br />
+                    <a
+                        className={classNames('tw-mt-md tw-flex', !border && 'tw-justify-center')}
+                        href={link.href}
+                        target="_blank"
+                        rel="nofollow noreferrer"
+                        title={link.text}
+                        data-button-style={buttonStyle.textWithArrow}
+                        data-button-location={buttonLocation.body}
+                        data-button-type="cta"
+                    >
+                        {link.text}
+                        <ArrowRightIcon className="ml-1 tw-inline" />
+                    </a>
+                ) : (
+                    <Link href={link.href}>
+                        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                         <a
-                            className={classNames('tw-mt-4 tw-flex', !border && 'tw-justify-center')}
-                            href={link.href}
-                            target="_blank"
-                            rel="nofollow noreferrer"
+                            className={classNames('tw-mt-md tw-flex', !border && 'tw-justify-center')}
                             title={link.text}
                             data-button-style={buttonStyle.textWithArrow}
                             data-button-location={buttonLocation.body}
                             data-button-type="cta"
                         >
                             {link.text}
-                            <ArrowRightIcon className="ml-1 tw-inline" />
+                            <ArrowRightIcon className="tw-ml-1 tw-inline" />
                         </a>
-                    </>
-                ) : (
-                    <Link href={link.href} passHref={true}>
-                        <>
-                            <br />
-                            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                            <a
-                                className={classNames('tw-mt-4 tw-flex', !border && 'tw-justify-center')}
-                                title={link.text}
-                                data-button-style={buttonStyle.textWithArrow}
-                                data-button-location={buttonLocation.body}
-                                data-button-type="cta"
-                            >
-                                <p className="tw-mb-0">{link.text}</p>
-                                <ArrowRightIcon className="tw-ml-1 tw-inline" />
-                            </a>
-                        </>
                     </Link>
                 ))}
         </blockquote>


### PR DESCRIPTION
This fixes broken links in our Blockquote component to match the API spec for Next.js' Link component. This closes #5747 .

### Changelog
- Removed react fragment as the child of the Link component in lieu of the `a` element directly as the child

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure links are working as expected on our Use Case pages in Blockquote sections and Blockquote Carousels where there are links that read "read the case study"
