### PR TITLE
Add linkedin insights tag and track form conversion

### DIFF
--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -1,6 +1,11 @@
 import Document, { Head, Html, Main, NextScript } from 'next/document'
 import Script from 'next/script'
 
+/**
+ * LinkedIn Partner ID for the LinkedIn Insights Tag
+ */
+const linkedinPartnerId = '5259873'
+
 export default class MyDocument extends Document {
     public override render(): JSX.Element {
         return (
@@ -97,6 +102,28 @@ export default class MyDocument extends Document {
                         src="https://plausible.io/js/plausible.js"
                         strategy="afterInteractive"
                     />
+
+\                   {/* LinkedIn Insights Tag */}
+                    <Script id="linkedin-insights-tag" type="text/javascript" strategy="afterInteractive">
+                        {`<script type="text/javascript">
+                        _linkedin_partner_id = "${linkedinPartnerId}";
+                        window._linkedin_data_partner_ids = window._linkedin_data_partner_ids || [];
+                        window._linkedin_data_partner_ids.push(_linkedin_partner_id);
+                        </script><script type="text/javascript">
+                        (function(l) {
+                        if (!l){window.lintrk = function(a,b){window.lintrk.q.push([a,b])};
+                        window.lintrk.q=[]}
+                        var s = document.getElementsByTagName("script")[0];
+                        var b = document.createElement("script");
+                        b.type = "text/javascript";b.async = true;
+                        b.src = "https://snap.licdn.com/li.lms-analytics/insight.min.js";
+                        s.parentNode.insertBefore(b, s);})(window.lintrk);
+                        </script>
+                        <noscript>
+                        <img height="1" width="1" style="display:none;" alt="" src="https://px.ads.linkedin.com/collect/?pid=${linkedinPartnerId}&fmt=gif" />
+                        </noscript>
+                        `}
+                    </Script>
 
                     {/* Triblio "Webpage Personalization" */}
                     {/* Triblio recommends this in the head which we follow with beforeInteractive */}

--- a/src/pages/starship/index.tsx
+++ b/src/pages/starship/index.tsx
@@ -75,6 +75,9 @@ const Starship: FunctionComponent = () => (
                     <HubSpotForm
                         formId="93419890-2b5e-4109-ad13-0fd2ee0c1607"
                         inlineMessage="Thanks for registering for Starship! You will receive event updates and product announcements from Sourcegraph in your email."
+                        onFormSubmitted={() => {
+                            window.lintrk?.('track', { conversion_id: 12782521 })
+                        }}
                     />
                 </div>
             </div>


### PR DESCRIPTION
- Add the LinkedIn Insights Tag script into the site
- Add a `window.lintrk` call on the submission of the Starship registration form, with a LinkedIn conversion id.