### PR TITLE
Create Sourcegraph 4.1 release post

### DIFF
--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -8,16 +8,25 @@ published: true
 heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-post/4.1/sourcegraph-4-1.png
 socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-post/4.1/sourcegraph-4-1.png
 changelogItems:
-  - description: 
-    url:
-    category:
-  - description:
-    url:
-    category:
-  - description: 
-    url: 
-    category: 
----
+  - description: Added repository sync counters to the code host details page to give visibility into external service sync progress.
+    url: https://github.com/sourcegraph/sourcegraph/pull/43039
+    category: Repositories
+  - description: "Added a new button in the repository settings, under \"Mirroring\", to delete a repository from disk and reclone it. This prevents the need to manually delete failed repositories from the Git server."
+    url: https://github.com/sourcegraph/sourcegraph/pull/42177
+    category: Repositories
+  - description: "GraphQL request logs are now compliant with the audit logging format. The old GraphQl logging based on `LOG_ALL_GRAPHQL_REQUESTS` env var is now deprecated and scheduled for removal."
+    url: https://github.com/sourcegraph/sourcegraph/pull/42550
+    category: Admin
+  - description: "Git server access logs are now compliant with the audit logging format. This introduces a breaking change: The 'actor' field is now nested under the 'audit' field."
+    url: https://github.com/sourcegraph/sourcegraph/pull/41865
+    category: Admin
+  - description: Security events are now included in the audit log by default.
+    url: https://github.com/sourcegraph/sourcegraph/pull/42653
+    category: Admin
+  - description: "Security events (in the audit log) can now optionally omit internal actor traffic to reduce noise."
+    url: https://github.com/sourcegraph/sourcegraph/pull/42946
+    category: Admin
+--
 
 Sourcegraph 4.1 is now available! For this release, we introduced:
 

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -11,7 +11,7 @@ changelogItems:
   - description: Added repository sync counters to the code host details page to give visibility into external service sync progress.
     url: https://github.com/sourcegraph/sourcegraph/pull/43039
     category: Repositories
-  - description: "Added a new button in the repository settings, under \"Mirroring\", to delete a repository from disk and reclone it. This prevents the need to manually delete failed repositories from the Git server."
+  - description: "Added a new button in the repository settings, under \"Mirroring\," to delete a repository from disk and reclone it. This prevents the need to manually delete failed repositories from the Git server."
     url: https://github.com/sourcegraph/sourcegraph/pull/42177
     category: Repositories
   - description: "GraphQL request logs are now compliant with the audit logging format. The old GraphQl logging based on `LOG_ALL_GRAPHQL_REQUESTS` env var is now deprecated and scheduled for removal."
@@ -20,13 +20,13 @@ changelogItems:
   - description: "Git server access logs are now compliant with the audit logging format. This introduces a breaking change: The 'actor' field is now nested under the 'audit' field."
     url: https://github.com/sourcegraph/sourcegraph/pull/41865
     category: Admin
-  - description: Security events are now included in the audit log by default.
+  - description: Security events are now included in the audit log by default to provide more visibility to security teams.
     url: https://github.com/sourcegraph/sourcegraph/pull/42653
     category: Admin
-  - description: "Security events (in the audit log) can now optionally omit internal actor traffic to reduce noise."
+  - description: "Security events in the audit log can now optionally exclude internal actor traffic to reduce noise. This traffic is excluded by default, but can be enabled with the `log.auditLog.backgroundJobs` setting."
     url: https://github.com/sourcegraph/sourcegraph/pull/42946
     category: Admin
-  - description: Fixed a bug with GitHub code hosts that did not label archived repos correctly when using the "public" repositoryQuery keyword.
+  - description: Fixed a bug with GitHub code hosts that caused archived repos to be incorrectly returned when using the "public" repositoryQuery keyword.
     url: https://github.com/sourcegraph/sourcegraph/pull/41461
     category: Admin
 ---
@@ -35,9 +35,9 @@ Sourcegraph 4.1 is now available! For this release, we introduced:
 
 <Badge link="/batch-changes" text="Batch Changes" color="blue" size="small" />
 
-#### Server-side batch changes now support file mounts and organization namespaces
+#### Server-side Batch Changes now support file mounts and organization namespaces
 
