### PR TITLE
ci: update to actions/checkout@v3

### DIFF
--- a/.github/workflows/codenotify.yml
+++ b/.github/workflows/codenotify.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-latest
     name: codenotify
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           ref: ${{ github.event.pull_request.head.sha }}
       - uses: sourcegraph/codenotify@v0.4


### PR DESCRIPTION
Update to actions/checkout@v3 to avoid deprecation warning

### Test plan
Created as part of batch change: [_Created by Sourcegraph batch change `sourcegraph-operator-dax/Upgrade_actions_checkout_v2-v3`._](https://sourcegraph.sourcegraph.com/users/sourcegraph-operator-dax/batch-changes/Upgrade_actions_checkout_v2-v3)