### PR TITLE
fix cta3 colour

### DIFF
--- a/src/components/CtaSection/index.tsx
+++ b/src/components/CtaSection/index.tsx
@@ -98,13 +98,14 @@ export const CtaSection: FunctionComponent<CtaSection> = ({
         link: '/demo',
     },
     cta3 = (
-        <p className="tw-max-w-screen-xl tw-mx-auto tw-mt-xs tw-pl-sm">
+        <p className="tw-max-w-screen-xl tw-mx-auto tw-mt-xs tw-pl-sm tw-text-gray-200">
             Want to deploy yourself?{' '}
             <a
                 href="https://docs.sourcegraph.com"
                 target="_blank"
                 rel="noopener noreferrer"
                 title="Sourcegraph self-hosted solution"
+                className="tw-text-white"
                 data-button-style={buttonStyle.text}
                 data-button-location={buttonLocation.trySourcegraph}
                 data-button-type="cta"


### PR DESCRIPTION
This fixes cta 3 (Want to deploy yourself? Try our self-hosted solution.) Insides a dark case study like https://about.sourcegraph.com/case-studies/cern-reduces-technical-debt 

From
![image](https://user-images.githubusercontent.com/1373867/215319842-67b15bf6-c971-47aa-9f42-7dd145ac6c15.png)

To
![image](https://user-images.githubusercontent.com/1373867/215319814-182b2283-de56-4ff1-84ef-e1ef89d9f13e.png)

