### PR TITLE
Universal and GA4 analytics

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -66,15 +66,26 @@ export default class MyDocument extends Document {
                     <Script id="ga" data-cookieconsent="ignore" async={true} strategy="beforeInteractive">
                         {`
                         window.dataLayer = window.dataLayer || [];
+                        
                         function gtag() {
                             dataLayer.push(arguments);
                         }
+                        
                         gtag("consent", "default", {
                             ad_storage: "denied",
                             analytics_storage: "denied",
-                        wait_for_update: 500,
+                            wait_for_update: 500,
                         });
+                        
                         gtag("set", "ads_data_redaction", true);
+                        
+                        gtag('js', new Date());
+                        
+                        // Universal
+                        gtag('config', 'UA-40540747-17');
+                        
+                        // GA-4
+                        gtag('config', 'G-E82CCDYYS1');
                     `}
                     </Script>
 


### PR DESCRIPTION
This is a follow up to #5743, manually adding our universal GA gtag ID, and the new GA4 gtag ID which is referenced and linked from our GTM ID.