### PR TITLE
4.0 landing page h1 width

### DIFF
--- a/src/pages/sourcegraph-4.tsx
+++ b/src/pages/sourcegraph-4.tsx
@@ -31,7 +31,7 @@ const Sourcegraph4: FunctionComponent = () => (
         className="navbar-dark"
         hero={
             <div className="tw-px-sm tw-py-3xl md:tw-py-5xl">
-                <div className="tw-max-w-[800px] tw-mx-auto tw-text-center tw-text-white">
+                <div className="tw-max-w-[850px] tw-mx-auto tw-text-center tw-text-white">
                     <img
                         src="/sourcegraph/sourcegraph-4-starship-reflected.svg"
                         alt="Sourcegraph 4.0 Starship"
@@ -39,7 +39,7 @@ const Sourcegraph4: FunctionComponent = () => (
                     />
 
                     <h1 className="tw-mb-sm -tw-mt-3xl sm:-tw-mt-36">From code search to code intelligence</h1>
-                    <h3 className="tw-mb-5xl">
+                    <h3 className="tw-mb-5xl tw-mx-auto tw-max-w-3xl">
                         Sourcegraph 4.0, the latest release of our code intelligence platform, is now available. Watch
                         the livestream.
                     </h3>


### PR DESCRIPTION
Adds more max width on 4.0 landing page's h1 so it sits on 1 line (and aligns with it's [Figma spec](https://www.figma.com/file/FrXCB2MwgntaBDtkQLvtYz/Sourcegraph-4.0?node-id=671%3A7998))

BEFORE
<img width="1066" alt="image" src="https://user-images.githubusercontent.com/59381432/192541175-2f18c9aa-febc-4e7b-aa88-13a895c9396f.png">

NOW
![image](https://user-images.githubusercontent.com/59381432/192541207-83652f93-32d1-4689-a006-34eb05bb6a2b.png)

### Test
1. Ensure prettier has standardized the proposed changes.
2. Nav to `/sourcegraph-4` & observe the h1 width