### PR TITLE
Bring back "Search code" link in top nav

### DIFF
--- a/src/components/Layout/Header/DesktopNav.tsx
+++ b/src/components/Layout/Header/DesktopNav.tsx
@@ -88,6 +88,17 @@ const DesktopNav: FunctionComponent<Props> = ({ navLinks, hideGetStartedButton }
 
             <Nav className="right-nav lg:tw-justify-end">
                 <Nav.Link
+                    className="px-2 py-2 btn tw-text-blurple-400 font-weight-bold"
+                    href="https://sourcegraph.com/search"
+                    title="Search code"
+                    data-button-style={buttonStyle.text}
+                    data-button-location={buttonLocation.nav}
+                    data-button-type="cta"
+                >
+                    Search code
+                </Nav.Link>
+
+                <Nav.Link
                     className="px-5 py-2 ml-3 btn btn-outline-primary font-weight-bold"
                     href={`/demo${isBlog ? '?utm_source=blog-integrations-update' : ''}`}
                     title="Request a demo"

--- a/src/components/Layout/Header/MobileNav.tsx
+++ b/src/components/Layout/Header/MobileNav.tsx
@@ -125,6 +125,20 @@ const MobileNav: FunctionComponent<Props> = ({ navLinks, hideGetStartedButton, i
                         </li>
                     )
                 )}
+
+                <li className="nav-item" role="presentation">
+                    <a
+                        className="nav-link"
+                        href="https://sourcegraph.com/search"
+                        title="Search code"
+                        data-button-style={buttonStyle.text}
+                        data-button-location={buttonLocation.nav}
+                        data-button-type="cta"
+                    >
+                        Search code
+                    </a>
+                </li>
+
                 <li className="nav-item" role="presentation">
                     <a
                         className="nav-link"


### PR DESCRIPTION
Bring back the "search code" nav link so users can find it more easily.

### Changelog
- added to desktop nav
- added to mobile nav

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure "search code" goes to dot com