### PR TITLE
Update calls-to-action

### DIFF
--- a/src/components/CtaSection/index.tsx
+++ b/src/components/CtaSection/index.tsx
@@ -11,7 +11,7 @@ import illustration from './illustration.svg'
 
 interface Cta {
     text: string
-    ctaStyle?: 'primaryButtonWhite' | 'outlineButtonLight'
+    ctaStyle?: 'primaryButtonWhite' | 'outlineButtonLight' | 'link'
     link?: string
 }
 
@@ -22,14 +22,6 @@ interface CtaSection {
     cta2?: Cta | boolean
 }
 
-/**
- * This is a CTA used within the CTA Section
- *
- * @param props - component props
- * @param props.text - text for the cta
- * @param props.ctaStyle - prop to display as a primary or outline button
- * @param props.link - href string
- */
 const Cta: FunctionComponent<Cta> = ({ text, ctaStyle, link }) => {
     const externalLink = link?.includes('http')
 
@@ -50,6 +42,7 @@ const Cta: FunctionComponent<Cta> = ({ text, ctaStyle, link }) => {
                     ctaStyle === 'primaryButtonWhite',
                 'btn tw-text-white tw-border-white hover:tw-bg-blurple-400 hover:tw-border-blurple-400':
                     ctaStyle === 'outlineButtonLight',
+                'btn btn-link tw-text-white hover:tw-text-blurple-200': ctaStyle === 'link',
             })}
             data-button-style={ctaTrackingStyle}
             data-button-location={buttonLocation.body}
