### PR TITLE
Update "How teams use Sourcegraph" copy on the homepage

### DIFF
--- a/src/components/CoreFeatures.tsx
+++ b/src/components/CoreFeatures.tsx
@@ -131,7 +131,7 @@ export const CoreFeatures: FunctionComponent = () => {
     return (
         <>
             <div className="tw-text-center mb-7">
-                <h2>How teams use Sourcegraph</h2>
+                <h2>How developers use Sourcegraph</h2>
                 <p className="tw-mx-auto tw-my-xs tw-max-w-3xl tw-text-lg">
                     Sourcegraph's code intelligence platform is built with features that help you understand, fix, and
                     automate across your entire codebase.


### PR DESCRIPTION
Change How teams use Sourcegraph to How developers use Sourcegraph on the homepage

