### PR TITLE
rename blog from "strings: the Sourcegraph blog" to just "Sourcegraph blog"

### DIFF
--- a/src/components/Blog/postTypes.tsx
+++ b/src/components/Blog/postTypes.tsx
@@ -6,17 +6,18 @@ import { PodcastSubscribeLinks } from '../Podcast/PodcastSubscribeLinks'
 
 export const BLOG_TYPE_TO_INFO: Record<BlogType, BlogTypeInfo> = {
     blog: {
-        title: 'strings: the Sourcegraph blog',
+        title: 'Blog',
         baseUrl: '/blog',
         belowTitle: (
             <>
-                <p className="mb-1 tw-text-xl">A collection of characters, stories, and other elements</p>
+                <p className="mb-1 tw-text-xl">
+                    Our changelog, announcements, dev posts, and anything else we think you'll find interesting.
+                </p>
             </>
         ),
         meta: {
-            title: 'strings: the Sourcegraph blog',
-            description:
-                "News from Sourcegraph: our changelog, announcements, tech blog posts, and anything else we think you'll find interesting.",
+            title: 'Sourcegraph blog',
+            description: "Our changelog, announcements, dev posts, and anything else we think you'll find interesting.",
         },
     },
     press: {


### PR DESCRIPTION
Also make the description more precise and less whimsical.

Why? I don't know why we called it "strings" in the first place, and I'm not aware of any good reason to keep that name. It's confusing, less descriptive, and feels like it's "trying too hard to be cool"

# before

![image](https://user-images.githubusercontent.com/1976/192158408-fa476c70-bbbc-4e6c-adc9-2fc8cb5ed4ae.png)


# after 

![image](https://user-images.githubusercontent.com/1976/192158360-a710edde-2d15-4b9e-b335-09346bfac126.png)
