### PR TITLE
[SGM-6109] : Adjustments to the Pricing page

### DIFF
--- a/src/components/Pricing/PricingPlan.tsx
+++ b/src/components/Pricing/PricingPlan.tsx
@@ -7,7 +7,7 @@ import { PricingPlanFeature } from './PricingPlanFeature'
 
 interface Props {
     name: string
-    description: string
+    description: ReactNode
     price: string
     priceDetail?: string
     buttons: ReactNode
@@ -35,7 +35,7 @@ export const PricingPlan: FunctionComponent<Props> = ({
             <div className="text-xl">{price}</div>{' '}
             {priceDetail && <div className="text-sm font-normal text-gray-400">{priceDetail}</div>}
         </h4>
-        <h3 className="my-sm max-w-sm text-lg font-normal">{description}</h3>
+        {description}
         {buttons}
 
         {(beforeFeatures || features.length > 0) && (

--- a/src/pages/pricing.tsx
+++ b/src/pages/pricing.tsx
@@ -143,7 +143,15 @@ const PricingPage: FunctionComponent = () => {
                 <div className="col-span-full mb-sm md:col-span-5 md:col-start-2 md:mb-0">
                     <PricingPlan
                         name="Enterprise Starter"
-                        description="Full platform access for teams and orgs. Flexible deployment options. Online Terms of Service and workshop based evaluation path."
+                        description={
+                            <h3 className="my-sm md:min-h-[108px] max-w-sm text-lg font-normal">
+                                Full platform access for teams and orgs. Flexible deployment options.{' '}
+                                <Link href="/terms" title="Online Terms of Service" className="text-black underline">
+                                    Online Terms of Service
+                                </Link>{' '}
+                                and workshop based evaluation path.
+                            </h3>
+                        }
                         price="Starts at $5k/year"
                         priceDetail="Scales with your team"
                         buttons={<StartFreeButton />}
@@ -155,7 +163,12 @@ const PricingPage: FunctionComponent = () => {
                 <div className="col-span-full md:col-span-5 md:col-start-7">
                     <PricingPlan
                         name="Enterprise"
-                        description="All the benefits of Enterprise Starter with increased Support SLAs and custom deployment options."
+                        description={
+                            <h3 className="my-sm md:min-h-[108px] max-w-sm text-lg font-normal">
+                                All the benefits of Enterprise Starter with increased Support SLAs and custom deployment
+                                options.
+                            </h3>
+                        }
                         price="Starts at $50k/year"
                         priceDetail="Scales with your team"
                         buttons={<EnterpriseButtons />}


### PR DESCRIPTION
## Description
We'd like to create 2 small adjustments to the Pricing page: https://about.sourcegraph.com/pricing

1. Make the text "Online Terms of Service" into a hyperlink. It should link here: https://about.sourcegraph.com/pricing
2. Add spacing on the 'Enterprise' panel so that the 'Start for free' buttons are level. The spacing should be added underneath the "All the benefits..." text segment.


## Ref
[SG Issue](https://github.com/sourcegraph/about/issues/6109)