-We're iterating on running batch changes server-side as we prepare it to move from beta to GA. In 4.1, we're  adding the last features to bring server-side batch changes up to feature parity with local runs.
+We're iterating on [server-side Batch Changes](https://about.sourcegraph.com/blog/release/4.0#high-leverage-ways-to-improve-your-entire-codebase) as we prepare to move it from beta to GA. In 4.1, we're adding the last features to bring server-side Batch Changes up to feature parity with batch changes that are run locally.
 - You can now mount files on batch change steps containers when running server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently: file mounts allow you to iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41).
 - Server-side batch changes can be created in an organization namespace, so any member of the organization can edit or delete the batch change. Previously server-side runs could only be created in a user namespace.
 
@@ -48,8 +48,8 @@ We're iterating on running batch changes server-side as we prepare it to move fr
 
 #### Reference panel improvements
 
-In 4.0, we launched a new version of the reference panel. In 4.1, we've added further enhancements to the panel to improve your code navigation experience.
-- Reference and definition results now have syntax highlighting.
+In 4.0, we launched a new version of the reference panel. In 4.1, we've added further enhancements to the panel to improve your code navigation experience. Here's what's new:
+- Reference and definition results now have syntax highlighting for better readability.
 - Behavior when using your browser's back and forward buttons has been improved. Previously, it was easy to lose track of your context while drilling into definitions and references through the reference panel. Now, every browser URL is mapped with a single URL (the focused line in the preview pane), allowing the reference panel to update accordingly when you click on the browser's back or forward buttons.
 - Clicking on any line in the preview panel now promotes the file to the main file view.
 

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -38,7 +38,7 @@ Sourcegraph 4.1 is now available! For this release, we introduced:
 #### Batch Changes
 
 We're iterating on running batch changes server-side as we head towards GA, and adding the last features that are missing for server-side runs to support all features of local runs.
-- (experimental) You can now mount files on batch change steps containers when running server-side ([docs](https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts)). This is very useful when your batch change needs to run long scripts, or binaries that change frequently and can't be built 
+- (Experimental) You can now mount files on batch change steps containers when running them server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently and can't be built. By mounting the files or binaries to the container, rather than baking them into it, you can iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41) where it was first introduced.
 into the step container.
 - Server-side runs can now be created in an organization namespace. Previously server-side runs could only be created in a user namespace.
 

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -40,6 +40,6 @@ Sourcegraph 4.1 is now available! For this release, we introduced:
 We're iterating on running batch changes server-side as we head towards GA, and adding the last features that are missing for server-side runs to support all features of local runs.
 - (Experimental) You can now mount files on batch change steps containers when running them server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently and can't be built. By mounting the files or binaries to the container, rather than baking them into it, you can iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41) where it was first introduced.
 into the step container.
-- Server-side runs can now be created in an organization namespace. Previously server-side runs could only be created in a user namespace.
+- Server-side runs can now be created in an organization namespace, which allows any member of that organization to edit or delete the batch change. Previously server-side runs could only be created in a user namespace.
 
 <a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -1,7 +1,7 @@
 ---
 title: "Sourcegraph 4.1 release"
 publishDate: 2022-10-21T10:00-07:00
-description: "Sourcegraph 4.1 introduces..."
+description: "Sourcegraph 4.1 introduces new features for server-side batch changes and improvements to the code navigation reference panel."
 tags: [blog, release]
 slug: "release/4.1"
 published: true
@@ -61,5 +61,5 @@ In 4.0, we launched a new version of the reference panel. In 4.1, we've added fu
   loop={true}
   title="The reference panel featuring syntax highlighting and improved functionality."
 />
-
+<br />
 <a href="https://docs.sourcegraph.com/code_navigation/explanations/features#find-references" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -26,7 +26,7 @@ changelogItems:
   - description: "Security events (in the audit log) can now optionally omit internal actor traffic to reduce noise."
     url: https://github.com/sourcegraph/sourcegraph/pull/42946
     category: Admin
