### PR TITLE
App: Fix font size of installation instructions

### DIFF
--- a/src/components/CodeSnippet.tsx
+++ b/src/components/CodeSnippet.tsx
@@ -27,7 +27,7 @@ export const CodeSnippet: FunctionComponent<CodeSnippetProps> = ({ code, classNa
     }, [copied])
 
     return (
-        <div className={classNames('my-2 flex justify-between rounded-md bg-gray-200 px-2 pt-3 pb-9', className)}>
+        <div className={classNames('my-2 flex justify-between rounded-md bg-gray-200 px-2 pt-3 pb-3', className)}>
             <code className="text-left text-xs text-gray-700">{code}</code>
 
             <Icon size={16} onClick={handleCopy} onKeyDown={handleCopy} role="button" tabIndex={0} />

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -174,7 +174,7 @@ const PlatformsInstallSnippet: FunctionComponent = () => (
                                         className="-ml-2.5"
                                     />
                                 </li>
-                                <li className="ml-2.5 text-sm leading-7">Run `Sourcegraph` in your local directory.</li>
+                                <li className="ml-2.5 text-sm leading-7">Run <code className="bg-gray-200 rounded-md p-1 text-xs text-gray-700">sourcegraph</code> in your local directory.</li>
                                 <li className="ml-2.5 text-sm leading-7">
                                     The app will detect code in the directory you run it in.
                                 </li>
@@ -210,7 +210,7 @@ const PlatformsInstallSnippet: FunctionComponent = () => (
 
                                     <CodeSnippet code="dpkg -i <file.deb>" className="-ml-2.5" />
                                 </li>
-                                <li className="ml-2.5 text-sm leading-7">Run `Sourcegraph` in your local directory.</li>
+                                <li className="ml-2.5 text-sm leading-7">Run <code className="bg-gray-200 rounded-md p-1 text-xs text-gray-700">sourcegraph</code> in your local directory.</li>
                                 <li className="ml-2.5 text-sm leading-7">
                                     The app will detect code in the directory you run it in.
                                 </li>

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -155,7 +155,7 @@ const PlatformsInstallSnippet: FunctionComponent = () => (
                     content: (
                         <div className="mx-0.5 flex flex-col px-4">
                             <ol className="m-0 text-left">
-                                <li className="ml-2.5 text-xs leading-7">
+                                <li className="ml-2.5 text-sm leading-7">
                                     <div className="self-start text-sm leading-7">
                                         Install via{' '}
                                         <Link
@@ -171,14 +171,14 @@ const PlatformsInstallSnippet: FunctionComponent = () => (
 
                                     <CodeSnippet
                                         code="brew install sourcegraph/sourcegraph-app/sourcegraph"
-                                        className="-ml-2.5 pb-3"
+                                        className="-ml-2.5"
                                     />
                                 </li>
-                                <li className="ml-2.5 text-xs leading-7">Run `Sourcegraph` in your local directory.</li>
-                                <li className="ml-2.5 text-xs leading-7">
+                                <li className="ml-2.5 text-sm leading-7">Run `Sourcegraph` in your local directory.</li>
+                                <li className="ml-2.5 text-sm leading-7">
                                     The app will detect code in the directory you run it in.
                                 </li>
-                                <li className="ml-2.5 text-xs leading-7">
+                                <li className="ml-2.5 text-sm leading-7">
                                     Your browser will automatically open localhost:3080.
                                 </li>
                             </ol>
@@ -195,7 +195,7 @@ const PlatformsInstallSnippet: FunctionComponent = () => (
                     content: (
                         <div className="mx-0.5 flex flex-col px-4">
                             <ol className="m-0 text-left">
-                                <li className="ml-2.5 text-xs leading-7">
+                                <li className="ml-2.5 text-sm leading-7">
                                     <div className="self-start text-sm leading-7">
                                         Download the{' '}
                                         <Link
@@ -208,13 +208,13 @@ const PlatformsInstallSnippet: FunctionComponent = () => (
                                         and install it:
                                     </div>
 
-                                    <CodeSnippet code="dpkg -i <file.deb>" className="-ml-2.5 pb-3" />
+                                    <CodeSnippet code="dpkg -i <file.deb>" className="-ml-2.5" />
                                 </li>
-                                <li className="ml-2.5 text-xs leading-7">Run `Sourcegraph` in your local directory.</li>
-                                <li className="ml-2.5 text-xs leading-7">
+                                <li className="ml-2.5 text-sm leading-7">Run `Sourcegraph` in your local directory.</li>
+                                <li className="ml-2.5 text-sm leading-7">
                                     The app will detect code in the directory you run it in.
                                 </li>
-                                <li className="ml-2.5 text-xs leading-7">
+                                <li className="ml-2.5 text-sm leading-7">
                                     Your browser will automatically open localhost:3080.
                                 </li>
                             </ol>


### PR DESCRIPTION
## Description

This PR:
1. Updates the font-size of steps 2,3,4 to match step 1 - `text-sm`
2. Updates `CodeSnippet` to remove the `pb-9` that makes the snippet look so big. This was fixed in [this PR](https://github.com/sourcegraph/about/pull/6069) but I noticed that this still doesn't work for me, it seems to take different padding depending on the CSS order. We only use `CodeSnippet` in this one place so we can change this.

Before:

<img width="847" alt="image" src="https://user-images.githubusercontent.com/9516420/224718355-9318cd2e-3054-44bc-8475-22f3bbd7defd.png">

After:

<img width="787" alt="image" src="https://user-images.githubusercontent.com/9516420/224718448-3c1e3438-11b4-4b85-b589-be5291b30c3e.png">
