### PR TITLE
Update launch time to 16:00 UTC

### DIFF
--- a/src/pages/sourcegraph-4.tsx
+++ b/src/pages/sourcegraph-4.tsx
@@ -47,7 +47,7 @@ const Sourcegraph4: FunctionComponent = () => {
         seconds: '0',
         launched: false,
     })
-    const launchDate = new Date('September 27, 2022 13:00 UTC').getTime()
+    const launchDate = new Date('September 27, 2022 16:00 UTC').getTime()
     const second = 1000
     const minute = second * 60
     const hour = minute * 60


### PR DESCRIPTION
The [calendar event](https://www.addevent.com/event/EJ14905143) says the event is at 16:00 UTC:

<img width="725" alt="screenshot_2022-09-27_11 19 50@2x" src="https://user-images.githubusercontent.com/1185253/192487458-53682ecf-d2c2-4200-bc82-ebf5a79351b6.png">


