### PR TITLE
Move DownloadLink into separate component file

### DIFF
--- a/src/components/DownloadLink.tsx
+++ b/src/components/DownloadLink.tsx
@@ -1,0 +1,25 @@
+import Link from 'next/link'
+
+import { getEventLogger } from '../hooks/eventLogger'
+
+type DownloadLinkProps = React.ComponentProps<typeof Link> & { downloadName: string }
+
+/**
+ * Wrapper for the Link component that logs download clicks. Requires a
+ * downloadName which is an identifier for the download, such as
+ * "app-download-mac-zip".
+ */
+export const DownloadLink: React.FunctionComponent<DownloadLinkProps> = props => {
+    const { downloadName, ...linkProps } = props
+    const handleOnClick = (): void => {
+        const eventArguments = {
+            downloadSource: 'about',
+            downloadName,
+            downloadLinkUrl: linkProps.href,
+        }
+        // eslint-disable-next-line @typescript-eslint/no-floating-promises
+        getEventLogger().log('DownloadClick', eventArguments, eventArguments)
+    }
+
+    return <Link {...linkProps} onClick={handleOnClick} />
+}

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -11,23 +11,7 @@ import Link from 'next/link'
 import { Layout, Heading, Tabs, Badge, ThreeUpText } from '../components'
 import { DemoVideo } from '../components/AppVideo'
 import { CodeSnippet } from '../components/CodeSnippet'
-import { getEventLogger } from '../hooks/eventLogger'
-
-type DownloadLinkProps = React.ComponentProps<typeof Link> & { downloadName: string }
-const DownloadLink: React.FunctionComponent<DownloadLinkProps> = props => {
-    const { downloadName, ...linkProps } = props
-    const handleOnClick = (): void => {
-        const eventArguments = {
-            downloadSource: 'about',
-            downloadName,
-            downloadLinkUrl: linkProps.href,
-        }
-        // eslint-disable-next-line @typescript-eslint/no-floating-promises
-        getEventLogger().log('DownloadClick', eventArguments, eventArguments)
-    }
-
-    return <Link {...linkProps} onClick={handleOnClick} />
-}
+import { DownloadLink } from '../components/DownloadLink'
 
 const AppPage: FunctionComponent = () => {
     const threeUpTextItems = [


### PR DESCRIPTION
Move the `<DownloadLink>` component so that it can be used in multiple pages.

This is important for the other page updates, because all App download links (direct links to download files) need to be tracked using `<DownloadLink downloadName="..."/>`