### PR TITLE
Feature/5783: bring back 'rss.xml'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,8 @@ public/data
 # Cypress screenshots
 cypress/screenshots
 
-# Generated service worker and map files
+# Generated files
 public/*.map
-public/workbox-*.js
+public/rss.xml
 public/sw.js
+public/workbox-*.js

--- a/package.json
+++ b/package.json
@@ -3,10 +3,10 @@
   "private": true,
   "license": "Apache-2.0",
   "scripts": {
-    "predev": "./scripts/buildCache.sh",
+    "predev": "./scripts/buildCache.sh && node ./scripts/rss.js",
     "dev": "next dev",
     "build:cache": "TS_NODE_COMPILER_OPTIONS='{\"module\":\"commonjs\"}' ts-node src/scripts/cache.ts",
-    "prebuild": "./scripts/buildCache.sh",
+    "prebuild": "./scripts/buildCache.sh && node ./scripts/rss.js",
     "build": "next build && next export",
     "postbuild": "next-sitemap",
     "start": "next start",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "react-icons": "^4.4.0",
     "react-spring": "^9.4.4",
     "react-twitch-embed": "^3.0.1",
+    "rss": "^1.2.2",
     "sass": "^1.49.7",
     "start-server-and-test": "^1.14.0",
     "tailwindcss": "^3.1.7",

--- a/scripts/rss.js
+++ b/scripts/rss.js
@@ -1,0 +1,63 @@
+const { promises: fs } = require('fs')
+const matter = require('gray-matter')
+const path = require('path')
+const RSS = require('rss')
+
+async function walk(dir) {
+  const files = []
+  const entries = await fs.readdir(dir, { withFileTypes: true })
+  for (const e of entries) {
+    const fullPath = path.join(dir, e.name)
+    if (e.isDirectory()) {
+      const nested = await walk(fullPath)
+      files.push(...nested)
+    } else if (e.name.endsWith('.md')) {
+      files.push(fullPath)
+    }
+  }
+  return files
+}
+
+;(async function () {
+  const feed = new RSS({
+    title: 'Sourcegraph blog',
+    site_url: 'https://about.sourcegraph.com/',
+    feed_url: 'https://about.sourcegraph.com/rss.xml',
+  })
+
+  const folder = path.join(__dirname, '..', 'content', 'blogposts')
+  const files = await walk(folder)
+
+  const posts = []
+  await Promise.all(
+    files.map(async name => {
+      const content = await fs.readFile(name)
+      const frontmatter = matter(content)
+      posts.push(frontmatter)
+    })
+  )
+
+  posts.sort((a, b) => {
+    return new Date(b.data.publishDate).getTime() - new Date(a.data.publishDate).getTime()
+  })
+
+  const recent = posts.slice(0, 10)
+  recent.map(post => {
+    let description = post.data.description
+    if (description === null) {
+      const paragraphs = post.content.split('\n\n')
+      if (paragraphs.length > 0) {
+        description = paragraphs[0].trim()
+      }
+    }
+
+    feed.item({
+      title: post.data.title,
+      url: path.join('/blog', post.data.slug),
+      date: post.data.publishDate,
+      description: description,
+    })
+  })
+
+  await fs.writeFile('./public/rss.xml', feed.xml({ indent: true }))
+})()

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -22,6 +22,8 @@ export default class MyDocument extends Document {
 
                     <link rel="manifest" href="/manifest.json" />
 
+                    <link rel="alternate" type="application/rss+xml" title="Sourcegraph blog RSS Feed" href="/rss.xml" />
+
                     {/* Sourcegraph Chrome Extension */}
                     <link
                         rel="chrome-webstore-item"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6947,6 +6947,18 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
   integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
 
+mime-db@~1.25.0:
+  version "1.25.0"
+  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.25.0.tgz#c18dbd7c73a5dbf6f44a024dc0d165a1e7b1c392"
+  integrity sha512-5k547tI4Cy+Lddr/hdjNbBEWBwSl8EBc5aSdKvedav8DReADgWJzcYiktaRIw3GtGC1jjwldXtTzvqJZmtvC7w==
+
+mime-types@2.1.13:
+  version "2.1.13"
+  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.13.tgz#e07aaa9c6c6b9a7ca3012c69003ad25a39e92a88"
+  integrity sha512-ryBDp1Z/6X90UvjUK3RksH0IBPM137T7cmg4OgD5wQBojlAiUwuok0QeELkim/72EtcYuNlmbkrcGuxj3Kl0YQ==
+  dependencies:
+    mime-db "~1.25.0"
+
 mime-types@^2.1.12, mime-types@^2.1.27, mime-types@~2.1.19:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
@@ -8479,6 +8491,14 @@ rollup@^2.43.1:
   integrity sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==
   optionalDependencies:
     fsevents "~2.3.2"
+
+rss@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/rss/-/rss-1.2.2.tgz#50a1698876138133a74f9a05d2bdc8db8d27a921"
+  integrity sha512-xUhRTgslHeCBeHAqaWSbOYTydN2f0tAzNXvzh3stjz7QDhQMzdgHf3pfgNIngeytQflrFPfy6axHilTETr6gDg==
+  dependencies:
+    mime-types "2.1.13"
+    xml "1.0.1"
 
 run-async@^2.4.0:
   version "2.4.1"
@@ -10100,6 +10120,11 @@ xdg-basedir@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/xdg-basedir/-/xdg-basedir-4.0.0.tgz#4bc8d9984403696225ef83a1573cbbcb4e79db13"
   integrity sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+
+xml@1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/xml/-/xml-1.0.1.tgz#78ba72020029c5bc87b8a81a3cfcd74b4a2fc1e5"
+  integrity sha512-huCv9IH9Tcf95zuYCsQraZtWnJvBtLVE0QHMOs8bWyZAFZNDcYjsPq1nEx8jKA9y+Beo9v+7OBPRisQTjinQMw==
 
 xtend@^4.0.0, xtend@^4.0.2:
   version "4.0.2"


### PR DESCRIPTION
When trying to follow the Sourcegraph blog, I noticed that the RSS feed was missing. Digging through the issues, I realized that this was already reported on #5783.

This PR adds an `rss.js` script [based on the upstream example][1], adapted to the repository `blogposts/` directory structure. It also enables the RSS feed auto-build and auto-discovery.

@elzannewentzel @bretthayes can you please take a look?

Closes #5783.

[1]: https://github.com/vercel/next.js/blob/7796b1e/examples/blog/scripts/gen-rss.js