### PR TITLE
Blog/ Remove nested code tag borders

### DIFF
--- a/src/styles/templates/_PostTemplate.scss
+++ b/src/styles/templates/_PostTemplate.scss
@@ -37,6 +37,10 @@
             border: 1px solid var(--sg-color-gray-200);
         }
 
+        pre code {
+            border: none;
+        }
+
         p {
             line-height: 1.8;
             margin-bottom: 1.25rem;


### PR DESCRIPTION
 Removes borders around code tags when nested in a code block

**BEFORE**:
![image](https://user-images.githubusercontent.com/59381432/193104998-c8e536dd-8ab7-4e4e-8602-81d2d8014af1.png)

**NOW**:
![image](https://user-images.githubusercontent.com/59381432/193105397-64cbbdc4-0f5f-4a70-83e3-52b842e3efef.png)

### Test
1. Ensure prettier has standardized the proposed changes.
2. Nav to a blog with code blocks, ensure no nested borders appear (i.e. `/blog/introducing-migrator-service`)