### PR TITLE
[SGM-6220] - Add hello bar to homepage

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -1,0 +1,21 @@
+import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
+import { FunctionComponent } from 'mdx/types'
+import Link from 'next/link'
+
+export const Banner: FunctionComponent<{}> = () => (
+    <div className="sg-border-gradient-banner z-[1000] border-b-1 bg-black py-[13px]">
+        <div className="mx-auto flex max-w-screen-xl flex-col items-center justify-center gap-y-[9px] gap-x-12 md:flex-row">
+            <p className="mb-0 font-semibold leading-[22px] text-white">
+                Big Code in the AI era: How are companies adapting?
+            </p>
+            <Link
+                href="/big-code/big-code-in-ai-era"
+                title="Read the report"
+                className="btn bg-transparent !px-0 !py-0 leading-[22px] text-violet-300"
+            >
+                Read the report
+                <ChevronRightIcon className="!mb-0 ml-[18px] inline" />
+            </Link>
+        </div>
+    </div>
+)

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -7,6 +7,7 @@ import Link from 'next/link'
 import { useRouter } from 'next/router'
 
 import { buttonLocation } from '../../../data/tracking'
+import { Banner } from '../../Banner'
 import { MeetWithProductExpertButton } from '../../cta/MeetWithProductExpertButton'
 
 import { NavItems } from './NavItems'
@@ -65,7 +66,12 @@ export const Header: FunctionComponent<Props> = ({ minimal, colorTheme }) => {
 
     return (
         <Disclosure as="nav" className={classNames('fixed top-0 left-0 right-0 z-[1030]')} ref={navRef}>
-            {({ open }) => <HeaderContent colorTheme={colorTheme} minimal={minimal} open={open} sticky={sticky} />}
+            {({ open }) => (
+                <>
+                    {pathname !== '/big-code/big-code-in-ai-era' && <Banner />}
+                    <HeaderContent colorTheme={colorTheme} minimal={minimal} open={open} sticky={sticky} />
+                </>
+            )}
         </Disclosure>
     )
 }


### PR DESCRIPTION
## Description
Add banner to all page except the big-code-in-ai-era page

## Ref
[SG Issue](https://github.com/sourcegraph/about/issues/6220)
[Gitstart ticket](https://clients.gitstart.com/sourcegraph/1/tickets/SGM-6220)

## Demo
<img width="1439" alt="Screen Shot 2023-04-28 at 17 15 42" src="https://user-images.githubusercontent.com/51731962/235136802-85c9dc73-f95d-4423-a689-a3729a3012bc.png">
