### PR TITLE
fix CTA color on light pages

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -118,11 +118,11 @@ const HeaderContent: FunctionComponent<Props & { open: boolean; sticky: boolean 
         <>
             <MeetWithProductExpertButton
                 buttonLocation={buttonLocation.nav}
-                buttonClassName="btn-outline-white !font-normal"
+                buttonClassName={classNames('!font-normal', dark ? 'btn-outline-white' : 'btn-link')}
                 requestInfo={true}
             />
             {EXP_GET_STARTED ? (
-                <GetStartedLinkButton buttonLocation={buttonLocation.nav} dark={true} />
+                <GetStartedLinkButton buttonLocation={buttonLocation.nav} dark={dark} />
             ) : (
                 <TrySourcegraphForFreeButton buttonLocation={buttonLocation.nav} dark={dark}>
                     Start for free


### PR DESCRIPTION
Now it is a link with good contrast instead of a white-on-light-background outline button.

![image](https://user-images.githubusercontent.com/1976/223450744-5c4b8d4a-2508-4e24-af45-062449e22d92.png)
