### PR TITLE
no shadow on figures by default

### DIFF
--- a/src/components/Figure.tsx
+++ b/src/components/Figure.tsx
@@ -19,7 +19,7 @@ export const Figure: FunctionComponent<Figure> = ({
     link,
     linkIcon = false,
     centre = false,
-    shadow = true,
+    shadow = false,
 }) => (
     <figure>
         <img src={src} alt={alt} title={alt} className={classNames({ 'mx-auto': centre, 'drop-shadow-xl': shadow })} />

--- a/src/components/Video.tsx
+++ b/src/components/Video.tsx
@@ -35,7 +35,7 @@ export const Video: FunctionComponent<Video> = ({
 }) => (
     <figure>
         <video
-            className="w-full drop-shadow-xl"
+            className="w-full"
             width={1280}
             height={720}
             autoPlay={autoPlay}

--- a/src/pages/batch-changes.tsx
+++ b/src/pages/batch-changes.tsx
@@ -113,7 +113,6 @@ export const BatchChangesPage: FunctionComponent = () => (
                         }}
                         loop={true}
                         title="Batch Changes: How it works"
-                        caption="Search, define, execute, and track code changes"
                     />
                 }
             />


### PR DESCRIPTION
Most static `<Figure>`s shouldn't have a drop shadow. Fixes an issue where the shadow was being applied to some figures where it did not look good:

![image](https://user-images.githubusercontent.com/1976/224183266-a98b5d34-f39e-4cdb-85c4-0116d9eb6631.png)



For some reason, this is showing up differently in local dev vs. prod.

Pushing to check deploy preview.