### PR TITLE
Centralize app download links for easier releases

### DIFF
--- a/src/components/DownloadLink.tsx
+++ b/src/components/DownloadLink.tsx
@@ -1,9 +1,9 @@
 import Link from 'next/link'
 
-import { sourcegraphAppDownloads } from '../data/downloads'
+import { appDownloads } from '../data/downloads'
 import { getEventLogger } from '../hooks/eventLogger'
 
-type DownloadLinkProps = Omit<React.ComponentProps<typeof Link> & { downloadName: keyof typeof sourcegraphAppDownloads }, 'href'>
+type DownloadLinkProps = Omit<React.ComponentProps<typeof Link> & { downloadName: keyof typeof appDownloads }, 'href'>
 
 /**
  * Wrapper for the Link component that logs download clicks. Requires a
@@ -12,7 +12,7 @@ type DownloadLinkProps = Omit<React.ComponentProps<typeof Link> & { downloadName
  */
 export const DownloadLink: React.FunctionComponent<DownloadLinkProps> = props => {
     const { downloadName, ...linkProps } = props
-    const href = sourcegraphAppDownloads[downloadName];
+    const href = appDownloads[downloadName]
     const handleOnClick = (): void => {
         const eventArguments = {
             downloadSource: 'about',

--- a/src/components/DownloadLink.tsx
+++ b/src/components/DownloadLink.tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link'
 
+import { sourcegraphAppDownloads } from '../data/downloads'
 import { getEventLogger } from '../hooks/eventLogger'
 
-type DownloadLinkProps = React.ComponentProps<typeof Link> & { downloadName: string }
+type DownloadLinkProps = Omit<React.ComponentProps<typeof Link> & { downloadName: keyof typeof sourcegraphAppDownloads }, 'href'>
 
 /**
  * Wrapper for the Link component that logs download clicks. Requires a
@@ -11,15 +12,16 @@ type DownloadLinkProps = React.ComponentProps<typeof Link> & { downloadName: str
  */
 export const DownloadLink: React.FunctionComponent<DownloadLinkProps> = props => {
     const { downloadName, ...linkProps } = props
+    const href = sourcegraphAppDownloads[downloadName];
     const handleOnClick = (): void => {
         const eventArguments = {
             downloadSource: 'about',
             downloadName,
-            downloadLinkUrl: linkProps.href,
+            downloadLinkUrl: href,
         }
         // eslint-disable-next-line @typescript-eslint/no-floating-promises
         getEventLogger().log('DownloadClick', eventArguments, eventArguments)
     }
 
-    return <Link {...linkProps} onClick={handleOnClick} />
+    return <Link href={href} {...linkProps} onClick={handleOnClick} />
 }

--- a/src/data/downloads.ts
+++ b/src/data/downloads.ts
@@ -1,0 +1,11 @@
+
+const appVersionString = '2023.03.23+209542.7216ba'
+
+const appDownloadPrefix = 'https://storage.googleapis.com/sourcegraph-app-releases'
+
+export const sourcegraphAppDownloads = {
+    'app-download-mac-dmg': `${appDownloadPrefix}/latest/Sourcegraph%20App.dmg`,
+    'app-download-mac-zip': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_darwin_all.zip`,
+    'app-download-linux-deb': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_linux_amd64.deb`,
+    'app-download-linux-zip': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_linux_amd64.zip`,
+} as const;

--- a/src/data/downloads.ts
+++ b/src/data/downloads.ts
@@ -1,11 +1,10 @@
-
 const appVersionString = '2023.03.23+209542.7216ba'
 
 const appDownloadPrefix = 'https://storage.googleapis.com/sourcegraph-app-releases'
 
-export const sourcegraphAppDownloads = {
+export const appDownloads = {
     'app-download-mac-dmg': `${appDownloadPrefix}/latest/Sourcegraph%20App.dmg`,
     'app-download-mac-zip': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_darwin_all.zip`,
     'app-download-linux-deb': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_linux_amd64.deb`,
     'app-download-linux-zip': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_linux_amd64.zip`,
-} as const;
+} as const

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -199,7 +199,6 @@ const PlatformsInstallSnippet: FunctionComponent = () => (
                                         Download the{' '}
                                         <DownloadLink
                                             downloadName="app-download-linux-deb"
-                                            href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+209542.7216ba/sourcegraph_2023.03.23+209542.7216ba_linux_amd64.deb"
                                             title="Sourcegaph App Debian package"
                                             className="text-gray-500 underline"
                                         >
@@ -239,7 +238,6 @@ const PlatformsInstallSnippet: FunctionComponent = () => (
 const DownloadSection: FunctionComponent = () => (
     <>
         <DownloadLink
-            href="https://storage.googleapis.com/sourcegraph-app-releases/latest/Sourcegraph%20App.dmg"
             className="btn btn-inverted-primary w-fit px-4 font-normal shadow-btn"
             title="Download for Mac"
             downloadName="app-download-mac-dmg"
@@ -250,7 +248,6 @@ const DownloadSection: FunctionComponent = () => (
         <p className="mt-3 text-sm text-gray-300">
             MacOS 13+ required.{' '}
             <DownloadLink
-                href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+209542.7216ba/sourcegraph_2023.03.23+209542.7216ba_darwin_all.zip"
                 title="Older versions"
                 downloadName="app-download-mac-zip"
                 className="text-sm leading-[21px] text-gray-300 underline"

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -178,7 +178,7 @@ const InterstitialAppContent: FunctionComponent = () => (
             <DownloadLink
                 className="btn btn-primary mt-6 w-fit px-4 font-normal"
                 title="Download for Mac"
-                downloadName='app-download-mac-dmg'
+                downloadName="app-download-mac-dmg"
             >
                 Download for Mac
             </DownloadLink>

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -176,7 +176,6 @@ const InterstitialAppContent: FunctionComponent = () => (
             </div>
 
             <DownloadLink
-                href="https://storage.googleapis.com/sourcegraph-app-releases/latest/Sourcegraph%20App.dmg"
                 className="btn btn-primary mt-6 w-fit px-4 font-normal"
                 title="Download for Mac"
                 downloadName='app-download-mac-dmg'
@@ -187,7 +186,6 @@ const InterstitialAppContent: FunctionComponent = () => (
             <p className="mb-0 mt-2.5 flex text-gray-500">
                 MacOS 13+ required.
                 <DownloadLink
-                    href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+209542.7216ba/sourcegraph_2023.03.23+209542.7216ba_darwin_all.zip"
                     className="ml-1 font-normal text-gray-500 underline"
                     title="Old versions"
                     target="_blank"
@@ -206,7 +204,6 @@ const InterstitialAppContent: FunctionComponent = () => (
 
             <div className="mt-4 flex flex-row gap-x-4">
                 <DownloadLink
-                    href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+209542.7216ba/sourcegraph_2023.03.23+209542.7216ba_linux_amd64.deb"
                     className="btn btn-primary w-fit px-4 font-normal"
                     title="Download .deb"
                     downloadName="app-download-linux-deb"
@@ -214,7 +211,6 @@ const InterstitialAppContent: FunctionComponent = () => (
                     Download .deb
                 </DownloadLink>
                 <DownloadLink
-                    href="https://storage.googleapis.com/sourcegraph-app-releases/2023.03.23+209542.7216ba/sourcegraph_2023.03.23+209542.7216ba_linux_amd64.zip"
                     className="btn btn-primary w-fit px-4 font-normal"
                     title="Download .zip"
                     downloadName="app-download-linux-zip"

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -280,7 +280,6 @@ const HomeHero: FunctionComponent = () => (
 const AppDownloadLinks: FunctionComponent<AppDownloadLinksProps> = ({ className }) => (
     <div className={className}>
         <DownloadLink
-            href="https://storage.googleapis.com/sourcegraph-app-releases/latest/Sourcegraph%20App.dmg"
             className="btn btn-inverted-primary w-fit px-4 font-normal shadow-btn"
             title="Download for Mac"
             downloadName="app-download-mac-dmg"


### PR DESCRIPTION
Centralize the download URLs for Sourcegraph app in `data/downloads.ts` for easier updating in one place.

Adds type-checking so that the `<DownloadLink>` component's `downloadName` must be a valid download by checking that it's present as a key of the `appDownloads` object.