### PR TITLE
[SGM-6144] : Updates to /cody

### DIFF
--- a/src/pages/cody.tsx
+++ b/src/pages/cody.tsx
@@ -34,10 +34,9 @@ const CodyPage: FunctionComponent = () => (
                     graph.
                 </Heading>
                 <Link
-                    href="https://sourcegraph.typeform.com/cody-signup"
+                    href="#cta"
                     title="Private beta access request form"
                     className="btn btn-inverted-primary mt-8"
-                    target="_blank"
                 >
                     Request access
                 </Link>
@@ -65,28 +64,35 @@ const CodyPage: FunctionComponent = () => (
         </ContentSection>
 
         <ContentSection
+            id="cta"
             parentClassName="!py-0"
             className="mx-auto flex flex-col items-center justify-center gap-x-8 py-[112px] md:flex-row"
         >
             <div className="max-w-[529px]">
                 <Heading size="h2" className="!text-4xl text-white">
-                    Cody is experimental
-                </Heading>
-                <p className="mt-6 text-lg text-gray-200">
-                    Often magical, often frustratingly wrong...but getting better quickly.
-                </p>
-            </div>
-            <div className="flex max-w-[452px] flex-col justify-center border-t border-gray-500 pt-8 md:h-[232px] md:border-l md:border-t-0 md:pl-8 md:pt-0">
-                <Heading size="h5" className="text-white">
-                    Interested in deploying Cody for your team? Let us know.
+                    Cody for Teams
                 </Heading>
                 <Link
                     href="https://sourcegraph.typeform.com/cody-signup"
-                    title="Private beta access request form"
+                    title="Join the waitlist for Cody Enterprise"
                     className="btn mt-8 bg-transparent pl-0 text-white"
                     target="_blank"
                 >
-                    Join the waitlist
+                    Join the waitlist for Cody Enterprise
+                    <ChevronRightIcon className="!mb-0 ml-[10px] inline" />
+                </Link>
+            </div>
+            <div className="flex max-w-[452px] flex-col justify-center border-t border-gray-500 pt-8 md:h-[232px] md:border-l md:border-t-0 md:pl-8 md:pt-0">
+                <Heading size="h2" className="!text-4xl text-white">
+                    Cody for Individuals
+                </Heading>
+                <Link
+                    href="https://sourcegraph.typeform.com/cody-signup"
+                    title="Get Cody Community"
+                    className="btn mt-8 bg-transparent pl-0 text-white"
+                    target="_blank"
+                >
+                    Get Cody Community
                     <ChevronRightIcon className="!mb-0 ml-[10px] inline" />
                 </Link>
             </div>


### PR DESCRIPTION
## Description
Update copy at the bottom of the page like the image attached (see [here](https://about.sourcegraph.com/cody#:~:text=Cody%20is%20experimental))
1. Cody for Teams and Cody for individuals should be h2 (like Cody is experimental)

2. CTAs should have the same style as Join the waitlist

3. Request access CTA at the top of the page should take you to these two new CTAs.

![228676937-ce65d53b-f7c0-4bf8-a72f-1050b9462ba5](https://user-images.githubusercontent.com/51731962/228756876-75e214ba-8415-4530-a374-2b16623450b0.png)


## Ref
[SG Issue](https://github.com/sourcegraph/about/issues/6144)
[Gitstart Ticket](https://clients.gitstart.com/sourcegraph/1/tickets/SGM-6144)

## Demo Video
https://www.loom.com/share/8c3a06cc19194442a54331792b6547f9