### PR TITLE
Add livestream video to 4.0 landing

### DIFF
--- a/src/components/YouTube.tsx
+++ b/src/components/YouTube.tsx
@@ -32,9 +32,9 @@ export const YouTube: FunctionComponent<YouTube> = ({
     showTitle = false,
 }) => (
     <figure>
-        <div className={`video-embed embed-responsive embed-responsive-16by9 ${className}`}>
+        <div className={`tw-aspect-video ${className}`}>
             <iframe
-                className="embed-responsive-item"
+                className="tw-w-full tw-h-full"
                 src={`https://www.youtube-nocookie.com/embed/${id}?autoplay=${autoplay ? 1 : 0}&cc_load_policy=${
                     captions ? 1 : 0
                 }&start=${start}&end=${end}&loop=${loop ? 1 : 0}&controls=${controls ? 1 : 0}&modestbranding=${

--- a/src/pages/sourcegraph-4.tsx
+++ b/src/pages/sourcegraph-4.tsx
@@ -173,16 +173,16 @@ const Sourcegraph4: FunctionComponent = () => (
                 />
             </div>
 
-            {/* TODO: Add in when livestream is ready */}
-            {/* <div className="tw-max-w-5xl tw-mx-auto tw-text-center">
+            <div className="tw-max-w-5xl tw-mx-auto tw-text-center">
                 <h2 className="tw-mb-3xl">
                     Experience 4.0 with the Sourcegraph Engineering team
                 </h2>
                 
                 <div className="tw-max-w-[800px] tw-mx-auto">
+                    {/* TODO: Add livestream video ID */}
                     <YouTube title="Sourcegraph 4.0" id="f9TCME0WYY8" />
                 </div>
-            </div> */}
+            </div>
             
             <h2 className="tw-mt-5xl tw-mb-3xl tw-max-w-[700px] tw-mx-auto tw-text-center">
                 Join these engineering orgs pushing forward modern software development

--- a/src/pages/sourcegraph-4.tsx
+++ b/src/pages/sourcegraph-4.tsx
@@ -6,6 +6,7 @@ import HeartOutlineIcon from 'mdi-react/HeartOutlineIcon'
 import MagnifyIcon from 'mdi-react/MagnifyIcon'
 import UpdateIcon from 'mdi-react/UpdateIcon'
 import Link from 'next/link'
+import { TwitchPlayer } from 'react-twitch-embed'
 
 import {
     ContentSection,
@@ -178,9 +179,8 @@ const Sourcegraph4: FunctionComponent = () => (
                     Experience 4.0 with the Sourcegraph Engineering team
                 </h2>
                 
-                <div className="tw-max-w-[800px] tw-mx-auto">
-                    {/* TODO: Add livestream video ID */}
-                    <YouTube title="Sourcegraph 4.0" id="f9TCME0WYY8" />
+                <div className="tw-max-w-[800px] tw-mx-auto tw-aspect-video">
+                    <TwitchPlayer video="1602809871" autoplay={false} width="100%" height="100%" />
                 </div>
             </div>
             


### PR DESCRIPTION
Follow up for #5690, adding the livestream video. 

### Changelog
- added livestream video to the bottom of the page using the TwitchPlayer
- removed Bootstrap classes for YouTube video aspect ratios in lieu of Tailwinds video aspect ratio utility class

### Test

1. Ensure prettier has standardized the proposed changes.
2. Ensure livestream video plays