### PR TITLE
4.0 post launch updates

### DIFF
--- a/src/components/Badge.tsx
+++ b/src/components/Badge.tsx
@@ -22,6 +22,7 @@ interface Badge {
     onClick?: () => void
     checked?: boolean
     circle?: boolean
+    breakWords?: boolean
 }
 
 /**
@@ -36,6 +37,7 @@ interface Badge {
  * @param props.onClick - an onClick function
  * @param props.checked - the controlled checked state
  * @param props.circle - whether it's a basic or circle radius badge
+ * @param props.breakWords - whether to break words or not for longer text
  */
 export const Badge: FunctionComponent<Badge> = ({
     text,
@@ -46,6 +48,7 @@ export const Badge: FunctionComponent<Badge> = ({
     onClick,
     checked,
     circle,
+    breakWords,
 }) => {
     const Icon: ElementType = icon || 'div'
 
@@ -124,7 +127,7 @@ export const Badge: FunctionComponent<Badge> = ({
     }
 
     const styles = classNames(
-        'tw-inline tw-font-mono tw-align-middle tw-font-medium tw-whitespace-nowrap',
+        'tw-inline tw-font-mono tw-align-middle tw-font-medium',
         sizes[size],
         colors[color].base,
         {
@@ -134,7 +137,8 @@ export const Badge: FunctionComponent<Badge> = ({
             'tw-cursor-pointer tw-transition-all tw-ease-out': !!onClick,
             'tw-rounded-full': circle,
             'tw-rounded-md': !circle,
-        }
+        },
+        breakWords ? 'tw-break-words' : 'tw-whitespace-nowrap'
     )
 
     return link ? (

--- a/src/components/IntegrationsSection.tsx
+++ b/src/components/IntegrationsSection.tsx
@@ -72,7 +72,7 @@ const selfHostedOptions: string[] = [
 const renderListItems = (items: string[]): ReactNode =>
     items.map((item: string) => (
         <li key={item} className="my-2 mr-2 list-inline-item">
-            <Badge text={item} size="small" />
+            <Badge text={item} size="small" breakWords={true} />
         </li>
     ))
 

--- a/src/components/ThreeUpText.tsx
+++ b/src/components/ThreeUpText.tsx
@@ -9,7 +9,7 @@ interface Item {
 }
 
 interface ThreeUpText {
-    title?: string
+    title?: string | ReactNode
     fullWidthTitle?: boolean
     subTitle?: string | ReactNode
     items: Item[]

--- a/src/pages/home/_Banner.tsx
+++ b/src/pages/home/_Banner.tsx
@@ -15,7 +15,7 @@ const Banner: FunctionComponent = () => (
                 draggable={false}
             />
             <p className="tw-text-white tw-text-lg tw-my-xs md:tw-my-0 md:tw-mx-sm md:tw-text-2xl lg:tw-mx-2xl">
-                From code search to code intelligence
+                The code intelligence platform for modern development teams
             </p>
             <Link href="/sourcegraph-4">
                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
@@ -23,7 +23,7 @@ const Banner: FunctionComponent = () => (
                     data-button-style={buttonStyle.textWithArrow}
                     data-button-location={buttonLocation.hero}
                     data-button-type="cta"
-                    className="tw-text-blue-300"
+                    className="tw-text-blue-300 tw-flex tw-whitespace-nowrap"
                 >
                     See what's new
                     <ArrowRightIcon className="tw-inline tw-ml-3" />

--- a/src/pages/home/_Banner.tsx
+++ b/src/pages/home/_Banner.tsx
@@ -15,7 +15,7 @@ const Banner: FunctionComponent = () => (
                 draggable={false}
             />
             <p className="tw-text-white tw-text-lg tw-my-xs md:tw-my-0 md:tw-mx-sm md:tw-text-2xl lg:tw-mx-2xl">
-                The code intelligence platform for modern development teams
+                From code search to code intelligence
             </p>
             <Link href="/sourcegraph-4">
                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}

--- a/src/pages/sourcegraph-4.tsx
+++ b/src/pages/sourcegraph-4.tsx
@@ -6,7 +6,6 @@ import HeartOutlineIcon from 'mdi-react/HeartOutlineIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import UpdateIcon from 'mdi-react/UpdateIcon'
 import Link from 'next/link'
-import { TwitchEmbed } from 'react-twitch-embed'
 
 import {
     ContentSection,
@@ -39,12 +38,11 @@ const Sourcegraph4: FunctionComponent = () => (
                     />
 
                     <h1 className="tw-mb-sm -tw-mt-3xl sm:-tw-mt-36">From code search to code intelligence</h1>
-                    <h3 className="tw-mb-5xl tw-mx-auto tw-max-w-4xl">
-                        Sourcegraph 4.0, the latest release of our code intelligence platform, is now available. Watch
-                        the livestream at 16:00 UTC today.
+                    <h3 className="tw-mb-5xl tw-mx-auto tw-max-w-2xl">
+                        Sourcegraph 4.0, the latest release of our code intelligence platform, is now available.
                     </h3>
 
-                    <TwitchEmbed channel="sourcegraph" width={800} className="tw-w-full" />
+                    <YouTube title="Sourcegraph 4.0" id="f9TCME0WYY8" />
                 </div>
             </div>
         }
@@ -91,7 +89,21 @@ const Sourcegraph4: FunctionComponent = () => (
         <ContentSection background="white" parentClassName="tw-pt-0 md:tw-pt-0">
             <div className="tw-mb-5xl">
                 <ThreeUpText
-                    title="Top updates released in Sourcegraph 4.0"
+                    title={
+                        <>
+                            Top updates released in{' '}
+                            <Link href="/blog/release/4.0" passHref={true}>
+                                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                                <a
+                                    data-button-style={buttonStyle.text}
+                                    data-button-location={buttonLocation.body}
+                                    data-button-type="cta"
+                                >
+                                    Sourcegraph 4.0
+                                </a>
+                            </Link>
+                        </>
+                    }
                     fullWidthTitle={true}
                     items={[
                         {
@@ -161,24 +173,17 @@ const Sourcegraph4: FunctionComponent = () => (
                 />
             </div>
 
-            <div className="tw-max-w-[800px] tw-mx-auto tw-text-center">
+            <div className="tw-max-w-5xl tw-mx-auto tw-text-center">
                 <h2 className="tw-mb-3xl">
-                    See the highlights from{' '}
-                    <Link href="/blog/release/4.0" passHref={true}>
-                        {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
-                        <a
-                            data-button-style={buttonStyle.text}
-                            data-button-location={buttonLocation.body}
-                            data-button-type="cta"
-                        >
-                            Sourcegraph 4.0
-                        </a>
-                    </Link>
+                    Experience 4.0 with the Sourcegraph Engineering team
                 </h2>
+                
+                {/* TODO: Add livestream recording */}
+                <div className="tw-max-w-[800px] tw-mx-auto">
+                    <YouTube title="Sourcegraph 4.0" id="f9TCME0WYY8" />
+                </div>
 
-                <YouTube title="Sourcegraph 4.0" id="f9TCME0WYY8" />
-
-                <h2 className="tw-mt-5xl tw-mb-3xl">
+                <h2 className="tw-mt-5xl tw-mb-3xl tw-max-w-[700px] tw-mx-auto">
                     Join these engineering orgs pushing forward modern software development
                 </h2>
             </div>
@@ -191,6 +196,11 @@ const Sourcegraph4: FunctionComponent = () => (
             centerContent={true}
             title="Experience the code intelligence platform for modern development teams"
             description=""
+            cta1={{
+                text: 'Get free trial',
+                ctaStyle: 'primaryButtonWhite',
+                link: 'https://signup.sourcegraph.com',
+            }}
             cta2={{
                 text: 'View pricing',
                 ctaStyle: 'outlineButtonWhiteText',

--- a/src/pages/sourcegraph-4.tsx
+++ b/src/pages/sourcegraph-4.tsx
@@ -173,20 +173,20 @@ const Sourcegraph4: FunctionComponent = () => (
                 />
             </div>
 
-            <div className="tw-max-w-5xl tw-mx-auto tw-text-center">
+            {/* TODO: Add in when livestream is ready */}
+            {/* <div className="tw-max-w-5xl tw-mx-auto tw-text-center">
                 <h2 className="tw-mb-3xl">
                     Experience 4.0 with the Sourcegraph Engineering team
                 </h2>
                 
-                {/* TODO: Add livestream recording */}
                 <div className="tw-max-w-[800px] tw-mx-auto">
                     <YouTube title="Sourcegraph 4.0" id="f9TCME0WYY8" />
                 </div>
-
-                <h2 className="tw-mt-5xl tw-mb-3xl tw-max-w-[700px] tw-mx-auto">
-                    Join these engineering orgs pushing forward modern software development
-                </h2>
-            </div>
+            </div> */}
+            
+            <h2 className="tw-mt-5xl tw-mb-3xl tw-max-w-[700px] tw-mx-auto tw-text-center">
+                Join these engineering orgs pushing forward modern software development
+            </h2>
 
             <CustomerLogos />
         </ContentSection>


### PR DESCRIPTION
This closes #5690 

### Changelog
- copy updates from Figma post launch design
- added the `breakWords` prop to the Badge component so Badges on the homepage in the `IntegrationsSection` don't break the viewport with long text

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure videos play
3. Ensure links go to their corresponding locations

#### Follow Up
Will follow up to add the livestream when it's ready
