### PR TITLE
Cta changes product pages

### DIFF
--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -58,7 +58,7 @@ export const Hero: FunctionComponent<Omit<Hero, 'className' | 'children' | 'illu
 
             {subtitle && <h3 className="tw-max-w-3xl tw-mt-sm">{subtitle}</h3>}
 
-            {cta && <div className="tw-mt-md tw-flex tw-flex-col max-w-400">{cta}</div>}
+            {cta && <div className="tw-mt-md tw-flex tw-flex-col max-w-350">{cta}</div>}
         </div>
     )
 

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -32,7 +32,7 @@ export const BatchChangesPage: FunctionComponent = () => (
                 title={'Automate large-scale\ncode changes'}
                 subtitle="Keep your code up to date, fix critical security issues, and pay down tech debt across all of your repositories with Batch Changes."
                 cta={
-                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
+                    <div className="tw-text-left tw-flex-col md:tw-flex-row md:tw-flex">
                         <div className="mb-3 mb-md-0">
                             <a
                                 href="https://signup.sourcegraph.com"
@@ -51,7 +51,7 @@ export const BatchChangesPage: FunctionComponent = () => (
                                 <a
                                     className="btn btn-outline-primary w-100 max-w-350"
                                     title="Request a Demo."
-                                    data-button-style={buttonStyle.primary}
+                                    data-button-style={buttonStyle.outline}
                                     data-button-location={buttonLocation.hero}
                                     data-button-type="cta"
                                 >

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -38,7 +38,7 @@ export const BatchChangesPage: FunctionComponent = () => (
                                 href="https://signup.sourcegraph.com"
                                 className="btn btn-primary w-100 max-w-350"
                                 title="Get free trial"
-                                data-button-style={buttonStyle.outline}
+                                data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.hero}
                                 data-button-type="cta"
                             >

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -32,9 +32,9 @@ export const BatchChangesPage: FunctionComponent = () => (
                 title={'Automate large-scale\ncode changes'}
                 subtitle="Keep your code up to date, fix critical security issues, and pay down tech debt across all of your repositories with Batch Changes."
                 cta={
-<div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
+                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
                         <div className="mb-3 mb-md-0">
-                        <a
+                            <a
                                 href="https://signup.sourcegraph.com"
                                 className="btn btn-primary w-100 max-w-350"
                                 title="Get free trial"
@@ -46,7 +46,7 @@ export const BatchChangesPage: FunctionComponent = () => (
                             </a>
                         </div>
                         <div className="ml-md-3">
-                        <Link href="/demo" passHref={true}>
+                            <Link href="/demo" passHref={true}>
                                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                 <a
                                     className="btn btn-outline-primary w-100 max-w-350"

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -1,12 +1,13 @@
 import { FunctionComponent } from 'react'
 
+import Link from 'next/link'
+
 import {
     Blockquote,
     ContentSection,
     CtaSection,
     Figure,
     Hero,
-    HubSpotForm,
     Layout,
     Tabs,
     TwoColumnSection,
@@ -30,7 +31,36 @@ export const BatchChangesPage: FunctionComponent = () => (
                 product="batch changes"
                 title={'Automate large-scale\ncode changes'}
                 subtitle="Keep your code up to date, fix critical security issues, and pay down tech debt across all of your repositories with Batch Changes."
-                cta={<HubSpotForm masterFormName="contactEmail" chiliPiper={true} />}
+                cta={
+<div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
+                        <div className="mb-3 mb-md-0">
+                        <a
+                                href="https://signup.sourcegraph.com"
+                                className="btn btn-primary w-100 max-w-350"
+                                title="Get free trial"
+                                data-button-style={buttonStyle.outline}
+                                data-button-location={buttonLocation.hero}
+                                data-button-type="cta"
+                            >
+                                Get free trial
+                            </a>
+                        </div>
+                        <div className="ml-md-3">
+                        <Link href="/demo" passHref={true}>
+                                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                                <a
+                                    className="btn btn-outline-primary w-100 max-w-350"
+                                    title="Request a Demo."
+                                    data-button-style={buttonStyle.primary}
+                                    data-button-location={buttonLocation.hero}
+                                    data-button-type="cta"
+                                >
+                                    Request a demo
+                                </a>
+                            </Link>
+                        </div>
+                    </div>
+                }
                 displayUnderNav={true}
             />
         }

--- a/src/pages/code-insights.tsx
+++ b/src/pages/code-insights.tsx
@@ -319,33 +319,33 @@ const CodeInsightsPage: FunctionComponent = () => (
                 subtitle="Transform your code into a queryable database to create customizable, visual dashboards in seconds."
                 cta={
                     <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
-                    <div className="mb-3 mb-md-0">
-                    <a
-                            href="https://signup.sourcegraph.com"
-                            className="btn btn-primary w-100 max-w-350"
-                            title="Get free trial"
-                            data-button-style={buttonStyle.outline}
-                            data-button-location={buttonLocation.hero}
-                            data-button-type="cta"
-                        >
-                            Get free trial
-                        </a>
-                    </div>
-                    <div className="ml-md-3">
-                    <Link href="/demo" passHref={true}>
-                            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                        <div className="mb-3 mb-md-0">
                             <a
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Request a Demo."
-                                data-button-style={buttonStyle.primary}
+                                href="https://signup.sourcegraph.com"
+                                className="btn btn-primary w-100 max-w-350"
+                                title="Get free trial"
+                                data-button-style={buttonStyle.outline}
                                 data-button-location={buttonLocation.hero}
                                 data-button-type="cta"
                             >
-                                Request a demo
+                                Get free trial
                             </a>
-                        </Link>
+                        </div>
+                        <div className="ml-md-3">
+                            <Link href="/demo" passHref={true}>
+                                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                                <a
+                                    className="btn btn-outline-primary w-100 max-w-350"
+                                    title="Request a Demo."
+                                    data-button-style={buttonStyle.primary}
+                                    data-button-location={buttonLocation.hero}
+                                    data-button-type="cta"
+                                >
+                                    Request a demo
+                                </a>
+                            </Link>
+                        </div>
                     </div>
-                </div>
                 }
                 displayUnderNav={true}
             />

--- a/src/pages/code-insights.tsx
+++ b/src/pages/code-insights.tsx
@@ -318,13 +318,13 @@ const CodeInsightsPage: FunctionComponent = () => (
                 title={'Track what really matters\nto you and your team.'}
                 subtitle="Transform your code into a queryable database to create customizable, visual dashboards in seconds."
                 cta={
-                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
+                    <div className="tw-text-left tw-flex-col md:tw-flex-row md:tw-flex">
                         <div className="mb-3 mb-md-0">
                             <a
                                 href="https://signup.sourcegraph.com"
                                 className="btn btn-primary w-100 max-w-350"
                                 title="Get free trial"
-                                data-button-style={buttonStyle.outline}
+                                data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.hero}
                                 data-button-type="cta"
                             >
@@ -337,7 +337,7 @@ const CodeInsightsPage: FunctionComponent = () => (
                                 <a
                                     className="btn btn-outline-primary w-100 max-w-350"
                                     title="Request a Demo."
-                                    data-button-style={buttonStyle.primary}
+                                    data-button-style={buttonStyle.outline}
                                     data-button-location={buttonLocation.hero}
                                     data-button-type="cta"
                                 >

--- a/src/pages/code-insights.tsx
+++ b/src/pages/code-insights.tsx
@@ -4,6 +4,7 @@ import BullsEyeArrowIcon from 'mdi-react/BullseyeArrowIcon'
 import LighteningBoltOutlineIcon from 'mdi-react/LightningBoltOutlineIcon'
 import RocketLaunchOutlineIcon from 'mdi-react/RocketLaunchOutlineIcon'
 import TrendingUpIcon from 'mdi-react/TrendingUpIcon'
+import Link from 'next/link'
 
 import { CodeInsightExample } from '@code-insights/CodeInsightsExamples'
 import {
@@ -21,7 +22,6 @@ import {
     CtaSection,
     CustomCarousel,
     Hero,
-    HubSpotForm,
     Layout,
     ResourceList,
     TabCarousel,
@@ -317,7 +317,36 @@ const CodeInsightsPage: FunctionComponent = () => (
                 product="code insights"
                 title={'Track what really matters\nto you and your team.'}
                 subtitle="Transform your code into a queryable database to create customizable, visual dashboards in seconds."
-                cta={<HubSpotForm masterFormName="contactEmail" chiliPiper={true} />}
+                cta={
+                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
+                    <div className="mb-3 mb-md-0">
+                    <a
+                            href="https://signup.sourcegraph.com"
+                            className="btn btn-primary w-100 max-w-350"
+                            title="Get free trial"
+                            data-button-style={buttonStyle.outline}
+                            data-button-location={buttonLocation.hero}
+                            data-button-type="cta"
+                        >
+                            Get free trial
+                        </a>
+                    </div>
+                    <div className="ml-md-3">
+                    <Link href="/demo" passHref={true}>
+                            {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                            <a
+                                className="btn btn-outline-primary w-100 max-w-350"
+                                title="Request a Demo."
+                                data-button-style={buttonStyle.primary}
+                                data-button-location={buttonLocation.hero}
+                                data-button-type="cta"
+                            >
+                                Request a demo
+                            </a>
+                        </Link>
+                    </div>
+                </div>
+                }
                 displayUnderNav={true}
             />
         }

--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -56,13 +56,13 @@ export const CodeSearchPage: FunctionComponent = () => (
                 title={'Search your code.\nAll of it.'}
                 subtitle="Onboard to a new codebase, understand code faster, and identify security risks with universal code search."
                 cta={
-                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
+                    <div className="tw-text-left tw-flex-col md:tw-flex-row md:tw-flex">
                         <div className="mb-3 mb-md-0">
                             <a
                                 href="https://signup.sourcegraph.com"
                                 className="btn btn-primary w-100 max-w-350"
                                 title="Get free trial"
-                                data-button-style={buttonStyle.outline}
+                                data-button-style={buttonStyle.primary}
                                 data-button-location={buttonLocation.hero}
                                 data-button-type="cta"
                             >
@@ -75,7 +75,7 @@ export const CodeSearchPage: FunctionComponent = () => (
                                 <a
                                     className="btn btn-outline-primary w-100 max-w-350"
                                     title="Request a Demo."
-                                    data-button-style={buttonStyle.primary}
+                                    data-button-style={buttonStyle.outline}
                                     data-button-location={buttonLocation.hero}
                                     data-button-type="cta"
                                 >

--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -58,7 +58,7 @@ export const CodeSearchPage: FunctionComponent = () => (
                 cta={
                     <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
                         <div className="mb-3 mb-md-0">
-                        <a
+                            <a
                                 href="https://signup.sourcegraph.com"
                                 className="btn btn-primary w-100 max-w-350"
                                 title="Get free trial"
@@ -70,7 +70,7 @@ export const CodeSearchPage: FunctionComponent = () => (
                             </a>
                         </div>
                         <div className="ml-md-3">
-                        <Link href="/demo" passHref={true}>
+                            <Link href="/demo" passHref={true}>
                                 {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
                                 <a
                                     className="btn btn-outline-primary w-100 max-w-350"

--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -1,10 +1,11 @@
 import { FunctionComponent } from 'react'
 
+import Link from 'next/link'
+
 import {
     Blockquote,
     ContentSection,
     IntegrationsSection,
-    HubSpotForm,
     Layout,
     Hero,
     TwoColumnSection,
@@ -12,6 +13,7 @@ import {
     ResourceList,
     CtaSection,
 } from '@components'
+import { buttonStyle, buttonLocation } from '@data'
 
 const blogResources = [
     {
@@ -53,7 +55,36 @@ export const CodeSearchPage: FunctionComponent = () => (
                 product="code search"
                 title={'Search your code.\nAll of it.'}
                 subtitle="Onboard to a new codebase, understand code faster, and identify security risks with universal code search."
-                cta={<HubSpotForm masterFormName="contactEmail" chiliPiper={true} />}
+                cta={
+                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
+                        <div className="mb-3 mb-md-0">
+                        <a
+                                href="https://signup.sourcegraph.com"
+                                className="btn btn-primary w-100 max-w-350"
+                                title="Get free trial"
+                                data-button-style={buttonStyle.outline}
+                                data-button-location={buttonLocation.hero}
+                                data-button-type="cta"
+                            >
+                                Get free trial
+                            </a>
+                        </div>
+                        <div className="ml-md-3">
+                        <Link href="/demo" passHref={true}>
+                                {/* eslint-disable-next-line jsx-a11y/anchor-is-valid */}
+                                <a
+                                    className="btn btn-outline-primary w-100 max-w-350"
+                                    title="Request a Demo."
+                                    data-button-style={buttonStyle.primary}
+                                    data-button-location={buttonLocation.hero}
+                                    data-button-type="cta"
+                                >
+                                    Request a demo
+                                </a>
+                            </Link>
+                        </div>
+                    </div>
+                }
                 displayUnderNav={true}
             />
         }


### PR DESCRIPTION
Made CTA changes to product pages

### Changelog
 - Removed Hubspot form from product page hero
 - Added two CTAs to the product page hero

### Test

1. Ensure prettier has standardized the proposed changes.
2. Test all CTAs redirects to the correct pages