-  - description: "Fixed a bug with GitHub code hosts that did not label archived repos correctly when using the "public" repositoryQuery keyword."
+  - description: Fixed a bug with GitHub code hosts that did not label archived repos correctly when using the "public" repositoryQuery keyword.
     url: https://github.com/sourcegraph/sourcegraph/pull/41461
     category: Admin
 ---

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -21,3 +21,10 @@ changelogItems:
 
 Sourcegraph 4.1 is now available! For this release, we introduced:
 
+#### Batch Changes
+
+We're iterating on running batch changes server-side as we head towards GA, and adding the last features that are missing for server-side runs to support all features of local runs.
+- (experimental) You can now mount files on batch change steps containers when running server-side ([docs](https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts)). This is very useful when your batch change needs to run long scripts, or binaries that change frequently and can't be built 
+into the step container.
+- Server-side runs can now be created in an organization namespace. Previously server-side runs could only be created in a user namespace.
+

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -61,3 +61,6 @@ In 4.0, we launched a new version of the reference panel. In 4.1, we've added fu
 />
 <br />
 <a href="https://docs.sourcegraph.com/code_navigation/explanations/features#find-references" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>
+
+<br />
+Sourcegraph 4.1 is now available to download. For Sourcegraph Cloud users, instances will be upgraded to 4.1 beginning October 24.

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -47,10 +47,7 @@ We're iterating on running batch changes server-side as we prepare it to move fr
 
 After launching a new version of the reference panel in 4.0 we've added a few improvements that will boost your code navigation experience.
 - References and definition results now have syntax highlighting.
-- Browser history improvements: Previously, it was easy to loose track of your context while drilling
-into definitions/references through the reference panel. Now, the reference panel no longer supports deep history. Every browser
-URL is mapped with a single URL (the focused line in the preview pane) allowing the panel to update accordingly when the
-you click on the browser's back or forward buttons.
+- Browser history improvements: Previously, it was easy to lose track of your context while drilling into definitions/references through the reference panel. Now, the reference panel no longer supports deep history. Every browser URL is mapped with a single URL (the focused line in the preview pane) allowing the panel to update accordingly when the you click on the browser's back or forward buttons.
 - Clicking on any line in the preview panel will now promote the file to the main file view.
 
 <video title="Reference panel improvements" alt="." loop autoplay muted playsinline>

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -1,0 +1,23 @@
+---
+title: "Sourcegraph 4.1 release"
+publishDate: 2022-10-21T10:00-07:00
+description: "Sourcegraph 4.1 introduces..."
+tags: [blog, release]
+slug: "release/4.1"
+published: true
+heroImage: 
+socialImage: 
+changelogItems:
+  - description: 
+    url:
+    category:
+  - description:
+    url:
+    category:
+  - description: 
+    url: 
+    category: 
+---
+
+Sourcegraph 4.1 is now available! For this release, we introduced:
+

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -61,3 +61,5 @@ After launching a new version of the reference panel in 4.0 we've added a few im
   loop={true}
   title="The reference panel featuring syntax highlighting and improved functionality."
 />
+
+<a href="https://docs.sourcegraph.com/code_navigation/explanations/features#find-references" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -5,8 +5,8 @@ description: "Sourcegraph 4.1 introduces..."
 tags: [blog, release]
 slug: "release/4.1"
 published: true
-heroImage: 
-socialImage: 
+heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-post/4.1/sourcegraph-4-1.png
+socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-post/4.1/sourcegraph-4-1.png
 changelogItems:
   - description: 
     url:

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -48,9 +48,9 @@ We're iterating on running batch changes server-side as we prepare it to move fr
 
 #### Reference panel improvements
 
-After launching a new version of the reference panel in 4.0 we've added a few improvements that will boost your code navigation experience.
-- References and definition results now have syntax highlighting.
-- Browser history improvements: Previously, it was easy to lose track of your context while drilling into definitions/references through the reference panel. Now, the reference panel no longer supports deep history. Every browser URL is mapped with a single URL (the focused line in the preview pane) allowing the panel to update accordingly when the you click on the browser's back or forward buttons.
+In 4.0, we launched a new version of the reference panel. In 4.1, we've added further enhancements to the panel to improve your code navigation experience.
+- Reference and definition results now have syntax highlighting.
+- Behavior when using your browser's back and forward buttons has been improved. Previously, it was easy to lose track of your context while drilling into definitions and references through the reference panel. Now, every browser URL is mapped with a single URL (the focused line in the preview pane), allowing the reference panel to update accordingly when you click on the browser's back or forward buttons.
 - Clicking on any line in the preview panel will now promote the file to the main file view.
 
 <Video 

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -43,6 +43,9 @@ We're iterating on running batch changes server-side as we prepare it to move fr
 
 <a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>
 
