### PR TITLE
Remove async and manual gtag script

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -42,17 +42,16 @@ export default class MyDocument extends Document {
                         data-cbid="fb31dc3e-afb3-4be8-ae84-7090bba7797d"
                         data-blockingmode="auto"
                         type="text/javascript"
-                        async={true}
                         strategy="beforeInteractive"
                     />
 
                     {/* Google Tag Manager Data Layer Window */}
-                    <Script id="gtm-data-layer" async={true} strategy="beforeInteractive">
+                    <Script id="gtm-data-layer" strategy="beforeInteractive">
                         window.dataLayer = window.dataLayer || [];
                     </Script>
 
                     {/* Google Tag Manager */}
-                    <Script id="gtm" data-cookieconsent="ignore" async={true} strategy="beforeInteractive">
+                    <Script id="gtm" data-cookieconsent="ignore" strategy="beforeInteractive">
                         {`
                             (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
                             new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
@@ -62,8 +61,9 @@ export default class MyDocument extends Document {
                         `}
                     </Script>
 
-                    {/* Google Analytics */}
-                    <Script id="ga" data-cookieconsent="ignore" async={true} strategy="beforeInteractive">
+                    {/* Google Analytics Data Layer Settings */}
+                    {/* Note: GA is configured via GTM */}
+                    <Script id="ga" data-cookieconsent="ignore" strategy="beforeInteractive">
                         {`
                         window.dataLayer = window.dataLayer || [];
                         
@@ -78,14 +78,6 @@ export default class MyDocument extends Document {
                         });
                         
                         gtag("set", "ads_data_redaction", true);
-                        
-                        gtag('js', new Date());
-                        
-                        // Universal
-                        gtag('config', 'UA-40540747-17');
-                        
-                        // GA-4
-                        gtag('config', 'G-E82CCDYYS1');
                     `}
                     </Script>
 


### PR DESCRIPTION
This is a follow up to #5743

### Changelog
- removes async attributes for scripts needing to load immediately to ensure tracking
- removes manual calls to `gtag` since GA/GA4 is configured in GTM

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure new sessions and data is being tracked in [GA](https://analytics.google.com/analytics/web/#/report-home/a40540747w150533180p155508056/%3F_u.date00=20220919&_u.date01=20220920) and [GA4](https://analytics.google.com/analytics/web/#/p250155169/reports/intelligenthome?params=_u..nav%3Dmaui) post-merge

