### PR TITLE
Change TAM to Technical Advisor

### DIFF
--- a/src/components/Pricing/data.ts
+++ b/src/components/Pricing/data.ts
@@ -70,7 +70,7 @@ export const ENTERPRISE_FEATURES_OVERVIEW: FeatureCluster[] = [
     },
     {
         topic: '24/5 priority support',
-        features: ['slaSupport', 'dedicatedManager'],
+        features: ['slaSupport', 'dedicatedAdvisor'],
     },
 ]
 
@@ -209,7 +209,7 @@ export const ALL_FEATURES_COMPARED_DATA: FeatureDictionary[] = [
                 enterprise: '24/5 support',
             },
             {
-                label: 'dedicatedManager',
+                label: 'dedicatedAdvisor',
                 business: 'Available',
                 enterprise: true,
             },
@@ -393,10 +393,10 @@ export const SPOTLIGHT_FEATURE_INFO: Record<string, FeatureInfo> = {
         label: 'Priority support SLAs',
         description: 'Priority ticket handling and guaranteed initial response SLA from a dedicated team.',
     },
-    dedicatedManager: {
-        label: 'Dedicated Technical Account Manager',
+    dedicatedAdvisor: {
+        label: 'Dedicated Technical Advisor',
         description:
-            'Dedicated Technical Account Manager to support usage, training, enablement, technical strategy, and overall health.',
+            'Specialized technical experts to lead training & enablement, strategy, and overall account health.',
     },
 }
 
@@ -448,10 +448,10 @@ export const ALL_FEATURE_INFO: Record<string, FeatureInfo> = {
     support: {
         label: 'Support',
     },
-    dedicatedManager: {
-        label: 'Dedicated Technical Account Manager',
+    dedicatedAdvisor: {
+        label: 'Dedicated Technical Advisor',
         description:
-            'Dedicated Technical Account Manager to support usage, training, enablement, technical strategy, and overall health.',
+            'Specialized technical experts to lead training & enablement, strategy, and overall account health.',
     },
     supportSla: {
         label: 'Support SLA',


### PR DESCRIPTION
Updating Dedicated Technical Account Manager to Dedicated Technical Advisor. New tooltip: Specialized technical experts to lead training & enablement, strategy, and overall account health. 

<!--
Provide a brief summary in a sentence or two of your changes.

Don't forget to:
- Add reviewers
- Assign yourself
- Add Labels
- Add a Project
- Add a Milestone
-->

### Changelog

<!--
Add a bulleted list of your changes in more detail including which issues this PR closes.
Examples:
- Added MyCoolComponent and closes #1
- Closes #2
- Updated terms
-->

### Test

1. Ensure prettier has standardized the proposed changes.
<!--
Please list any other relevant steps that your reviewer should do to test this PR.
Examples:

- Visit /my/cool/page and ensure it matches the Figma
- Ensure MyCoolButton works
  -->