+
+<Badge link="/code-search" text="Code Search" color="cerise" size="small" />
+
 #### Reference panel improvements
 
 After launching a new version of the reference panel in 4.0 we've added a few improvements that will boost your code navigation experience.
@@ -50,6 +53,5 @@ After launching a new version of the reference panel in 4.0 we've added a few im
 - Browser history improvements: Previously, it was easy to lose track of your context while drilling into definitions/references through the reference panel. Now, the reference panel no longer supports deep history. Every browser URL is mapped with a single URL (the focused line in the preview pane) allowing the panel to update accordingly when the you click on the browser's back or forward buttons.
 - Clicking on any line in the preview panel will now promote the file to the main file view.
 
-<video title="Reference panel improvements" alt="." loop autoplay muted playsinline>
   <source src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/4.1/ref-panel-improvements.mp4" />
 </video>

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -26,9 +26,11 @@ changelogItems:
   - description: "Security events (in the audit log) can now optionally omit internal actor traffic to reduce noise."
     url: https://github.com/sourcegraph/sourcegraph/pull/42946
     category: Admin
---
+---
 
 Sourcegraph 4.1 is now available! For this release, we introduced:
+
+<Badge link="/batch-changes" text="Batch Changes" color="blue" size="small" />
 
 #### Batch Changes
 
@@ -37,3 +39,4 @@ We're iterating on running batch changes server-side as we head towards GA, and 
 into the step container.
 - Server-side runs can now be created in an organization namespace. Previously server-side runs could only be created in a user namespace.
 
+<a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -53,5 +53,11 @@ After launching a new version of the reference panel in 4.0 we've added a few im
 - Browser history improvements: Previously, it was easy to lose track of your context while drilling into definitions/references through the reference panel. Now, the reference panel no longer supports deep history. Every browser URL is mapped with a single URL (the focused line in the preview pane) allowing the panel to update accordingly when the you click on the browser's back or forward buttons.
 - Clicking on any line in the preview panel will now promote the file to the main file view.
 
-  <source src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/4.1/ref-panel-improvements.mp4" />
-</video>
+<Video 
+  source={{
+    webm: 'blog/release-post/4.1/ref-panel-improvements.webm',
+    mp4: 'blog/release-post/4.1/ref-panel-improvements.mp4'
+  }}
+  loop={true}
+  title="The reference panel featuring syntax highlighting and improved functionality."
+/>

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -11,7 +11,7 @@ changelogItems:
   - description: Added repository sync counters to the code host details page to give visibility into external service sync progress.
     url: https://github.com/sourcegraph/sourcegraph/pull/43039
     category: Repositories
-  - description: "Added a new button in the repository settings, under \"Mirroring\," to delete a repository from disk and reclone it. This prevents the need to manually delete failed repositories from the Git server."
+  - description: "Added a new button in the repository settings, under \"Mirroring,\" to delete a repository from disk and reclone it. This prevents the need to manually delete failed repositories from the Git server."
     url: https://github.com/sourcegraph/sourcegraph/pull/42177
     category: Repositories
   - description: "GraphQL request logs are now compliant with the audit logging format. The old GraphQl logging based on `LOG_ALL_GRAPHQL_REQUESTS` env var is now deprecated and scheduled for removal."

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -35,7 +35,7 @@ Sourcegraph 4.1 is now available! For this release, we introduced:
 
 <Badge link="/batch-changes" text="Batch Changes" color="blue" size="small" />
 
