### PR TITLE
Optimizations to convert users 

### DIFF
--- a/src/components/Dropdown.tsx
+++ b/src/components/Dropdown.tsx
@@ -1,0 +1,39 @@
+import { FunctionComponent } from 'react'
+
+export const Dropdown: FunctionComponent<{
+    options: string[]
+    defaultOption: string
+    onChange: (value: string) => void
+  }> = ({ options, defaultOption, onChange }) => (
+    <div className="relative inline-block text-left">
+    <div>
+      <span className="rounded-md shadow-sm">
+        <button
+          type="button"
+          className="inline-flex justify-center w-full rounded-md border border-gray-300 px-4 py-2 bg-white text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-indigo-500"
+          id="options-menu"
+          aria-haspopup="true"
+          aria-expanded="true"
+        >
+          {defaultOption}
+          <svg
+            className="-mr-1 ml-2 h-5 w-5"
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 20 20"
+            fill="currentColor"
+            aria-hidden="true"
+          >
+            <path
+              fillRule="evenodd"
+              d="M10 12a2 2 0 100-4 2 2 0 000 4z"
+            />
+            <path
+              fillRule="evenodd"
+              d="M10 3a2 2 0 100 4 2 2 0 000-4zM10 16a2 2 0 100-4 2 2 0 000 4z"
+            />
+          </svg>
+        </button>
+      </span>
+    </div>
+  </div>
+)

--- a/src/components/Layout/Header/NavItems.tsx
+++ b/src/components/Layout/Header/NavItems.tsx
@@ -51,6 +51,10 @@ const NAV_ITEMS: NavItem[] = EXP_SOURCEGRAPH_ENTERPRISE
                       href: '/code-search',
                   },
                   {
+                      name: 'Code Navigation',
+                      href: '/code-navigation',
+                  },
+                  {
                       name: 'Batch Changes',
                       href: '/batch-changes',
                   },
@@ -58,11 +62,57 @@ const NAV_ITEMS: NavItem[] = EXP_SOURCEGRAPH_ENTERPRISE
                       name: 'Code Insights',
                       href: '/code-insights',
                   },
+              ],
+          },
+          {
+              name: 'Usecases',
+              links: [
                   {
-                      name: 'Cloud',
-                      href: '/cloud',
+                      name: 'Improve code security',
+                      href: '/use-cases/code-security',
+                  },
+                  {
+                      name: 'Accelerate onboarding',
+                      href: '/use-cases/onboarding',
+                  },
+                  {
+                      name: 'Resolve incidents faster',
+                      href: '/use-cases/incident-response',
+                  },
+                  {
+                      name: 'Streamline code reuse',
+                      href: '/use-cases/code-reuse',
+                  },
+                  {
+                      name: 'Boost code health',
+                      href: '/use-cases/code-health',
                   },
               ],
+          },
+          {
+              name: 'Deploy',
+              links: [
+                  {
+                      name: 'On Cloud',
+                      href: '/deploy/on-cloud',
+                  },
+                  {
+                      name: 'On Prem',
+                      href: '/deploy/on-premises',
+                  },
+                  {
+                      name: 'Locally',
+                      href: '/deploy/app',
+                  },
+              ],
+          },
+          {
+              name: 'Pricing',
+              href: '/pricing',
+          },
+          {
+              name: 'Public code search',
+              href: 'https://sourcegraph.com/search',
           },
           {
               name: 'Resources',
@@ -83,40 +133,7 @@ const NAV_ITEMS: NavItem[] = EXP_SOURCEGRAPH_ENTERPRISE
                       name: 'Case studies',
                       href: '/case-studies',
                   },
-                  { divider: true },
-                  {
-                      name: 'All use cases',
-                      href: '/use-cases',
-                  },
-                  {
-                      name: 'Code security',
-                      href: '/use-cases/code-security',
-                  },
-                  {
-                      name: 'Developer onboarding',
-                      href: '/use-cases/onboarding',
-                  },
-                  {
-                      name: 'Incident response',
-                      href: '/use-cases/incident-response',
-                  },
-                  {
-                      name: 'Code reuse',
-                      href: '/use-cases/code-reuse',
-                  },
-                  {
-                      name: 'Code health',
-                      href: '/use-cases/code-health',
-                  },
               ],