@@ -80,13 +73,13 @@ export const CtaSection: FunctionComponent<CtaSection> = ({
     title = 'Try Sourcegraph on your code.',
     description = 'Experience code intelligence with a free trial for you and your team, or search millions of open source repositories.',
     cta1 = {
-        text: 'Get free trial',
+        text: 'Start for free',
         ctaStyle: 'primaryButtonWhite',
         link: 'https://signup.sourcegraph.com',
     },
     cta2 = {
-        text: 'Request a demo',
-        ctaStyle: 'outlineButtonLight',
+        text: 'Meet with a product expert',
+        ctaStyle: 'link',
         link: '/demo',
     },
 }) => {
@@ -101,18 +94,14 @@ export const CtaSection: FunctionComponent<CtaSection> = ({
                     // eslint-disable-next-line react/forbid-dom-props
                     style={lgAndUp ? { background: `url('${illustration}')` } : undefined}
                 >
-                    <div className="tw-col-span-full md:tw-col-span-7 lg:tw-col-span-5 lg:tw-col-start-4">
+                    <div className="tw-col-span-full md:tw-col-span-7 lg:tw-col-span-5 lg:tw-col-start-4 lg:tw-pl-xl">
                         <h2 className="tw-text-violet-200 tw-mb-sm">{title}</h2>
                         <p className="tw-text-lg tw-max-w-2xl">{description}</p>
                     </div>
 
                     <div
                         className={classNames(
-                            'tw-col-span-full md:tw-col-span-4 tw-flex tw-flex-col lg:tw-flex-row tw-items-start md:tw-items-center',
-                            {
-                                'lg:tw-justify-end': cta2,
-                                'lg:tw-justify-center': !cta2,
-                            }
+                            'tw-col-span-full md:tw-col-span-5 lg:tw-col-span-4 tw-flex tw-flex-col tw-items-center'
                         )}
                     >
                         {cta1 && (
@@ -122,7 +111,7 @@ export const CtaSection: FunctionComponent<CtaSection> = ({
                         )}
 
                         {cta2 && typeof cta2 === 'object' && (
-                            <div className="tw-mt-sm lg:tw-ml-md">
+                            <div className="tw-mt-sm">
                                 <Cta {...cta2} />
                             </div>
                         )}

--- a/src/components/DemoVideo.tsx
+++ b/src/components/DemoVideo.tsx
@@ -1,0 +1,38 @@
+import React from 'react'
+
+const VIDEOS: Record<'homepage-demo-202301', { poster: string; track: string; mp4: string; webm: string }> = {
+    'homepage-demo-202301': {
+        poster: 'https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1_poster.png',
+        track: 'https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1.vtt',
+        webm: 'https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-0.webm',
+        mp4: 'https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1.mp4',
+    },
+} as const
+
+export const DemoVideo: React.FunctionComponent<{ video: keyof typeof VIDEOS; className?: string }> = ({
+    video,
+    className,
+}) => (
+    <video
+        className={className}
+        autoPlay={false}
+        playsInline={true}
+        controls={true}
+        title="Sourcegraph demo video"
+        // Required for cross-origin caption track to work
+        crossOrigin="anonymous"
+        data-cookieconsent="ignore"
+        poster={VIDEOS[video].poster}
+    >
+        <track
+            default={true}
+            label="English"
+            kind="captions"
+            srcLang="en"
+            src={VIDEOS[video].track}
+            data-cookieconsent="ignore"
+        />
+        <source type="video/webm" src={VIDEOS[video].webm} data-cookieconsent="ignore" />
+        <source type="video/mp4" src={VIDEOS[video].mp4} data-cookieconsent="ignore" />
+    </video>
+)

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -68,7 +68,7 @@ export const Hero: FunctionComponent<Omit<Hero, 'className' | 'children' | 'illu
 
             {cta && (
                 <div
-                    className={classNames('tw-mt-md tw-flex tw-flex-col max-w-350', {
+                    className={classNames('tw-mt-md tw-flex tw-flex-col', {
                         'tw-items-center tw-mx-auto': centerContent,
                     })}
                 >

--- a/src/components/Layout/Header/DesktopNav.tsx
+++ b/src/components/Layout/Header/DesktopNav.tsx
@@ -88,12 +88,12 @@ const DesktopNav: FunctionComponent<DesktopNav> = ({ navLinks }) => {
                 <Nav.Link
                     className="px-5 py-2 ml-xs btn btn-primary font-weight-bold"
                     href="https://signup.sourcegraph.com"
-                    title="Get free trial"
+                    title="Start for free"
                     data-button-style={buttonStyle.primary}
                     data-button-location={buttonLocation.nav}
                     data-button-type="cta"
                 >
-                    Get free trial
+                    Start for free
                 </Nav.Link>
             </Nav>
         </>

--- a/src/components/Layout/Header/MobileNav.tsx
+++ b/src/components/Layout/Header/MobileNav.tsx
@@ -137,12 +137,12 @@ const MobileNav: FunctionComponent<Props> = ({ navLinks, isOpen }) => {
                     <a
                         className="nav-link"
                         href="https://signup.sourcegraph.com"
-                        title="Get free trial"
+                        title="Start for free"
                         data-button-style={buttonStyle.text}
                         data-button-location={buttonLocation.nav}
                         data-button-type="cta"
                     >
-                        Get free trial
+                        Start for free
                     </a>
                 </li>
             </ul>

--- a/src/components/cta/MeetWithProductExpertButton.tsx
+++ b/src/components/cta/MeetWithProductExpertButton.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+import Link from 'next/link'
+
+import { buttonStyle } from '../../data/tracking'
+
+export const MeetWithProductExpertButton: React.FunctionComponent<{ buttonLocation: number }> = ({
+    buttonLocation,
+}) => (
+    <Link
+        href="/demo"
+        className="btn btn-link tw-whitespace-nowrap"
+        title="Meet with a product expert"
+        data-button-style={buttonStyle.outline}
+        data-button-location={buttonLocation}
+        data-button-type="cta"
+    >
+        Meet with a product expert
+    </Link>
+)

--- a/src/components/cta/StandardCallToAction.tsx
+++ b/src/components/cta/StandardCallToAction.tsx
@@ -1,0 +1,24 @@
+import React from 'react'
+
+import classNames from 'classnames'
+
+import { MeetWithProductExpertButton } from './MeetWithProductExpertButton'
+import { TrySourcegraphForFreeButton } from './TrySourcegraphForFreeButton'
+
+export const StandardCallToAction: React.FunctionComponent<{ center?: boolean; buttonLocation: number }> = ({
+    center,
+    buttonLocation,
+}) => (
+    <div
+        className={classNames('tw-mx-auto tw-w-full tw-flex-col sm:tw-flex-row sm:tw-flex tw-items-center', {
+            'tw-justify-center': center,
+        })}
+    >
+        <div className="mb-3 sm:tw-px-0 mb-sm-0 mr-sm-3">
+            <TrySourcegraphForFreeButton buttonLocation={buttonLocation} />
+        </div>
+        <div>
+            <MeetWithProductExpertButton buttonLocation={buttonLocation} />
+        </div>
+    </div>
+)

--- a/src/components/cta/TrySourcegraphForFreeButton.tsx
+++ b/src/components/cta/TrySourcegraphForFreeButton.tsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+import { buttonStyle } from '../../data/tracking'
+
+export const TrySourcegraphForFreeButton: React.FunctionComponent<{ buttonLocation: number }> = ({
+    buttonLocation,
+}) => (
+    <a
+        className="btn btn-primary tw-whitespace-nowrap"
+        href="https://signup.sourcegraph.com"
+        title="Start for free"
+        data-button-style={buttonStyle.primary}
+        data-button-location={buttonLocation}
+        data-button-type="cta"
+    >
+        Try Sourcegraph for free
+    </a>
+)

--- a/src/pages/accelerate-dev-onboarding.tsx
+++ b/src/pages/accelerate-dev-onboarding.tsx
@@ -56,12 +56,12 @@ const AccelerateDevOnboarding: FunctionComponent = () => (
                     <a
                         className="mt-5 btn btn-primary tw-block sm:tw-inline-block"
                         href="https://signup.sourcegraph.com"
-                        title="Get free trial"
+                        title="Start for free"
                         data-button-style={buttonStyle.primary}
                         data-button-location={buttonLocation.bodyDemo}
                         data-button-type="cta"
                     >
-                        Get free trial
+                        Start for free
                     </a>
                 </div>
             </div>

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -12,6 +12,7 @@ import {
     Video,
     YouTube,
 } from '../components'
+import { StandardCallToAction } from '../components/cta/StandardCallToAction'
 import { buttonStyle, buttonLocation } from '../data/tracking'
 
 const batchChangesDemoFormURL = '/contact/request-batch-changes-demo'
@@ -29,34 +30,7 @@ export const BatchChangesPage: FunctionComponent = () => (
                 product="batch changes"
                 title={'Automate large-scale\ncode changes'}
                 subtitle="Keep your code up to date, fix critical security issues, and pay down tech debt across all of your repositories with Batch Changes."
-                cta={
-                    <div className="tw-text-left tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn btn-primary w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
                 displayUnderNav={true}
             />
         }

--- a/src/pages/cloud.tsx
+++ b/src/pages/cloud.tsx
@@ -4,7 +4,8 @@ import { FaGitAlt, FaLocationArrow } from 'react-icons/fa'
 import { MdOutlineAvTimer, MdBarChart } from 'react-icons/md'
 
 import { Layout, Hero, ContentSection, CtaSection, TwoColumnSection, Blockquote } from '../components'
-import { buttonStyle, buttonLocation } from '../data/tracking'
+import { StandardCallToAction } from '../components/cta/StandardCallToAction'
+import { buttonLocation } from '../data/tracking'
 
 const Cloud: FunctionComponent = () => (
     <Layout
@@ -22,34 +23,7 @@ const Cloud: FunctionComponent = () => (
                 titleClassName="tw-text-transparent tw-block tw-bg-clip-text tw-bg-gradient-to-l tw-from-white/10 tw-to-violet-200"
                 subtitle="Sourcegraph Cloud’s dedicated, single-tenant SaaS solution is the easiest way to get Sourcegraph in the cloud. Get full code intelligence for your codebase quickly, securely, and without having to host."
                 centerContent={true}
-                cta={
-                    <div className="tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn tw-bg-white tw-text-blurple-400 hover:tw-bg-blurple-400 hover:tw-text-white w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn tw-text-white tw-border-white hover:tw-bg-blurple-400 hover:tw-border-blurple-400 w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
                 floatingImg="/code-intelligence-platform-illustration.svg"
                 displayUnderNav={true}
             />

--- a/src/pages/code-insights.tsx
+++ b/src/pages/code-insights.tsx
@@ -31,6 +31,7 @@ import {
     OPENSSL_PYTHON,
 } from '../components/CodeInsights/mock-data'
 import { CodeInsightExampleType } from '../components/CodeInsights/types'
+import { StandardCallToAction } from '../components/cta/StandardCallToAction'
 import { buttonStyle, buttonLocation } from '../data/tracking'
 
 const items = [
@@ -321,34 +322,7 @@ const CodeInsightsPage: FunctionComponent = () => (
                 product="code insights"
                 title={'Track what really matters\nto you and your team.'}
                 subtitle="Transform your code into a queryable database to create customizable, visual dashboards in seconds."
-                cta={
-                    <div className="tw-text-left tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn btn-primary w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
                 displayUnderNav={true}
             />
         }

--- a/src/pages/code-intelligence-platform.tsx
+++ b/src/pages/code-intelligence-platform.tsx
@@ -165,12 +165,12 @@ const CodeIntelligencePlatform: FunctionComponent = () => (
                     <a
                         className="mt-5 btn btn-primary tw-block sm:tw-inline-block"
                         href="https://signup.sourcegraph.com"
-                        title="Get free trial"
+                        title="Start for free"
                         data-button-style={buttonStyle.primary}
                         data-button-location={buttonLocation.hero}
                         data-button-type="cta"
                     >
-                        Get free trial
+                        Start for free
                     </a>
                 </div>
             </div>
@@ -308,12 +308,12 @@ const CodeIntelligencePlatform: FunctionComponent = () => (
                 <a
                     className="mt-5 btn btn-primary tw-block sm:tw-inline-block"
                     href="https://signup.sourcegraph.com"
-                    title="Get free trial"
+                    title="Start for free"
                     data-button-style={buttonStyle.primary}
                     data-button-location={buttonLocation.body}
                     data-button-type="cta"
                 >
-                    Get free trial
+                    Start for free
                 </a>
             </div>
         </ContentSection>

--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -11,7 +11,8 @@ import {
     ResourceList,
     CtaSection,
 } from '../components'
-import { buttonStyle, buttonLocation } from '../data/tracking'
+import { StandardCallToAction } from '../components/cta/StandardCallToAction'
+import { buttonLocation } from '../data/tracking'
 
 const blogResources = [
     {
@@ -54,34 +55,7 @@ export const CodeSearchPage: FunctionComponent = () => (
                 product="code search"
                 title={'Search your code.\nAll of it.'}
                 subtitle="Onboard to a new codebase, understand code faster, and identify security risks with universal code search."
-                cta={
-                    <div className="tw-text-left tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn btn-primary w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
                 displayUnderNav={true}
             />
         }

--- a/src/pages/demo.tsx
+++ b/src/pages/demo.tsx
@@ -1,38 +1,33 @@
 import React, { FunctionComponent } from 'react'
 
-import { Layout, YouTube, HubSpotForm } from '../components'
+import { Layout, HubSpotForm } from '../components'
+import { DemoVideo } from '../components/DemoVideo'
 
 const Demo: FunctionComponent = () => (
     <Layout
         meta={{
-            title: 'Request a Demo - Sourcegraph',
+            title: 'Schedule a demo - Sourcegraph',
             description:
                 "From developer onboarding to incident response, see how companies of all sizes use Sourcegraph to solve the industry's most challenging code problems.",
         }}
         heroAndHeaderClassName="sg-bg-gradient-venus"
         hero={
-            <div className="container tw-pt-3xl tw-pb-sm">
-                <h1>Request a demo</h1>
-                <p className="max-w-450">Want to see Sourcegraph in action? Schedule time with a Sourcegraph expert.</p>
+            <div className="container tw-pt-3xl tw-pb-lg">
+                <h1>Schedule a demo with a product expert</h1>
             </div>
         }
     >
-        <div className="container tw-pt-3xl">
+        <div className="container tw-pt-xl">
             <div className="row">
-                <div className="col-lg-6">
-                    <h2>Let us show you around</h2>
-                    <p>Watch this quick video to see what Sourcegraph can do</p>
-
-                    <YouTube title="Sourcegraph Product Tour" id="7JeHvfwsxIY" className="my-5" />
-                </div>
-
-                <div className="mt-5 col-lg-6 lg:tw-pl-5xl mt-lg-0">
-                    <h2>Like what you see?</h2>
+                <div className="mt-2 col-lg-6 tw-pr-md">
                     <p className="mb-5">
-                        Get a live demo in your environment! Just fill out the form to request a demo.
+                        Want to see Sourcegraph in action and speak with a product expert? Fill out the form below, and
+                        we'll be in touch.
                     </p>
-
                     <HubSpotForm masterFormName="contactMulti" chiliPiper={true} />
+                </div>
+                <div className="col-lg-6">
+                    <DemoVideo video="homepage-demo-202301" className="my-4" />
                 </div>
             </div>
         </div>

--- a/src/pages/fixing-vulnerabilities.tsx
+++ b/src/pages/fixing-vulnerabilities.tsx
@@ -45,12 +45,12 @@ const FixingVulnerabilities: FunctionComponent = () => (
                 <a
                     className="mt-5 btn btn-primary tw-block sm:tw-inline-block"
                     href="https://signup.sourcegraph.com"
-                    title="Get free trial"
+                    title="Start for free"
                     data-button-style={buttonStyle.primary}
                     data-button-location={buttonLocation.body}
                     data-button-type="cta"
                 >
-                    Get free trial
+                    Start for free
                 </a>
             </div>
         </div>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -61,8 +61,8 @@ const HomeHero: FunctionComponent = () => (
             </div>
         ))}
 
-        <div className="tw-mx-auto tw-pt-md md:tw-pt-5xl tw-text-center">
-            <h1 className="tw-text-4xl tw-leading-10 md:tw-text-6xl lg:tw-text-[3.75rem] lg:tw-leading-[1]">
+        <div className="tw-mx-auto tw-pt-md md:tw-pt-4xl tw-text-center">
+            <h1 className="tw-text-4xl tw-leading-10 sm:tw-text-6xl md:tw-text-[3.5rem] lg:tw-text-[4rem] lg:tw-leading-[1]">
                 <span className="mb-2 tw-text-transparent tw-block tw-bg-clip-text tw-bg-gradient-to-l tw-from-violet-400 tw-to-vermillion-300">
                     Find. Fix. Flow.
                 </span>

--- a/src/pages/home/index.tsx
+++ b/src/pages/home/index.tsx
@@ -12,6 +12,8 @@ import {
     CustomerLogos,
     Heading,
 } from '../../components'
+import { StandardCallToAction } from '../../components/cta/StandardCallToAction'
+import { DemoVideo } from '../../components/DemoVideo'
 import { buttonLocation, buttonStyle } from '../../data/tracking'
 
 import meshLeft from './assets/hero/mesh-left.png'
@@ -74,64 +76,10 @@ const HomeHero: FunctionComponent = () => (
                 universal&nbsp;code&nbsp;search+nav and large-scale&nbsp;fixes/refactors.
             </Heading>
 
-            <div className="tw-mx-auto max-w-350 tw-flex-col sm:tw-flex-row sm:tw-flex tw-items-center">
-                <div className="mb-3 col-sm-6 sm:tw-px-0 mb-sm-0 mr-sm-3">
-                    <a
-                        className="btn btn-primary w-100"
-                        href="https://signup.sourcegraph.com"
-                        title="Get free trial"
-                        data-button-style={buttonStyle.primary}
-                        data-button-location={buttonLocation.hero}
-                        data-button-type="cta"
-                    >
-                        Get free trial
-                    </a>
-                </div>
-                <div className="col-sm-6 sm:tw-px-0">
-                    <Link
-                        href="/demo"
-                        className="btn btn-outline-primary w-100"
-                        title="Request a demo"
-                        data-button-style={buttonStyle.outline}
-                        data-button-location={buttonLocation.hero}
-                        data-button-type="cta"
-                    >
-                        Request a demo
-                    </Link>
-                </div>
-            </div>
+            <StandardCallToAction center={true} buttonLocation={buttonLocation.hero} />
 
             <div className="tw-max-w-4xl tw-mx-auto tw-my-3xl">
-                <video
-                    className="shadow w-100"
-                    autoPlay={false}
-                    playsInline={true}
-                    controls={true}
-                    title="Sourcegraph demo video"
-                    // Required for cross-origin caption track to work
-                    crossOrigin="anonymous"
-                    data-cookieconsent="ignore"
-                    poster="https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1_poster.png"
-                >
-                    <track
-                        default={true}
-                        label="English"
-                        kind="captions"
-                        srcLang="en"
-                        src="https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1.vtt"
-                        data-cookieconsent="ignore"
-                    />
-                    <source
-                        type="video/webm"
-                        src="https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-0.webm"
-                        data-cookieconsent="ignore"
-                    />
-                    <source
-                        type="video/mp4"
-                        src="https://cors-anywhere.sgdev.org/https://sourcegraphstatic.com/homepage-demo-202301-1.mp4"
-                        data-cookieconsent="ignore"
-                    />
-                </video>
+                <DemoVideo video="homepage-demo-202301" className="shadow w-100" />
             </div>
 
             <div className="tw-mx-auto tw-text-center max-w-700">

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -40,12 +40,12 @@ const BusinessCTA: FunctionComponent<{ className?: string; btnOnMobile?: boolean
                     : 'btn btn-primary'
             )}
             href="https://signup.sourcegraph.com"
-            title="Get free trial"
+            title="Start for free"
             data-button-style={buttonStyle.primary}
             data-button-location={buttonLocation.trySourcegraph}
             data-button-type="cta"
         >
-            Get free trial
+            Start for free
         </a>
     )
 }

--- a/src/pages/use-cases/code-health.tsx
+++ b/src/pages/use-cases/code-health.tsx
@@ -18,6 +18,7 @@ import {
     ThreeUpText,
     TwoColumnSection,
 } from '../../components'
+import { StandardCallToAction } from '../../components/cta/StandardCallToAction'
 import { buttonStyle, buttonLocation } from '../../data/tracking'
 
 const CarouselItem: FunctionComponent<{ header: string; text: ReactNode }> = ({ header, text }) => (
@@ -252,34 +253,7 @@ const UseCasePage: FunctionComponent = () => (
                 title={'Healthy code,\n happy teams'}
                 subtitle="Improve code health with large-scale changes and track key initiatives across your
                 entire codebase."
-                cta={
-                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn btn-primary w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
             />
         }
     >
@@ -350,12 +324,12 @@ const UseCasePage: FunctionComponent = () => (
                     <a
                         href="https://signup.sourcegraph.com"
                         className="btn btn-primary max-w-350 w-100"
-                        title="Get free trial"
+                        title="Start for free"
                         data-button-style={buttonStyle.primary}
                         data-button-location={buttonLocation.body}
                         data-button-type="cta"
                     >
-                        Get free trial
+                        Start for free
                     </a>
                     <Link
                         href="/use-cases"

--- a/src/pages/use-cases/code-reuse.tsx
+++ b/src/pages/use-cases/code-reuse.tsx
@@ -17,6 +17,7 @@ import {
     ThreeUpText,
     TwoColumnSection,
 } from '../../components'
+import { StandardCallToAction } from '../../components/cta/StandardCallToAction'
 import { buttonStyle, buttonLocation } from '../../data/tracking'
 
 const CarouselItem: FunctionComponent<{ header: string; text: ReactNode }> = ({ header, text }) => (
@@ -213,34 +214,7 @@ const CodeReusePage: FunctionComponent = () => (
                 title="Find and use code that already exists"
                 subtitle="Identify existing code libraries for reuse and use innersourcing to avoid spending time
                 on problems a teammate already solved."
-                cta={
-                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn btn-primary w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
             />
         }
     >
@@ -309,12 +283,12 @@ const CodeReusePage: FunctionComponent = () => (
                     <a
                         href="https://signup.sourcegraph.com"
                         className="btn btn-primary max-w-350 w-100"
-                        title="Get free trial"
+                        title="Start for free"
                         data-button-style={buttonStyle.outline}
                         data-button-location={buttonLocation.body}
                         data-button-type="cta"
                     >
-                        Get free trial
+                        Start for free
                     </a>
                     <Link
                         href="/use-cases"

--- a/src/pages/use-cases/code-security.tsx
+++ b/src/pages/use-cases/code-security.tsx
@@ -17,6 +17,7 @@ import {
     ThreeUpText,
     TwoColumnSection,
 } from '../../components'
+import { StandardCallToAction } from '../../components/cta/StandardCallToAction'
 import { buttonStyle, buttonLocation } from '../../data/tracking'
 
 const CarouselItem: FunctionComponent<{ header: string; text: ReactNode }> = ({ header, text }) => (
@@ -239,34 +240,7 @@ const UseCasePage: FunctionComponent = () => (
                 }}
                 title="Improve code security"
                 subtitle="Find, fix, and track vulnerable code across your entire codebase in minutes, not days"
-                cta={
-                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn btn-primary w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
             />
         }
     >
@@ -349,12 +323,12 @@ const UseCasePage: FunctionComponent = () => (
                     <a
                         className="btn btn-primary max-w-350 w-100"
                         href="https://signup.sourcegraph.com"
-                        title="Get free trial"
+                        title="Start for free"
                         data-button-style={buttonStyle.primary}
                         data-button-location={buttonLocation.body}
                         data-button-type="cta"
                     >
-                        Get free trial
+                        Start for free
                     </a>
                     <Link
                         href="/use-cases"

--- a/src/pages/use-cases/incident-response.tsx
+++ b/src/pages/use-cases/incident-response.tsx
@@ -16,6 +16,7 @@ import {
     ResourceList,
     ThreeUpText,
 } from '../../components'
+import { StandardCallToAction } from '../../components/cta/StandardCallToAction'
 import { buttonStyle, buttonLocation } from '../../data/tracking'
 
 const CarouselItem: FunctionComponent<{ header: string; text: ReactNode }> = ({ header, text }) => (
@@ -232,34 +233,7 @@ const IncidentResponsePage: FunctionComponent = () => (
                 title="Resolve incidents quickly and confidently"
                 subtitle="Identify the root cause of an incident, understand its potential impact on other
                 services, and fix the issue everywhere in your codebase so it won't reoccur."
-                cta={
-                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn btn-primary w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
             />
         }
     >
@@ -291,12 +265,12 @@ const IncidentResponsePage: FunctionComponent = () => (
                     <a
                         className="btn btn-primary max-w-350 w-100"
                         href="https://signup.sourcegraph.com"
-                        title="Get free trial"
+                        title="Start for free"
                         data-button-style={buttonStyle.primary}
                         data-button-location={buttonLocation.body}
                         data-button-type="cta"
                     >
-                        Get free trial
+                        Start for free
                     </a>
                     <Link
                         href="/use-cases"

--- a/src/pages/use-cases/index.tsx
+++ b/src/pages/use-cases/index.tsx
@@ -57,7 +57,7 @@ const UseCases: React.FunctionComponent = () => (
                         </div>
 
                         <div className="mb-6 tw-pt-sm col-lg-5 mt-lg-6">
-                            <h4 className="tw-pb-xxs">See how customers use Sourcegraph to</h4>
+                            <h4 className="tw-pb-xxs tw-text-xl">See how customers use Sourcegraph to...</h4>
 
                             <div className="list-group">
                                 {features.map((feature: { id: string; description: string }) => (
@@ -117,25 +117,15 @@ const UseCases: React.FunctionComponent = () => (
                                 </li>
                                 <li>Alert for known vulnerabilities and risky code changes with code monitoring</li>
                             </ul>
-                            <a
-                                className="btn btn-outline-primary"
-                                href="https://signup.sourcegraph.com"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.body}
-                                data-button-type="cta"
-                            >
-                                Get free trial <ArrowRightBoxIcon className="ml-1 tw-inline" />
-                            </a>
                             <Link
                                 href="/use-cases/code-security"
-                                className="tw-ml-8"
                                 title="Learn more"
                                 data-button-style={buttonStyle.text}
                                 data-button-location={buttonLocation.body}
                                 data-button-type="cta"
                             >
-                                Learn more
+                                Learn more about code security with Sourcegraph{' '}
+                                <ArrowRightBoxIcon className="ml-1 tw-inline" />
                             </Link>
                         </>
                     }
@@ -196,25 +186,15 @@ const UseCases: React.FunctionComponent = () => (
                                 </li>
                                 <li>Get answers faster with shareable links to specific code</li>
                             </ul>
-                            <a
-                                className="btn btn-outline-primary"
-                                href="https://signup.sourcegraph.com"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.body}
-                                data-button-type="cta"
-                            >
-                                Get free trial <ArrowRightBoxIcon className="ml-1 tw-inline" />
-                            </a>
                             <Link
                                 href="/use-cases/onboarding"
-                                className="tw-ml-8"
                                 title="Learn more"
                                 data-button-style={buttonStyle.text}
                                 data-button-location={buttonLocation.body}
                                 data-button-type="cta"
                             >
-                                Learn more
+                                Learn more about dev onboarding with Sourcegraph{' '}
+                                <ArrowRightBoxIcon className="ml-1 tw-inline" />
                             </Link>
                         </>
                     }
@@ -251,25 +231,15 @@ const UseCases: React.FunctionComponent = () => (
                                     a search notebook
                                 </li>
                             </ul>
-                            <a
-                                className="btn btn-outline-primary"
-                                href="https://signup.sourcegraph.com"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.body}
-                                data-button-type="cta"
-                            >
-                                Get free trial <ArrowRightBoxIcon className="ml-1 tw-inline" />
-                            </a>
                             <Link
                                 href="/use-cases/incident-response"
-                                className="tw-ml-8"
                                 title="Learn more"
                                 data-button-style={buttonStyle.text}
                                 data-button-location={buttonLocation.body}
                                 data-button-type="cta"
                             >
-                                Learn more
+                                Learn more about incident response with Sourcegraph{' '}
+                                <ArrowRightBoxIcon className="ml-1 tw-inline" />
                             </Link>
                         </>
                     }
@@ -344,25 +314,15 @@ const UseCases: React.FunctionComponent = () => (
                                 </li>
                                 <li>Add a code monitor to alert you of commits using an out-of-date library</li>
                             </ul>
-                            <a
-                                className="btn btn-outline-primary"
-                                href="https://signup.sourcegraph.com"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.body}
-                                data-button-type="cta"
-                            >
-                                Get free trial <ArrowRightBoxIcon className="ml-1 tw-inline" />
-                            </a>
                             <Link
                                 href="/use-cases/code-reuse"
-                                className="tw-ml-8"
                                 title="Learn more"
                                 data-button-style={buttonStyle.text}
                                 data-button-location={buttonLocation.body}
                                 data-button-type="cta"
                             >
-                                Learn more
+                                Learn more about code reuse with Sourcegraph{' '}
+                                <ArrowRightBoxIcon className="ml-1 tw-inline" />
                             </Link>
                         </>
                     }
@@ -397,25 +357,15 @@ const UseCases: React.FunctionComponent = () => (
                                 </li>
                                 <li>Efficiently tackle tech debt from legacy systems and acquisitions</li>
                             </ul>
-                            <a
-                                className="btn btn-outline-primary"
-                                href="https://signup.sourcegraph.com"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.body}
-                                data-button-type="cta"
-                            >
-                                Get free trial <ArrowRightBoxIcon className="ml-1 tw-inline" />
-                            </a>
                             <Link
                                 href="/use-cases/code-health"
-                                className="tw-ml-8"
                                 title="Learn more"
                                 data-button-style={buttonStyle.text}
                                 data-button-location={buttonLocation.body}
                                 data-button-type="cta"
                             >
-                                Learn more
+                                Learn more about code health with Sourcegraph{' '}
+                                <ArrowRightBoxIcon className="ml-1 tw-inline" />
                             </Link>
                         </>
                     }

--- a/src/pages/use-cases/onboarding.tsx
+++ b/src/pages/use-cases/onboarding.tsx
@@ -17,6 +17,7 @@ import {
     ThreeUpText,
     TwoColumnSection,
 } from '../../components'
+import { StandardCallToAction } from '../../components/cta/StandardCallToAction'
 import { buttonStyle, buttonLocation } from '../../data/tracking'
 
 const CarouselItem: FunctionComponent<{ header: string; text: ReactNode }> = ({ header, text }) => (
@@ -205,34 +206,7 @@ const UseCasePage: FunctionComponent = () => (
                 title="Accelerate developer onboarding"
                 subtitle="Decrease time to first commit for new developers, help existing engineers master your
                 codebase, and fast-track full codebase understanding."
-                cta={
-                    <div className="tw-text-center tw-flex-col md:tw-flex-row md:tw-flex">
-                        <div className="mb-3 mb-md-0">
-                            <a
-                                href="https://sourcegraph.com"
-                                className="btn btn-primary w-100 max-w-350"
-                                title="Search code"
-                                data-button-style={buttonStyle.primary}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Search code
-                            </a>
-                        </div>
-                        <div className="ml-md-3">
-                            <a
-                                href="https://signup.sourcegraph.com"
-                                className="btn btn-outline-primary w-100 max-w-350"
-                                title="Get free trial"
-                                data-button-style={buttonStyle.outline}
-                                data-button-location={buttonLocation.hero}
-                                data-button-type="cta"
-                            >
-                                Get free trial
-                            </a>
-                        </div>
-                    </div>
-                }
+                cta={<StandardCallToAction buttonLocation={buttonLocation.hero} />}
             />
         }
     >
@@ -316,12 +290,12 @@ const UseCasePage: FunctionComponent = () => (
                     <a
                         className="btn btn-primary max-w-350 w-100"
                         href="https://signup.sourcegraph.com"
-                        title="Get free trial"
+                        title="Start for free"
                         data-button-style={buttonStyle.primary}
                         data-button-location={buttonLocation.body}
                         data-button-type="cta"
                     >
-                        Get free trial
+                        Start for free
                     </a>
                     <Link
                         href="/use-cases"

--- a/src/pages/webinars/code-insights-turning-your-metrics-into-action.tsx
+++ b/src/pages/webinars/code-insights-turning-your-metrics-into-action.tsx
@@ -95,12 +95,12 @@ const Webinar: FunctionComponent = () => {
                         <a
                             className="mt-4 btn btn-primary col-12 col-md-3 col-xl-2"
                             href="https://signup.sourcegraph.com"
-                            title="Get free trial"
+                            title="Start for free"
                             data-button-style={buttonStyle.primary}
                             data-button-location={buttonLocation.body}
                             data-button-type="cta"
                         >
-                            Get free trial
+                            Start for free
                         </a>
                     </ContentSection>
                 }


### PR DESCRIPTION
- "Schedule a demo" -> "Meet with a product expert"
- "Get free trial" -> "Try Sourcegraph for free" and "Start for free"
- Rewrite some copy on the schedule-demo page to refer to "product experts"
- Refactor code to reduce duplication of CTA-related code
- Use case pages now have the 2 standard CTAs (start for free + meet with product expert) instead of "Search code" as the first CTA


<img width="1105" alt="image" src="https://user-images.githubusercontent.com/1976/216576109-6369d3ab-0cc1-490c-b3f1-49c43ee0a641.png">
