### PR TITLE
Update get-started.tsx Server link

### DIFF
--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -286,7 +286,7 @@ const EnterPriseTrial: FunctionComponent = () => (
                     Cloud
                 </Link>
                 <Link
-                    href="/get-started/self-hosted"
+                    href="https://docs.sourcegraph.com/admin/deploy"
                     title="Server"
                     className="ml-2 text-xl font-semibold text-violet-500"
                 >


### PR DESCRIPTION
Updating the 'server' link to point to the docs instead of /get-started/self-hosted