### PR TITLE
Add /accessibility page

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -45,6 +45,10 @@ const FOOTER_LINK_SECTIONS: { name: string; items: LinkWithIcon[] }[] = [
                 name: 'Pricing',
                 href: '/pricing',
             },
+            {
+                name: 'Use cases',
+                href: '/use-cases',
+            },
         ],
     },
     {
@@ -63,10 +67,6 @@ const FOOTER_LINK_SECTIONS: { name: string; items: LinkWithIcon[] }[] = [
                 href: '/case-studies',
             },
             {
-                name: 'Use cases',
-                href: '/use-cases',
-            },
-            {
                 name: 'Changelog',
                 href: 'https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/blob/CHANGELOG.md',
             },
@@ -74,6 +74,10 @@ const FOOTER_LINK_SECTIONS: { name: string; items: LinkWithIcon[] }[] = [
                 name: 'Podcast',
                 href: '/podcast',
             },
+            {
+                name: 'Accessibility',
+                href: '/accessibility',
+            }
         ],
     },
     {

--- a/src/pages/accessibility/index.tsx
+++ b/src/pages/accessibility/index.tsx
@@ -18,7 +18,7 @@ const Accessibility: React.FunctionComponent = () => (
             <p>You can check our progress and contribute to accessibility improvements on our <a href="https://github.com/orgs/sourcegraph/projects/238" target="_blank" rel="noopener noreferrer">GitHub project board</a></p>
 
             <h2 className="mt-xl mb-xs">Contact us</h2>
-            <p>If you encounter any accessibility issues while using our product, please let us know by <a href="https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=accessibility%2Cwcag%2F2.1%2Cwcag%2F2.1%2Ffixing&template=accessibility_issue.yaml&title=%5BAccessibility%5D%3A+">raising an issue on GitHub</a>.</p>
+            <p>If you encounter any accessibility issues while using our product, please let us know by <a href="https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=accessibility%2Cwcag%2F2.1%2Cwcag%2F2.1%2Ffixing&template=accessibility_issue.yaml&title=%5BAccessibility%5D%3A+" target="_blank" rel="noopener noreferrer">raising an issue on GitHub</a>.</p>
             <p>We welcome feedback from our users on how we can improve accessibility. If you have any other questions or concerns, please <Link href="/contact">contact us</Link>.</p>
         </ContentSection>
     </Layout>

--- a/src/pages/accessibility/index.tsx
+++ b/src/pages/accessibility/index.tsx
@@ -13,7 +13,7 @@ const Accessibility: React.FunctionComponent = () => (
             <p>If you want to learn more about the accessibility of our product, you can check our latest <a href="https://storage.googleapis.com/sourcegraph-assets/Sourcegraph%20VPAT_Report_2023-01-20.pdf" target="_blank" rel="noopener noreferrer">VPAT report</a>.</p>
             <p>The report explains how our product conforms to WCAG 2.1 AA criteria, and it lists any known accessibility issues.</p>
 
-            <h2 className="mt-xl mb-xs">How we ensure accessibility</h2>
+            <h2 className="mt-xl mb-xs">Continuing to improve</h2>
             <p>We are actively working on improving accessibility and we consider it for all new features.</p>
             <p>You can check our progress and contribute to accessibility improvements on our <a href="https://github.com/orgs/sourcegraph/projects/238" target="_blank" rel="noopener noreferrer">GitHub project board</a></p>
 

--- a/src/pages/accessibility/index.tsx
+++ b/src/pages/accessibility/index.tsx
@@ -1,0 +1,27 @@
+import Link from 'next/link'
+
+import { ContentSection, Layout } from '../../components'
+
+const Accessibility: React.FunctionComponent = () => (
+    <Layout headerColorTheme="white">
+        <ContentSection background="white">
+            <h1 className="mb-xs">Accessibility</h1>
+            <p>At Sourcegraph, we take accessibility seriously and strive to make our product usable by as many people as possible, including those with disabilities.</p>
+            <p>We work to meet the internationally recognized <a href="https://www.w3.org/TR/WCAG21/" target="_blank" rel="noopener noreferrer">Web Content Accessibility Guidelines</a> (WCAG) 2.1 AA standard for digital accessibility.</p>
+
+            <h2 className="mt-xl mb-xs">Voluntary Product Accessibility Template (VPAT)</h2>
+            <p>If you want to learn more about the accessibility of our product, you can check our latest <a href="https://storage.googleapis.com/sourcegraph-assets/Sourcegraph%20VPAT_Report_2023-01-20.pdf" target="_blank" rel="noopener noreferrer">VPAT report</a>.</p>
+            <p>The report explains how our product conforms to WCAG 2.1 AA criteria, and it lists any known accessibility issues.</p>
+
+            <h2 className="mt-xl mb-xs">How we ensure accessibility</h2>
+            <p>We are actively working on improving accessibility and we consider it for all new features.</p>
+            <p>You can check our progress and contribute to accessibility improvements on our <a href="https://github.com/orgs/sourcegraph/projects/238" target="_blank" rel="noopener noreferrer">GitHub project board</a></p>
+
+            <h2 className="mt-xl mb-xs">Contact us</h2>
+            <p>If you encounter any accessibility issues while using our product, please let us know by <a href="https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=accessibility%2Cwcag%2F2.1%2Cwcag%2F2.1%2Ffixing&template=accessibility_issue.yaml&title=%5BAccessibility%5D%3A+">raising an issue on GitHub</a>.</p>
+            <p>We welcome feedback from our users on how we can improve accessibility. If you have any other questions or concerns, please <Link href="/contact">contact us</Link>.</p>
+        </ContentSection>
+    </Layout>
+)
+
+export default Accessibility


### PR DESCRIPTION
## Description

This PR:
- Adds /accessibility route with link to our VPAT, project board and issue template
- Updates footer links. I wanted to avoid making it too uneven so I moved "Use cases" under the "Product" section.
  - cc @sqs as I know you've made recent changes here

## Screenshot

![image](https://user-images.githubusercontent.com/9516420/220071077-570a60d8-d8f9-45de-a2bf-4af995843397.png)
