### PR TITLE
SGM-6194 - Add tweets to /cody

### DIFF
--- a/src/components/EmbedTweet.tsx
+++ b/src/components/EmbedTweet.tsx
@@ -1,0 +1,21 @@
+import React, { FunctionComponent } from 'react'
+
+import classNames from 'classnames'
+
+interface Props {
+    tweetId: string
+    dark?: boolean
+    className?: string
+}
+
+export const TwitterEmbed: FunctionComponent<Props> = ({ tweetId, className, dark = true }) => {
+    const theme = dark ? 'dark' : 'light'
+
+    return (
+        <div className={classNames(className)}>
+            <blockquote className='twitter-tweet' data-theme={theme}>
+                <a href={`https://twitter.com/twitter/status/${tweetId}`}> </a>
+            </blockquote>
+        </div>
+    )
+}

--- a/src/components/EmbedTweet.tsx
+++ b/src/components/EmbedTweet.tsx
@@ -1,21 +1,37 @@
 import React, { FunctionComponent } from 'react'
 
 import classNames from 'classnames'
+import Script from 'next/script'
 
+/**
+ * Props for the TwitterEmbed component.
+ */
 interface Props {
+    /** The ID of the tweet to embed. */
     tweetId: string
+    /** Whether to use the dark theme. Default to true */
     dark?: boolean
+    /** Additional class name(s) for the component. */
     className?: string
 }
 
+/**
+ * A component that embeds a tweet from Twitter.
+ */
 export const TwitterEmbed: FunctionComponent<Props> = ({ tweetId, className, dark = true }) => {
     const theme = dark ? 'dark' : 'light'
 
     return (
-        <div className={classNames(className)}>
-            <blockquote className='twitter-tweet' data-theme={theme}>
-                <a href={`https://twitter.com/twitter/status/${tweetId}`}> </a>
-            </blockquote>
-        </div>
+        <>
+            {/* Load the Twitter widgets script */}
+            <Script id="tweeter_widget" async={true} src="https://platform.twitter.com/widgets.js" />
+
+            <div className={classNames(className)}>
+                <blockquote className="twitter-tweet" data-theme={theme}>
+                    {/* Link to the tweet on Twitter */}
+                    <a href={`https://twitter.com/twitter/status/${tweetId}`}> </a>
+                </blockquote>
+            </div>
+        </>
     )
 }

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -132,6 +132,14 @@ export default class MyDocument extends Document {
                         strategy="afterInteractive"
                         defer={true}
                     />
+
+                    {/* Support Tweets Embed */}
+                    <Script
+                        id="tweeter"
+                        type="text/javascript"
+                        src="https://platform.twitter.com/widgets.js"
+                        strategy="afterInteractive"
+                    />
                 </Head>
                 <body>
                     {/* Google Tag Manager (noscript) */}

--- a/src/pages/_document.tsx
+++ b/src/pages/_document.tsx
@@ -132,14 +132,6 @@ export default class MyDocument extends Document {
                         strategy="afterInteractive"
                         defer={true}
                     />
-
-                    {/* Support Tweets Embed */}
-                    <Script
-                        id="tweeter"
-                        type="text/javascript"
-                        src="https://platform.twitter.com/widgets.js"
-                        strategy="afterInteractive"
-                    />
                 </Head>
                 <body>
                     {/* Google Tag Manager (noscript) */}

--- a/src/pages/cody.tsx
+++ b/src/pages/cody.tsx
@@ -5,6 +5,10 @@ import Link from 'next/link'
 
 import { Badge, ContentSection, Heading, Layout } from '../components'
 import { DemoVideo } from '../components/CodyVideo'
+import { TwitterEmbed } from '../components/EmbedTweet'
+
+// Update tweetIds here, to change/add displayed tweets
+const tweetsIds = ['1645903813302185984', '1647765520673046529']
 
 const CodyPage: FunctionComponent = () => (
     <Layout
@@ -64,9 +68,21 @@ const CodyPage: FunctionComponent = () => (
             <img src="/cody/cody.svg" alt="Own Illustration" className="w-full max-w-[630px]" />
         </ContentSection>
 
+        <ContentSection parentClassName="text-center !pb-0">
+            <Heading size="h2" className="text-white">
+                See what devs are building with Cody
+            </Heading>
+
+            <div className="mt-6 grid grid-cols-1 justify-center gap-6 md:mt-16 md:grid-cols-2">
+                {tweetsIds.map(id => (
+                    <TwitterEmbed tweetId={id} key={id} className="flex max-w-[100%] justify-center " />
+                ))}
+            </div>
+        </ContentSection>
+
         <ContentSection
             parentClassName="!py-0"
-            className="mx-auto flex flex-col items-center justify-center gap-x-8 py-[112px] md:flex-row"
+            className="mx-auto flex flex-col items-center justify-center gap-x-8  py-16 md:flex-row md:py-[112px]"
         >
             <div className="max-w-[529px]">
                 <Heading size="h2" className="!text-4xl text-white">

--- a/src/pages/cody.tsx
+++ b/src/pages/cody.tsx
@@ -7,9 +7,6 @@ import { Badge, ContentSection, Heading, Layout } from '../components'
 import { DemoVideo } from '../components/CodyVideo'
 import { TwitterEmbed } from '../components/EmbedTweet'
 
-// Update tweetIds here, to change/add displayed tweets
-const tweetsIds = ['1645903813302185984', '1647765520673046529']
-
 const CodyPage: FunctionComponent = () => (
     <Layout
         meta={{
@@ -73,10 +70,12 @@ const CodyPage: FunctionComponent = () => (
                 See what devs are building with Cody
             </Heading>
 
-            <div className="mt-6 grid grid-cols-1 justify-center gap-6 md:mt-16 md:grid-cols-2">
-                {tweetsIds.map(id => (
-                    <TwitterEmbed tweetId={id} key={id} className="flex max-w-[100%] justify-center " />
-                ))}
+            <div className="mt-6 grid w-full grid-cols-1 gap-6 md:mt-16 md:grid-cols-2">
+                <TwitterEmbed tweetId="1645903813302185984" className="flex max-w-[100%] justify-center" />
+                <div className="flex flex-col">
+                    <TwitterEmbed tweetId="1647765520673046529?s=20" className="flex max-w-[100%] justify-center" />
+                    <TwitterEmbed tweetId="1645490165857542145" className="flex max-w-[100%] justify-center " />
+                </div>
             </div>
         </ContentSection>
 


### PR DESCRIPTION
## Description
- Create an `EmbedTweet` component, to be used for adding embedded tweets by `ids`
- Add embedded tweets on `/cody` page.

## Ref 
[SG Issue](https://github.com/sourcegraph/about/issues/6194)
[Gitstart Ticket](https://clients.gitstart.com/sourcegraph/1/tickets/SGM-6194)


## How to Update/Add Embedded tweet
- Extract the `id` of the desired tweet you wish to embed.
- Go to `src/pages/cody.tsx` file.
- Find `<TwitterEmbed />` snippet below within the file `cody.tsx`
- Update the `tweetId` property to the new value.


## Demo


https://user-images.githubusercontent.com/45232708/233074294-187eb3fa-a536-404a-88dd-a36fe94f738c.mov