-#### Batch Changes
+#### Run batch changes server-side with file mounting and organizational namespaces
 
 We're iterating on running batch changes server-side as we prepare it to move from beta to GA. In 4.1, we're  adding the last features to bring server-side runs up to feature parity with local runs.
 - (Experimental) You can now mount files on batch change steps containers when running them server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently and can't be built. By mounting the files or binaries to the container, rather than baking them into it, you can iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41) where it was first introduced.

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -36,8 +36,8 @@ changelogItems:
 #### Server-side Batch Changes now support file mounts and organization namespaces
 
 We're iterating on [server-side Batch Changes](https://about.sourcegraph.com/blog/release/4.0#high-leverage-ways-to-improve-your-entire-codebase) as we prepare to move it from beta to GA. In 4.1, we're adding the last features to bring server-side Batch Changes up to feature parity with batch changes that are run locally.
-- You can now mount files on batch change steps containers when running server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently: file mounts allow you to iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41).
-- Server-side batch changes can be created in an organization namespace, so any member of the organization can edit or delete the batch change. Previously these batch changes could only be created in a user namespace.
+- You can now mount files on batch change steps containers using `steps.mount` when running server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently: file mounts allow you to iterate on those scripts and binaries without needing to bake them into the container and rebuild the container every time they change. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41).
+- Previously, server-side batch changes could only be edited or deleted by the users that created them (or site admins). Now, users can create server-side batch changes in an organization namespace, which allows any user within that organization to edit or delete the batch change, making it easier to work collaboratively on batch changes across teams.
 
 <a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>
 

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -43,3 +43,17 @@ into the step container.
 - Server-side runs can now be created in an organization namespace, which allows any member of that organization to edit or delete the batch change. Previously server-side runs could only be created in a user namespace.
 
 <a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>
+
+#### Reference panel improvements
+
+After launching a new version of the reference panel in 4.0 we've added a few improvements that will boost your code navigation experience.
+- References and definition results now have syntax highlighting.
+- Browser history improvements: Previously, it was easy to loose track of your context while drilling
+into definitions/references through the reference panel. Now, the reference panel no longer supports deep history. Every browser
+URL is mapped with a single URL (the focused line in the preview pane) allowing the panel to update accordingly when the
+you click on the browser's back or forward buttons.
+- Clicking on any line in the preview panel will now promote the file to the main file view.
+
+<video title="Reference panel improvements" alt="." loop autoplay muted playsinline>
+  <source src="https://storage.googleapis.com/sourcegraph-assets/docs/images/code-intelligence/4.1/ref-panel-improvements.mp4" />
+</video>

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -38,8 +38,8 @@ Sourcegraph 4.1 is now available! For this release, we introduced:
 #### Server-side batch changes now support file mounts and organization namespaces
 
 We're iterating on running batch changes server-side as we prepare it to move from beta to GA. In 4.1, we're  adding the last features to bring server-side batch changes up to feature parity with local runs.
-- You can now mount files on batch change steps containers when running server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently: by using file mounts, you can iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41) where it was first introduced.
-- Server-side batch changes can now be created in an organization namespace, which allows any member of that organization to edit or delete the batch change. Previously server-side runs could only be created in a user namespace.
+- You can now mount files on batch change steps containers when running server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently: file mounts allow you to iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41).
+- Server-side batch changes can be created in an organization namespace, so any member of the organization can edit or delete the batch change. Previously server-side runs could only be created in a user namespace.
 
 <a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>
 
@@ -51,7 +51,7 @@ We're iterating on running batch changes server-side as we prepare it to move fr
 In 4.0, we launched a new version of the reference panel. In 4.1, we've added further enhancements to the panel to improve your code navigation experience.
 - Reference and definition results now have syntax highlighting.
 - Behavior when using your browser's back and forward buttons has been improved. Previously, it was easy to lose track of your context while drilling into definitions and references through the reference panel. Now, every browser URL is mapped with a single URL (the focused line in the preview pane), allowing the reference panel to update accordingly when you click on the browser's back or forward buttons.
