### PR TITLE
remove triblio

### DIFF
--- a/cypress/e2e/scripts.test.ts
+++ b/cypress/e2e/scripts.test.ts
@@ -36,14 +36,6 @@ describe('Third party scripts', () => {
     it('renders Cookiebot script in the head', () => {
         cy.get('#script-cookiebot').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
     })
-
-    it('renders Triblio web personalization script in the head', () => {
-        cy.get('#script-triblio-personalization').parent().should('have.prop', 'tagName').should('equal', 'HEAD')
-    })
-
-    it('renders Triblio Analaytics and Overlay Cards script in the body', () => {
-        cy.get('#script-triblio-analytics').parent().should('have.prop', 'tagName').should('equal', 'BODY')
-    })
 })
 
 export {}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -6,9 +6,6 @@ export default class MyDocument extends Document {
         return (
             <Html lang="en">
                 <Head>
-                    {/* So that Triblio (and other third-party scripts) can read the full URL. More details here: https://learning.triblio.com/article/212-understanding-site-referrer-policy */}
-                    <meta name="referrer" content="no-referrer-when-downgrade" />
-
                     <meta charSet="utf-8" />
                     <meta httpEquiv="X-UA-Compatible" content="IE=edge" />
                     <meta httpEquiv="Content-Type" content="text/html; charset=utf-8" />
@@ -92,26 +89,6 @@ export default class MyDocument extends Document {
                         data-domain="about.sourcegraph.com"
                         src="https://plausible.io/js/plausible.js"
                         strategy="afterInteractive"
-                    />
-
-                    {/* Triblio "Webpage Personalization" */}
-                    {/* Triblio recommends this in the head which we follow with beforeInteractive */}
-                    <Script
-                        id="script-triblio-personalization"
-                        type="text/javascript"
-                        src="https://tribl.io/h.js?orgId=Yee6bMKj7QSARqAePdE8"
-                        async={true}
-                        strategy="beforeInteractive"
-                    />
-
-                    {/* Triblio "Analytics and Overlay Cards" */}
-                    {/* Triblio recommends this in the body which aligns with Next.js' recommendation for analytics */}
-                    <Script
-                        id="script-triblio-analytics"
-                        type="text/javascript"
-                        src="https://tribl.io/footer.js?orgId=Yee6bMKj7QSARqAePdE8"
-                        strategy="afterInteractive"
-                        defer={true}
                     />
                 </Head>
                 <body>


### PR DESCRIPTION
Remove Triblio scripts. Triblio is no longer being used (per [Slack message](https://sourcegraph.slack.com/archives/C03B4EMBXL4/p1672838415721909?thread_ts=1672837088.069059&cid=C03B4EMBXL4)).