### PR TITLE
Livestream timestamp

### DIFF
--- a/src/pages/sourcegraph-4.tsx
+++ b/src/pages/sourcegraph-4.tsx
@@ -39,9 +39,9 @@ const Sourcegraph4: FunctionComponent = () => (
                     />
 
                     <h1 className="tw-mb-sm -tw-mt-3xl sm:-tw-mt-36">From code search to code intelligence</h1>
-                    <h3 className="tw-mb-5xl tw-mx-auto tw-max-w-3xl">
+                    <h3 className="tw-mb-5xl tw-mx-auto tw-max-w-4xl">
                         Sourcegraph 4.0, the latest release of our code intelligence platform, is now available. Watch
-                        the livestream.
+                        the livestream at 16:00 UTC today.
                     </h3>
 
                     <TwitchEmbed channel="sourcegraph" width={800} className="tw-w-full" />


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/59381432/192552672-68434e07-4817-44b3-926b-314452536537.png)

Adds timestamp to livestream announcement

### Test
1. Ensure prettier has standardized the proposed changes.
2. Nav to `/sourcegraph-4` and observe description above twitch embed