-          },
-          {
-              name: 'Pricing',
-              href: '/pricing',
-          },
-          {
-              name: 'Public code search',
-              href: 'https://sourcegraph.com/search',
           },
           {
               name: 'Docs',

--- a/src/components/TwoColumnSection.tsx
+++ b/src/components/TwoColumnSection.tsx
@@ -4,6 +4,7 @@ import classNames from 'classnames'
 
 interface TwoColumnSection {
     leftColumn: ReactNode
+    leftColumnCta?: ReactNode
     rightColumn: ReactNode
     reverseOnMobile?: boolean
     blockOnMdAndDown?: boolean
@@ -13,6 +14,7 @@ interface TwoColumnSection {
 
 export const TwoColumnSection: FunctionComponent<TwoColumnSection> = ({
     leftColumn,
+    leftColumnCta,
     rightColumn,
     reverseOnMobile = false,
     blockOnMdAndDown = false,
@@ -35,6 +37,7 @@ export const TwoColumnSection: FunctionComponent<TwoColumnSection> = ({
             })}
         >
             {leftColumn}
+            {leftColumnCta}
         </div>
         <div className={classNames(!mergeColumns && `col-span-12 ${blockOnMdAndDown ? 'md' : 'lg'}:col-span-6`)}>
             {rightColumn}

--- a/src/components/cta/GenericCallToAction.tsx
+++ b/src/components/cta/GenericCallToAction.tsx
@@ -1,0 +1,36 @@
+import React from 'react'
+
+import classNames from 'classnames'
+
+import { buttonStyle } from '../../data/tracking'
+
+export const GenericCallToAction: React.FunctionComponent<{
+    buttonLocation: number
+    href?: string
+    dark?: boolean
+    size?: 'md' | 'lg'
+    children?: string
+    center? : boolean
+    blank?: boolean
+}> = ({ buttonLocation, href, dark = false, size = 'md', children, center = false, blank= true }) => (
+    <div
+        className={classNames('mt-md ', {
+            'mx-auto items-center': center,
+        })}
+    >
+        <a
+            className={classNames(
+                'btn whitespace-nowrap',
+                dark ? 'btn-inverted-primary' : 'btn-primary',
+                size === 'lg' && 'py-xs'
+            )}
+            href={href}
+            data-button-style={buttonStyle.primary}
+            data-button-location={buttonLocation}
+            target={blank ? '_blank' : '_self'}
+            data-button-type="cta"
+        >
+            {children}
+        </a>
+    </div>
+)

--- a/src/pages/code-search.tsx
+++ b/src/pages/code-search.tsx
@@ -13,6 +13,7 @@ import {
 } from '../components'
 import { StandardCallToAction } from '../components/cta/StandardCallToAction'
 import { buttonLocation } from '../data/tracking'
+import { Dropdown } from '../components/Dropdown'
 
 const blogResources = [
     {
@@ -41,6 +42,8 @@ const blogResources = [
         href: '/guides/key-traits-of-a-code-intelligence-platform.pdf',
     },
 ]
+
+  const languages = ['JavaScript', 'TypeScript', 'Python', 'Go']
 
 export const CodeSearchPage: FunctionComponent = () => (
     <Layout
@@ -92,6 +95,8 @@ export const CodeSearchPage: FunctionComponent = () => (
                                 confidence in what's in your codebase.
                             </li>
                         </ul>
+                        <h4 className='mb-6'>Try a sample</h4>
+                        <Dropdown options={languages} defaultOption="JavaScript" onChange= {() => {}} />
                     </>
                 }
             />

--- a/src/pages/use-cases/code-security.tsx
+++ b/src/pages/use-cases/code-security.tsx
@@ -17,6 +17,7 @@ import {
     ThreeUpText,
     TwoColumnSection,
 } from '../../components'
+import { GenericCallToAction } from '../../components/cta/GenericCallToAction'
 import { StandardCallToAction } from '../../components/cta/StandardCallToAction'
 import { UseCasePageCallToAction } from '../../components/cta/UseCasePageCallToAction'
 import { buttonStyle, buttonLocation } from '../../data/tracking'
@@ -302,6 +303,7 @@ const UseCasePage: FunctionComponent = () => (
                         </Link>
                     </div>
                 }
+                leftColumnCta={<GenericCallToAction buttonLocation={buttonLocation.hero} href="https://sourcegraph.com/search?q=context%3Aglobal+log4j&patternType=standard&sm=1&groupBy=repo&flag=vulnerabilities" children = "Find vulnerabilities in your code" />}
             />
         </ContentSection>
 

--- a/src/pages/use-cases/code-security.tsx
+++ b/src/pages/use-cases/code-security.tsx
@@ -56,6 +56,29 @@ const items = [
         ),
     },
     {
+        title: 'Mitigate upstream licensing risks',
+        text: (
+            <CarouselItem
+                header="Mitigate upstream licensing risks"
+                text={
+                    <p className="py-4">
+                        Some open source licenses like GPL require strict compliance to help mitigate any potential risks. With{' '}
+                        <Link
+                            href="/code-search"
+                            title="Code Search"
+                            data-button-style={buttonStyle.text}
+                            data-button-location={buttonLocation.body}
+                            data-button-type="cta"
+                        >
+                            Code Search
+                        </Link>
+                        , quickly find any instances of GPL licensed code.
+                    </p>
+                }
+            />
+        ),
+    },
+    {
         title: 'Automatically merge and deploy fixes',
         text: (
             <CarouselItem


### PR DESCRIPTION
1. made main nav bar logically consistent albeit longer (eg - Cloud doesn't belong under Product but Code Navigation should)
![image](https://user-images.githubusercontent.com/40180234/222641262-53cf0e23-a5ac-485d-b41a-0f2fde189823.png)

2. added CTA where value proposition is presented - user should be able to visualize how that VP will help them specifically
![image](https://user-images.githubusercontent.com/40180234/222641375-b1568b50-4ab5-476b-8850-ec60ac77ea5a.png)

3. identified another use case for the Code Security usecase 
![image](https://user-images.githubusercontent.com/40180234/222641433-9dcde306-55fa-4c48-82b8-26141ea67abe.png)

4. view sample searches customized to user's preferred language (it's supposed to be a dropdown but I haven't used Tailwind before)
![image](https://user-images.githubusercontent.com/40180234/222641671-27c0b383-43b2-4bf0-992c-dbae4a0dc885.png)

5. track user intent through flag
for [2] above, if the user clicks through the CTA, a flag identifying their area of interest is appended to the URL. This can feed into the ABM tool to track who cares about what.
![image](https://user-images.githubusercontent.com/40180234/222642020-5d059d48-a608-4689-a730-11254dd70397.png)
