### PR TITLE
Fix homepage video

### DIFF
--- a/src/pages/home/_Hero.tsx
+++ b/src/pages/home/_Hero.tsx
@@ -94,18 +94,28 @@ const Hero: FunctionComponent = () => {
                         playsInline={true}
                         controls={true}
                         title="Sourcegraph demo video"
+                        // Required for cross-origin caption track to work
+                        crossOrigin="anonymous"
+                        data-cookieconsent="ignore"
+                        poster="https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1_poster.png"
                     >
                         <track
                             default={true}
                             label="English"
                             kind="captions"
                             srcLang="en"
-                            src="https://sourcegraphstatic.com/homepage-demo-202301-0.vtt"
+                            src="https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1.vtt"
+                            data-cookieconsent="ignore"
                         />
-                        <source type="video/webm" src="https://sourcegraphstatic.com/homepage-demo-202301-0.webm" />
+                        <source
+                            type="video/webm"
+                            src="https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-0.webm"
+                            data-cookieconsent="ignore"
+                        />
                         <source
                             type="video/mp4"
-                            src="https://sourcegraphstatic.com/homepage-demo-202301-0smaller.mp4"
+                            src="https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1.mp4"
+                            data-cookieconsent="ignore"
                         />
                     </video>
                 </div>


### PR DESCRIPTION
- The video was not loading properly in iOS Safari. Not sure exactly why, I think the MP4 must have been encoded in an unsupported codec because I re-encoded it with CloudConvert and reuploaded it and it works now.
- The VTT file was broken – all start/end timestamps for every caption were `0`. I downloaded the SRT from YouTube and converted it to VTT and reuploaded that.
- Captions for some reason are not allowed to be loaded cross-origin unless the video is marked up with `crossorigin` (and then the resources include CORS headers). Added the `crossorigin` attribute and proxied the URLs through our `cors-anywhere` proxy. Don't know exactly why browsers allow videos but not captions crossorigin but it is what it is
- iOS Safari doesn't load the video to display a thumbnail until the video is played, to save bandwidth. Adding a `poster` attribute with a snapshot frame from the video makes sure there's a placeholder thumbnail.
- Ignores the video from Cookiebot since GCP doesn't set any cookies