### PR TITLE
New 4.0 launch twitch video id

### DIFF
--- a/src/pages/sourcegraph-4.tsx
+++ b/src/pages/sourcegraph-4.tsx
@@ -178,7 +178,7 @@ const Sourcegraph4: FunctionComponent = () => (
                 <h2 className="tw-mb-3xl">Experience 4.0 with the Sourcegraph Engineering team</h2>
 
                 <div className="tw-max-w-[800px] tw-mx-auto tw-aspect-video">
-                    <TwitchPlayer video="1602809871" autoplay={false} width="100%" height="100%" />
+                    <TwitchPlayer video="1604525409" autoplay={false} width="100%" height="100%" />
                 </div>
             </div>
 


### PR DESCRIPTION
Adds a working Twitch video ID to 4.0 launch page (closes #5833)

### Test
1. Ensure prettier has standardized the proposed changes.
2. Ensure all videos work on [`/sourcegraph-4`](https://deploy-preview-5832--sourcegraph.netlify.app/sourcegraph-4)