-- Clicking on any line in the preview panel will now promote the file to the main file view.
+- Clicking on any line in the preview panel now promotes the file to the main file view.
 
 <Video 
   source={{

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -31,8 +31,6 @@ changelogItems:
     category: Admin
 ---
 
-Sourcegraph 4.1 is now available! For this release, we introduced:
-
 <Badge link="/batch-changes" text="Batch Changes" color="blue" size="small" />
 
 #### Server-side Batch Changes now support file mounts and organization namespaces

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -26,6 +26,9 @@ changelogItems:
   - description: "Security events (in the audit log) can now optionally omit internal actor traffic to reduce noise."
     url: https://github.com/sourcegraph/sourcegraph/pull/42946
     category: Admin
+  - description: "Fixed a bug with GitHub code hosts that did not label archived repos correctly when using the "public" repositoryQuery keyword."
+    url: https://github.com/sourcegraph/sourcegraph/pull/41461
+    category: Admin
 ---
 
 Sourcegraph 4.1 is now available! For this release, we introduced:

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -37,7 +37,7 @@ Sourcegraph 4.1 is now available! For this release, we introduced:
 
 #### Batch Changes
 
-We're iterating on running batch changes server-side as we head towards GA, and adding the last features that are missing for server-side runs to support all features of local runs.
+We're iterating on running batch changes server-side as we prepare it to move from beta to GA. In 4.1, we're  adding the last features to bring server-side runs up to feature parity with local runs.
 - (Experimental) You can now mount files on batch change steps containers when running them server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently and can't be built. By mounting the files or binaries to the container, rather than baking them into it, you can iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41) where it was first introduced.
 into the step container.
 - Server-side runs can now be created in an organization namespace, which allows any member of that organization to edit or delete the batch change. Previously server-side runs could only be created in a user namespace.

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -5,8 +5,8 @@ description: "Sourcegraph 4.1 introduces new features for server-side Batch Chan
 tags: [blog, release]
 slug: "release/4.1"
 published: true
-heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-post/4.1/sourcegraph-4-1.png
-socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-post/4.1/sourcegraph-4-1.png
+heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-post/4.1/sourcegraph-4-1-hero.png
+socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-post/4.1/sourcegraph-4-1-hero.png
 changelogItems:
   - description: Added repository sync counters to the code host details page to give visibility into external service sync progress.
     url: https://github.com/sourcegraph/sourcegraph/pull/43039

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -26,7 +26,7 @@ changelogItems:
   - description: "Security events in the audit log can now optionally exclude internal actor traffic to reduce noise. This traffic is excluded by default, but can be enabled with the `log.auditLog.backgroundJobs` setting."
     url: https://github.com/sourcegraph/sourcegraph/pull/42946
     category: Admin
-  - description: Fixed a bug with GitHub code hosts that caused archived repos to be incorrectly returned when using the "public" repositoryQuery keyword.
+  - description: Fixed a bug with the GitHub integration that caused archived repositories to be incorrectly returned when using the "public" repositoryQuery keyword.
     url: https://github.com/sourcegraph/sourcegraph/pull/41461
     category: Admin
 ---
@@ -35,7 +35,7 @@ changelogItems:
 
 #### Server-side Batch Changes now supports file mounts and organization namespaces
 
-We're iterating on [server-side Batch Changes](https://about.sourcegraph.com/blog/release/4.0#high-leverage-ways-to-improve-your-entire-codebase) as we prepare to move it from beta to GA. In 4.1, we're adding the last features to bring server-side Batch Changes up to feature parity with batch changes that are run locally.
+We're iterating on [server-side Batch Changes](https://about.sourcegraph.com/blog/release/4.0#high-leverage-ways-to-improve-your-entire-codebase) as we prepare to move it from beta to GA. In 4.1, we're adding the last features to bring server-side Batch Changes up to feature parity with changes that are run locally.
 - When running server-side Batch Changes, you can now mount files on batch change steps containers using `steps.mount`. This is useful when your batch change needs to run long scripts or binaries that change frequently because file mounts allow you to iterate on those scripts and binaries without needing to bake them into the container and rebuild the container every time they change. You can read more about this feature in the [3.41 release post](https://about.sourcegraph.com/blog/release/3.41).
 - Previously, server-side batch changes could only be edited or deleted by the users that created them (or site admins). Now, users can create server-side batch changes in an organization namespace, which allows any user within that organization to edit or delete the batch change, making it easier to work collaboratively on batch changes with other devs.
 

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -33,11 +33,11 @@ changelogItems:
 
 <Badge link="/batch-changes" text="Batch Changes" color="blue" size="small" />
 
-#### Server-side Batch Changes now support file mounts and organization namespaces
+#### Server-side Batch Changes now supports file mounts and organization namespaces
 
 We're iterating on [server-side Batch Changes](https://about.sourcegraph.com/blog/release/4.0#high-leverage-ways-to-improve-your-entire-codebase) as we prepare to move it from beta to GA. In 4.1, we're adding the last features to bring server-side Batch Changes up to feature parity with batch changes that are run locally.
-- You can now mount files on batch change steps containers using `steps.mount` when running server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently: file mounts allow you to iterate on those scripts and binaries without needing to bake them into the container and rebuild the container every time they change. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41).
-- Previously, server-side batch changes could only be edited or deleted by the users that created them (or site admins). Now, users can create server-side batch changes in an organization namespace, which allows any user within that organization to edit or delete the batch change, making it easier to work collaboratively on batch changes across teams.
+- When running server-side Batch Changes, you can now mount files on batch change steps containers using `steps.mount`. This is useful when your batch change needs to run long scripts or binaries that change frequently because file mounts allow you to iterate on those scripts and binaries without needing to bake them into the container and rebuild the container every time they change. You can read more about this feature in the [3.41 release post](https://about.sourcegraph.com/blog/release/3.41).
+- Previously, server-side batch changes could only be edited or deleted by the users that created them (or site admins). Now, users can create server-side batch changes in an organization namespace, which allows any user within that organization to edit or delete the batch change, making it easier to work collaboratively on batch changes with other devs.
 
 <a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>
 

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -37,7 +37,7 @@ changelogItems:
 
 We're iterating on [server-side Batch Changes](https://about.sourcegraph.com/blog/release/4.0#high-leverage-ways-to-improve-your-entire-codebase) as we prepare to move it from beta to GA. In 4.1, we're adding the last features to bring server-side Batch Changes up to feature parity with batch changes that are run locally.
 - You can now mount files on batch change steps containers when running server-side. This is useful when your batch change needs to run long scripts or binaries that change frequently: file mounts allow you to iterate on them without needing to rebuild the container every time. You can read more about this feature in [release post 3.41](https://about.sourcegraph.com/blog/release/3.41).
-- Server-side batch changes can be created in an organization namespace, so any member of the organization can edit or delete the batch change. Previously server-side runs could only be created in a user namespace.
+- Server-side batch changes can be created in an organization namespace, so any member of the organization can edit or delete the batch change. Previously these batch changes could only be created in a user namespace.
 
 <a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>
 

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -1,7 +1,7 @@
 ---
 title: "Sourcegraph 4.1 release"
 publishDate: 2022-10-21T10:00-07:00
-description: "Sourcegraph 4.1 introduces new features for server-side batch changes and improvements to the code navigation reference panel."
+description: "Sourcegraph 4.1 introduces new features for server-side Batch Changes and improvements to the code navigation reference panel."
 tags: [blog, release]
 slug: "release/4.1"
 published: true

--- a/content/blogposts/2022/release-4.1.md
+++ b/content/blogposts/2022/release-4.1.md
@@ -43,7 +43,7 @@ We're iterating on running batch changes server-side as we prepare it to move fr
 
 <a href="https://docs.sourcegraph.com/batch_changes/how-tos/server_side_file_mounts" className="tw-not-italic tw-flex tw-items-center tw-mb-sm">Docs<OpenInNewIcon className="tw-ml-xxs" size={18} /></a>
 
-
+<br />
 <Badge link="/code-search" text="Code Search" color="cerise" size="small" />
 
 #### Reference panel improvements
@@ -55,8 +55,8 @@ In 4.0, we launched a new version of the reference panel. In 4.1, we've added fu
 
 <Video 
   source={{
-    webm: 'blog/release-post/4.1/ref-panel-improvements.webm',
-    mp4: 'blog/release-post/4.1/ref-panel-improvements.mp4'
+    webm: 'blog/release-post/4.1/ref-panel-improvements',
+    mp4: 'blog/release-post/4.1/ref-panel-improvements'
   }}
   loop={true}
   title="The reference panel featuring syntax highlighting and improved functionality."


### PR DESCRIPTION
Add the Sourcegraph 4.1 release post to the blog.

Release Post guidance can be found [here](https://handbook.sourcegraph.com/departments/marketing/product-marketing/release_post_process/).

