### PR TITLE
Next.js script recommendations

### DIFF
--- a/cypress/e2e/scripts.test.ts
+++ b/cypress/e2e/scripts.test.ts
@@ -10,8 +10,8 @@ beforeEach(() => {
     cy.visit('/')
 })
 
-describe('Analytics', () => {
-    it('has a data layer for GTM and GTM loads', () => {
+describe('Google Tag Manager', () => {
+    it('has a data layer and gtm.js loads', () => {
         cy.window().then(window => {
             assert.isDefined(window.dataLayer, 'window.dataLayer is defined')
             assert.isDefined(
@@ -21,37 +21,32 @@ describe('Analytics', () => {
         })
     })
 
-    it('renders a GTM Data Layer script tag in the head and should not have a src attribute', () => {
-        cy.get('#gtm-data-layer').should('not.have.attr', 'src')
-        cy.get('#gtm-data-layer').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
+    it('renders a GTM Data Layer script tag in the body and should not have a src attribute', () => {
+        cy.get('#script-gtm-data-layer').should('not.have.attr', 'src')
+        cy.get('#script-gtm-data-layer').parent().should('have.prop', 'tagName').should('equal', 'BODY')
     })
 
-    it('renders a GTM script tag in the head and should not have a src attribute', () => {
-        cy.get('#gtm').should('not.have.attr', 'src')
-        cy.get('#gtm').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
-    })
-
-    it('renders a GA script tag in the head and should not have a src attribute', () => {
-        cy.get('#ga').should('not.have.attr', 'src')
-        cy.get('#ga').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
+    it('renders a GTM script tag in the body and should not have a src attribute', () => {
+        cy.get('#script-gtm').should('not.have.attr', 'src')
+        cy.get('#script-gtm').parent().should('have.prop', 'tagName').should('equal', 'BODY')
     })
 })
 
 describe('Third party scripts', () => {
     it('renders Cookiebot script in the head', () => {
-        cy.get('#cookiebot').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
+        cy.get('#script-cookiebot').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
     })
 
     it('renders Triblio web personalization script in the head', () => {
-        cy.get('#triblio-p').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
+        cy.get('#script-triblio-personalization').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
     })
 
     it('renders Triblio Analaytics and Overlay Cards script in the body', () => {
-        cy.get('#triblio-a').parent().should('have.prop', 'tagName').should('equal', 'BODY')
+        cy.get('#script-triblio-analytics').parent().should('have.prop', 'tagName').should('equal', 'BODY')
     })
 
     it('renders Drift script in the body', () => {
-        cy.get('#drift').parent().should('have.prop', 'tagName').should('equal', 'BODY')
+        cy.get('#script-drift').parent().should('have.prop', 'tagName').should('equal', 'BODY')
     })
 })
 

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -7,7 +7,6 @@ import '@styles/globals.scss'
 import { ReactNode } from 'react'
 
 import type { AppProps } from 'next/app'
-import Script from 'next/script'
 import SSRProvider from 'react-bootstrap/SSRProvider'
 
 import { useEventLogger, useLogAllLinkClicks, useLandingSource } from '@hooks'
@@ -22,46 +21,6 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
     return (
         <>
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-
-            {/* // Import all top-level scripts here: https://nextjs.org/docs/messages/no-script-in-document-page */}
-
-            {/* Triblio "Analytics and Overlay Cards" */}
-            <Script
-                id="triblio-a"
-                type="text/javascript"
-                src="https://tribl.io/footer.js?orgId=Yee6bMKj7QSARqAePdE8"
-                strategy="afterInteractive"
-                defer={true}
-            />
-
-            {/* Drift */}
-            <Script id="drift" type="text/javascript" strategy="afterInteractive" defer={true}>
-                {`
-                    "use strict";
-                    !function() {
-                    var t = window.driftt = window.drift = window.driftt || [];
-                    if (!t.init) {
-                        if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
-                        t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ], 
-                        t.factory = function(e) {
-                        return function() {
-                            var n = Array.prototype.slice.call(arguments);
-                            return n.unshift(e), t.push(n), t;
-                        };
-                        }, t.methods.forEach(function(e) {
-                        t[e] = t.factory(e);
-                        }), t.load = function(t) {
-                        var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
-                        o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
-                        var i = document.getElementsByTagName("script")[0];
-                        i.parentNode.insertBefore(o, i);
-                        };
-                    }
-                    }();
-                    drift.SNIPPET_VERSION = '0.3.1';
-                    drift.load('bgv3pp29xsp9');
-                `}
-            </Script>
 
             <SSRProvider>
                 <Component {...pageProps} />

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -15,17 +15,11 @@ export default class MyDocument extends Document {
 
                     <link rel="icon" type="image/png" href="/favicon.png" />
 
-                    {/* TODO Implement RSS Feed */}
-                    {/* <link rel="alternate" type="application/rss+xml" title="Universal Code Search - Sourcegraph" href="/rss.xml" /> */}
-
                     {/* Sourcegraph Chrome Extension */}
                     <link
                         rel="chrome-webstore-item"
                         href="https://chrome.google.com/webstore/detail/dgjhfomjieaadpoljlnidmbgkdffpack"
                     />
-
-                    {/* Adobe Source Sans Pro Fonts */}
-                    <link rel="stylesheet" href="https://use.typekit.net/ngk3rlb.css" />
 
                     {/* Google Fonts */}
                     <link rel="preconnect" href="https://fonts.googleapis.com" />
@@ -36,8 +30,9 @@ export default class MyDocument extends Document {
                     />
 
                     {/* Cookiebot */}
+                    {/* Cookiebot recommends this in the head, which aligns with Next.js' recommendation for CCMs */}
                     <Script
-                        id="cookiebot"
+                        id="script-cookiebot"
                         src="https://consent.cookiebot.com/uc.js"
                         data-cbid="fb31dc3e-afb3-4be8-ae84-7090bba7797d"
                         data-blockingmode="auto"
@@ -45,25 +40,10 @@ export default class MyDocument extends Document {
                         strategy="beforeInteractive"
                     />
 
-                    {/* Google Tag Manager Data Layer Window */}
-                    <Script id="gtm-data-layer" strategy="beforeInteractive">
-                        window.dataLayer = window.dataLayer || [];
-                    </Script>
-
-                    {/* Google Tag Manager */}
-                    <Script id="gtm" data-cookieconsent="ignore" strategy="beforeInteractive">
-                        {`
-                            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
-                            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
-                            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-                            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
-                        })(window,document,'script','dataLayer','GTM-TB4NLS7');  
-                        `}
-                    </Script>
-
-                    {/* Google Analytics Data Layer Settings */}
-                    {/* Note: GA is configured via GTM */}
-                    <Script id="ga" data-cookieconsent="ignore" strategy="beforeInteractive">
+                    {/* GTM Data Layer */}
+                    {/* Google recommends this in the head, but Next.js recommends afterInteractive */}
+                    {/* Note: Deprecate gtag UA config when we've migrated to GA4 */}
+                    <Script id="script-gtm-data-layer" data-cookieconsent="ignore" strategy="afterInteractive">
                         {`
                         window.dataLayer = window.dataLayer || [];
                         
@@ -78,17 +58,73 @@ export default class MyDocument extends Document {
                         });
                         
                         gtag("set", "ads_data_redaction", true);
+                        
+                        gtag('js', new Date());
+                        gtag('config', 'UA-40540747-17');
                     `}
                     </Script>
 
+                    {/* Google Tag Manager */}
+                    {/* Google recommends this in the head, but Next.js recommends afterInteractive */}
+                    <Script id="script-gtm" data-cookieconsent="ignore" strategy="afterInteractive">
+                        {`
+                            (function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
+                            new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
+                            j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
+                            'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+                            })(window,document,'script','dataLayer','GTM-TB4NLS7');  
+                        `}
+                    </Script>
+
                     {/* Triblio "Webpage Personalization" */}
+                    {/* Triblio recommends this in the head which we follow with beforeInteractive */}
                     <Script
-                        id="triblio-p"
+                        id="script-triblio-personalization"
                         type="text/javascript"
                         src="https://tribl.io/h.js?orgId=Yee6bMKj7QSARqAePdE8"
                         async={true}
                         strategy="beforeInteractive"
                     />
+
+                    {/* Triblio "Analytics and Overlay Cards" */}
+                    {/* Triblio recommends this in the body which aligns with Next.js' recommendation for analytics */}
+                    <Script
+                        id="script-triblio-analytics"
+                        type="text/javascript"
+                        src="https://tribl.io/footer.js?orgId=Yee6bMKj7QSARqAePdE8"
+                        strategy="afterInteractive"
+                        defer={true}
+                    />
+
+                    {/* Drift */}
+                    {/* Drift recommends this in the head, but Next.js recommends chat bots afterInteractive */}
+                    <Script id="script-drift" type="text/javascript" strategy="afterInteractive" defer={true}>
+                        {`
+                            "use strict";
+                            !function() {
+                            var t = window.driftt = window.drift = window.driftt || [];
+                            if (!t.init) {
+                                if (t.invoked) return void (window.console && console.error && console.error("Drift snippet included twice."));
+                                t.invoked = !0, t.methods = [ "identify", "config", "track", "reset", "debug", "show", "ping", "page", "hide", "off", "on" ], 
+                                t.factory = function(e) {
+                                return function() {
+                                    var n = Array.prototype.slice.call(arguments);
+                                    return n.unshift(e), t.push(n), t;
+                                };
+                                }, t.methods.forEach(function(e) {
+                                t[e] = t.factory(e);
+                                }), t.load = function(t) {
+                                var e = 3e5, n = Math.ceil(new Date() / e) * e, o = document.createElement("script");
+                                o.type = "text/javascript", o.async = !0, o.crossorigin = "anonymous", o.src = "https://js.driftt.com/include/" + n + "/" + t + ".js";
+                                var i = document.getElementsByTagName("script")[0];
+                                i.parentNode.insertBefore(o, i);
+                                };
+                            }
+                            }();
+                            drift.SNIPPET_VERSION = '0.3.1';
+                            drift.load('bgv3pp29xsp9');
+                        `}
+                    </Script>
                 </Head>
                 <body>
                     {/* Google Tag Manager (noscript) */}


### PR DESCRIPTION
This is another follow up to #5743 following the recommendations in [the Next.js docs](https://nextjs.org/docs/basic-features/script) for scripts.

For context, there is conflicting documentation between different services and Next.js which I've noted in comments above each script. The tests follow the recommendations of Next.js.

### Changelog
- moved all scripts to `_document`
- updated tests and script loading strategies to follow recommendations of Next.js
- manually declared Google Analytics UA gtag since it was not firing via triggers in GTM (potentially due to GA4 taking precedence)
- updated the names of the script id's to include the `script-` prefix for easier debugging in Chrome Dev Tools to ensure placements

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure tests pass
3. Ensure GTM data flows:
    1. Pull down and start our local dev environment
    2. Open our sourcegraph.com container in [GTM](https://tagmanager.google.com/#/container/accounts/6000399571/containers/30433084/workspaces/126) and click the Preview button in the top right of the dashboard.
   3. Connect to `http://localhost:3000` which will open a new tab. You may need the [Tag Assistant Companion](https://chrome.google.com/webstore/detail/tag-assistant-companion/jmekfmbnaedfebfnmakmokmlfpblbfdm) extension. 
    4. Jump back to the GTM tab and press Continue.
    5. You should see 3 Google Containers Found in the top left, listing all the tags fired by triggers.
    6. Click around in in our dev environment and watch the triggers fire tags. All 3; GTM, UA, and GA4 containers should be receiving data.