### PR TITLE
[SGM-6186]: Update Gartner page

### DIFF
--- a/src/components/GatedResourceLayout.tsx
+++ b/src/components/GatedResourceLayout.tsx
@@ -63,12 +63,12 @@ export const GatedResourceLayout: FunctionComponent<Props> = ({
                 </div>
             ) : (
                 // ---- DEFAULT BODY VARIATION ----
-                <ContentSection background="white" className="flex flex-col-reverse md:flex-row">
+                <ContentSection background="white" className="mb-4 grid grid-cols-1 gap-0  md:grid-cols-2 md:gap-9">
                     {description}
 
-                    <div className="pb-3xl md:pb-0">
-                        <h2>{formLabel}</h2>
-                        <div className="sg-border-gradient-saturn mt-4 border-3 border-solid p-sm drop-shadow">
+                    <div className="order-1 pb-3xl md:order-2 md:pb-0">
+                        <h2 className="mb-[30px]">{formLabel}</h2>
+                        <div className="sg-border-gradient-saturn mt-0 border-3 border-solid p-sm drop-shadow md:mt-4">
                             {!hasWatchNowQuery && !demioForm && (
                                 <HubSpotForm
                                     masterFormName="gatedMulti"

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -22,9 +22,10 @@ interface Hero extends Background {
     displayUnderNav?: boolean
     mergeColumns?: boolean
     centerContent?: boolean
+    className?: string
 }
 
-export const Hero: FunctionComponent<Omit<Hero, 'className' | 'children' | 'illustration'>> = ({
+export const Hero: FunctionComponent<Omit<Hero, 'children' | 'illustration'>> = ({
     variant,
     product,
     title,
@@ -38,6 +39,7 @@ export const Hero: FunctionComponent<Omit<Hero, 'className' | 'children' | 'illu
     displayUnderNav = false,
     mergeColumns = false,
     centerContent = false,
+    className,
 }) => {
     let illustration: Background['illustration']
     if (product && product !== 'sourcegraph cloud') {
@@ -88,7 +90,7 @@ export const Hero: FunctionComponent<Omit<Hero, 'className' | 'children' | 'illu
         <ContentSection
             background={variant}
             illustration={illustration}
-            parentClassName={classNames({
+            parentClassName={classNames(className, {
                 '-mt-[68px] md:-mt-[74px] pt-5xl md:!pt-[148px]': displayUnderNav,
                 'relative md:h-[750px] lg:mb-xs md:mb-4xl mb-0': floatingImg,
             })}

--- a/src/pages/2022-gartner-cool-vendors-in-software-engineering.tsx
+++ b/src/pages/2022-gartner-cool-vendors-in-software-engineering.tsx
@@ -11,7 +11,10 @@ export const Report: FunctionComponent = () => (
         }}
         hero={
             <Hero
-                variant="venusCode"
+                className="enterprise-form-bg"
+                displayUnderNav={true}
+                titleClassName="text-white text-4xl md:text-7xl"
+                variant="purple"
                 title="Cool Vendors in Software Engineering: Enhancing Developer Productivity"
                 leftColumn={
                     <img
@@ -23,26 +26,26 @@ export const Report: FunctionComponent = () => (
                 mergeColumns={true}
             />
         }
+        headerColorTheme="purple"
     >
         <GatedResourceLayout
             title="Cool Vendors in Software Engineering: Enhancing Developer Productivity"
-            formLabel="Access the report"
+            formLabel="Download the report"
             resource="https://www.gartner.com/doc/reprints?id=1-2A44UTV8&ct=220524&st=sb"
             description={
-                <section>
+                <section className="order-2 md:order-1">
                     <h3 className="pb-md font-normal">
-                        Get complimentary access to the 2022 Gartner® Cool Vendors™ report.
+                        Get complimentary access to 2022 Gartner® Cool Vendors™ report to learn how we believe
+                        Sourcegraph and other innovative tools help engineers and engineering leaders boost developer
+                        productivity while mitigating security risks.
                     </h3>
-                    <p className="pb-xxs">
-                        Learn how we believe Sourcegraph and other innovative tools help engineers and engineering
-                        leaders boost developer productivity while mitigating security risks.
-                    </p>
+
                     <p className="text-gray-400">
-                        The GARTNER COOL VENDOR badge and Gartner are registered trademarks and service mark of Gartner,
-                        Inc. and/or its affiliates and is used herein with permission. All rights reserved. Gartner does
-                        not endorse any vendor, product or service depicted in its research publications and does not
-                        advise technology users to select only those vendors with the highest ratings or other
-                        designation. Gartner research publications consist of the opinions of Gartner’s Research &
+                        TThe GARTNER COOL VENDOR badge and Gartner are registered trademarks and service mark of
+                        Gartner, Inc. and/or its affiliates and is used herein with permission. All rights reserved.
+                        Gartner does not endorse any vendor, product or service depicted in its research publications
+                        and does not advise technology users to select only those vendors with the highest ratings or
+                        other designation. Gartner research publications consist of the opinions of Gartner’s Research &
                         Advisory organization and should not be construed as statements of fact. Gartner disclaims all
                         warranties, expressed or implied, with respect to this research, including any warranties of
                         merchantability or fitness for a particular purpose.


### PR DESCRIPTION
### Description
Update design of [Gartner Page](https://about.sourcegraph.com/2022-gartner-cool-vendors-in-software-engineering) so it follows the [Figma ](https://www.figma.com/file/vVvebR510dGnR8zPx12Upv/Gartner?node-id=0-1&t=PbEfto7N2R6QxEz1-0). The page currently uses a different hero, and it's not rendering well.

### Ref
[SG Issue](https://github.com/sourcegraph/about/issues/6186)
[GitStart Ticket](https://clients.gitstart.com/sourcegraph/1/tickets/SGM-6186)

### Demo

https://user-images.githubusercontent.com/89894075/231758879-0ccb12d6-7ce9-4080-b56b-5eeb7413d250.mov


