### PR TITLE
Fix use/challenge/solution/results component

### DIFF
--- a/src/components/CaseStudies/UseChallengeSolutionResults.tsx
+++ b/src/components/CaseStudies/UseChallengeSolutionResults.tsx
@@ -1,9 +1,8 @@
-import { FunctionComponent, useEffect, useRef, useState } from 'react'
+import { FunctionComponent } from 'react'
 
 import AlertIcon from 'mdi-react/AlertIcon'
 import ChartLineVariantIcon from 'mdi-react/ChartLineVariantIcon'
 import CheckCircleIcon from 'mdi-react/CheckCircleIcon'
-import ClipboardTextIcon from 'mdi-react/ClipboardTextIcon'
 import Link from 'next/link'
 
 interface TextLink {
@@ -22,90 +21,88 @@ interface ListItemProps {
     item: TextLink
 }
 
-const isString = (value: string | TextLink): boolean => typeof value === 'string'
-
 const ListItemType: FunctionComponent<ListItemProps> = ({ item }) => (
     <li className="py-1">{item?.href ? <Link href={item.href}>{item.text}</Link> : <span>{item.text}</span>}</li>
 )
 
-export const UseChallengeSolutionResults: FunctionComponent<Props> = ({ useCases, challenges, solutions, results }) => {
-    return (
-        <div className="relative grid grid-cols-1 lg:grid-cols-2 gap-8">
-            <div className="flex items-center lg:rounded-lg lg:border lg:border-gray-300 lg:p-8">
-                <div>
-                    <h4 className="mb-2 text-2xl lg:text-3xl leading-[1]">Use case</h4>
-                    {useCases.length > 1 ? (
-                        <ul className="mb-0 ml-0 pl-sm">
-                            {useCases.map(useCase => (
-                                <ListItemType key={useCase.text} item={useCase} />
-                            ))}
-                        </ul>
-                    ) : useCases[0].href ? (
-                        <p className="mb-0 text-3xl lg:text-4xl">
-                            <Link href={useCases[0].href} className="font-semibold">{useCases[0].text}</Link>
-                        </p>
-                    ) : (
-                        <span>{useCases[0].text}</span>
-                    )}
-                </div>
-            </div>
-            <div className="flex flex-col gap-4 lg:mb-0 lg:flex-row border rounded-lg border-gray-300 p-5 md:p-8">
-                <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
-                    <AlertIcon size={40} className="p-1 text-violet-400" />
-                </div>
-                <div>
-                    <h4>Challenge</h4>
-                    {challenges.length > 1 ? (
-                        <ul className="mb-0 ml-0 pl-sm">
-                            {challenges.map(challenge => (
-                                <ListItemType key={challenge.text} item={challenge} />
-                            ))}
-                        </ul>
-                    ) : challenges[0].href ? (
-                        <Link href={challenges[0].href}>{challenges[0].text}</Link>
-                    ) : (
-                        <span>{challenges[0].text}</span>
-                    )}
-                </div>
-            </div>
-            <div className="flex flex-col gap-4 lg:mb-0 lg:flex-row border rounded-lg border-gray-300 p-5 md:p-8">
-                <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
-                    <CheckCircleIcon size={40} className="p-1 text-violet-400" />
-                </div>
-                <div>
-                    <h4>Solution</h4>
-                    {solutions.length > 1 ? (
-                        <ul className="mb-0 ml-0 pl-sm">
-                            {solutions.map(solution => (
-                                <ListItemType key={solution.text} item={solution} />
-                            ))}
-                        </ul>
-                    ) : solutions[0].href ? (
-                        <Link href={solutions[0].href}>{solutions[0].text}</Link>
-                    ) : (
-                        <span>{solutions[0].text}</span>
-                    )}
-                </div>
-            </div>
-            <div className="flex flex-col gap-4 lg:ml-0 lg:flex-row sg-bg-gradient-venus p-8 border rounded-lg border-gray-300 p-5 md:p-8">
-                <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
-                    <ChartLineVariantIcon size={40} className="p-1 text-violet-400" />
-                </div>
-                <div>
-                    <h4>Results</h4>
-                    {results.length > 1 ? (
-                        <ul className="mb-0 ml-0 pl-6">
-                            {results.map(result => (
-                                <ListItemType key={result.text} item={result} />
-                            ))}
-                        </ul>
-                    ) : results[0].href ? (
-                        <Link href={results[0].href}>{results[0].text}</Link>
-                    ) : (
-                        <span>{results[0].text}</span>
-                    )}
-                </div>
+export const UseChallengeSolutionResults: FunctionComponent<Props> = ({ useCases, challenges, solutions, results }) => (
+    <div className="relative grid grid-cols-1 gap-8 lg:grid-cols-2">
+        <div className="flex items-center lg:rounded-lg lg:border lg:border-gray-300 lg:p-8">
+            <div>
+                <h4 className="mb-2 text-2xl leading-[1] lg:text-3xl">Use case</h4>
+                {useCases.length > 1 ? (
+                    <ul className="mb-0 ml-0 pl-sm">
+                        {useCases.map(useCase => (
+                            <ListItemType key={useCase.text} item={useCase} />
+                        ))}
+                    </ul>
+                ) : useCases[0].href ? (
+                    <p className="mb-0 text-3xl lg:text-4xl">
+                        <Link href={useCases[0].href} className="font-semibold">
+                            {useCases[0].text}
+                        </Link>
+                    </p>
+                ) : (
+                    <span>{useCases[0].text}</span>
+                )}
             </div>
         </div>
-    )
-}
+        <div className="flex flex-col gap-4 rounded-lg border border-gray-300 p-5 md:p-8 lg:mb-0 lg:flex-row">
+            <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
+                <AlertIcon size={40} className="p-1 text-violet-400" />
+            </div>
+            <div>
+                <h4>Challenge</h4>
+                {challenges.length > 1 ? (
+                    <ul className="mb-0 ml-0 pl-sm">
+                        {challenges.map(challenge => (
+                            <ListItemType key={challenge.text} item={challenge} />
+                        ))}
+                    </ul>
+                ) : challenges[0].href ? (
+                    <Link href={challenges[0].href}>{challenges[0].text}</Link>
+                ) : (
+                    <span>{challenges[0].text}</span>
+                )}
+            </div>
+        </div>
+        <div className="flex flex-col gap-4 rounded-lg border border-gray-300 p-5 md:p-8 lg:mb-0 lg:flex-row">
+            <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
+                <CheckCircleIcon size={40} className="p-1 text-violet-400" />
+            </div>
+            <div>
+                <h4>Solution</h4>
+                {solutions.length > 1 ? (
+                    <ul className="mb-0 ml-0 pl-sm">
+                        {solutions.map(solution => (
+                            <ListItemType key={solution.text} item={solution} />
+                        ))}
+                    </ul>
+                ) : solutions[0].href ? (
+                    <Link href={solutions[0].href}>{solutions[0].text}</Link>
+                ) : (
+                    <span>{solutions[0].text}</span>
+                )}
+            </div>
+        </div>
+        <div className="sg-bg-gradient-venus flex flex-col gap-4 rounded-lg border border-gray-300 p-8 p-5 md:p-8 lg:ml-0 lg:flex-row">
+            <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
+                <ChartLineVariantIcon size={40} className="p-1 text-violet-400" />
+            </div>
+            <div>
+                <h4>Results</h4>
+                {results.length > 1 ? (
+                    <ul className="mb-0 ml-0 pl-6">
+                        {results.map(result => (
+                            <ListItemType key={result.text} item={result} />
+                        ))}
+                    </ul>
+                ) : results[0].href ? (
+                    <Link href={results[0].href}>{results[0].text}</Link>
+                ) : (
+                    <span>{results[0].text}</span>
+                )}
+            </div>
+        </div>
+    </div>
+)

--- a/src/components/CaseStudies/UseChallengeSolutionResults.tsx
+++ b/src/components/CaseStudies/UseChallengeSolutionResults.tsx
@@ -29,119 +29,81 @@ const ListItemType: FunctionComponent<ListItemProps> = ({ item }) => (
 )
 
 export const UseChallengeSolutionResults: FunctionComponent<Props> = ({ useCases, challenges, solutions, results }) => {
-    const box = useRef<HTMLDivElement | null>(null)
-    const [boxHeight, setBoxHeight] = useState<number>(0)
-    const bottomContainerPadding = 96
-    const boxHalfHeight = `-${boxHeight / 2 + bottomContainerPadding}px`
-
-    function getBoxHeight(): void {
-        if (box.current) {
-            setBoxHeight(box.current.clientHeight)
-        }
-    }
-
-    useEffect(() => {
-        if (box.current) {
-            setBoxHeight(box.current?.clientHeight)
-        }
-
-        window.addEventListener('resize', getBoxHeight)
-
-        return () => {
-            window.removeEventListener('resize', getBoxHeight)
-        }
-    }, [])
-
     return (
-        <div className="relative flex flex-col gap-lg py-xl lg:flex-row">
-            <div>
-                <div className="mb-8 flex flex-col lg:flex-row lg:justify-end">
-                    <div className="mb-4 flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
-                        <ClipboardTextIcon size={40} className="p-1 text-violet-400" />
-                    </div>
-                    <div className="pl-xs">
-                        <h4>Use case</h4>
-                        {useCases.length > 1 ? (
-                            <ul className="mb-0 ml-0 pl-sm">
-                                {useCases.map(useCase => (
-                                    <ListItemType key={useCase.text} item={useCase} />
-                                ))}
-                            </ul>
-                        ) : useCases[0].href ? (
-                            <p className="mb-0">
-                                <Link href={useCases[0].href}>{useCases[0].text}</Link>
-                            </p>
-                        ) : (
-                            <span>{useCases[0].text}</span>
-                        )}
-                    </div>
-                </div>
-                <div className="mb-8 flex flex-col lg:mb-0 lg:flex-row lg:justify-end">
-                    <div className="mb-4 flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
-                        <AlertIcon size={40} className="p-1 text-violet-400" />
-                    </div>
-                    <div className="pl-xs">
-                        <h4>Challenge</h4>
-                        {challenges.length > 1 ? (
-                            <ul className="mb-0 ml-0 pl-sm">
-                                {challenges.map(challenge => (
-                                    <ListItemType key={challenge.text} item={challenge} />
-                                ))}
-                            </ul>
-                        ) : challenges[0].href ? (
-                            <Link href={challenges[0].href}>{challenges[0].text}</Link>
-                        ) : (
-                            <span>{challenges[0].text}</span>
-                        )}
-                    </div>
+        <div className="relative grid grid-cols-1 lg:grid-cols-2 gap-8">
+            <div className="flex items-center lg:rounded-lg lg:border lg:border-gray-300 lg:p-8">
+                <div>
+                    <h4 className="mb-2 text-2xl lg:text-3xl leading-[1]">Use case</h4>
+                    {useCases.length > 1 ? (
+                        <ul className="mb-0 ml-0 pl-sm">
+                            {useCases.map(useCase => (
+                                <ListItemType key={useCase.text} item={useCase} />
+                            ))}
+                        </ul>
+                    ) : useCases[0].href ? (
+                        <p className="mb-0 text-3xl lg:text-4xl">
+                            <Link href={useCases[0].href} className="font-semibold">{useCases[0].text}</Link>
+                        </p>
+                    ) : (
+                        <span>{useCases[0].text}</span>
+                    )}
                 </div>
             </div>
-            <div>
-                <div className="mb-8 flex flex-col lg:mb-0 lg:flex-row xl:justify-center">
-                    <div className="mb-4 flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
-                        <CheckCircleIcon size={40} className="p-1 text-violet-400" />
-                    </div>
-                    <div className="pl-xs">
-                        <h4>Solution</h4>
-                        {solutions.length > 1 ? (
-                            <ul className="mb-0 ml-0 pl-sm">
-                                {solutions.map(solution => (
-                                    <ListItemType key={solution.text} item={solution} />
-                                ))}
-                            </ul>
-                        ) : solutions[0].href ? (
-                            <Link href={solutions[0].href}>{solutions[0].text}</Link>
-                        ) : (
-                            <span>{solutions[0].text}</span>
-                        )}
-                    </div>
+            <div className="flex flex-col gap-4 lg:mb-0 lg:flex-row border rounded-lg border-gray-300 p-5 md:p-8">
+                <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
+                    <AlertIcon size={40} className="p-1 text-violet-400" />
+                </div>
+                <div>
+                    <h4>Challenge</h4>
+                    {challenges.length > 1 ? (
+                        <ul className="mb-0 ml-0 pl-sm">
+                            {challenges.map(challenge => (
+                                <ListItemType key={challenge.text} item={challenge} />
+                            ))}
+                        </ul>
+                    ) : challenges[0].href ? (
+                        <Link href={challenges[0].href}>{challenges[0].text}</Link>
+                    ) : (
+                        <span>{challenges[0].text}</span>
+                    )}
                 </div>
             </div>
-
-            <div
-                ref={box}
-                // eslint-disable-next-line react/forbid-dom-props
-                style={{ marginBottom: boxHalfHeight }}
-                className="sg-bg-gradient-venus mx-auto w-[95%] max-w-[700px] p-8 lg:absolute lg:right-sm lg:bottom-0 lg:max-w-[500px] xl:right-5xl"
-            >
-                <div className="flex flex-col lg:ml-0 lg:flex-row">
-                    <div className="mb-4 flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
-                        <ChartLineVariantIcon size={40} className="p-1 text-violet-400" />
-                    </div>
-                    <div className="pr-0 pl-xs">
-                        <h4>Results</h4>
-                        {results.length > 1 ? (
-                            <ul className="mb-0 ml-0 pl-6">
-                                {results.map(result => (
-                                    <ListItemType key={result.text} item={result} />
-                                ))}
-                            </ul>
-                        ) : results[0].href ? (
-                            <Link href={results[0].href}>{results[0].text}</Link>
-                        ) : (
-                            <span>{results[0].text}</span>
-                        )}
-                    </div>
+            <div className="flex flex-col gap-4 lg:mb-0 lg:flex-row border rounded-lg border-gray-300 p-5 md:p-8">
+                <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
+                    <CheckCircleIcon size={40} className="p-1 text-violet-400" />
+                </div>
+                <div>
+                    <h4>Solution</h4>
+                    {solutions.length > 1 ? (
+                        <ul className="mb-0 ml-0 pl-sm">
+                            {solutions.map(solution => (
+                                <ListItemType key={solution.text} item={solution} />
+                            ))}
+                        </ul>
+                    ) : solutions[0].href ? (
+                        <Link href={solutions[0].href}>{solutions[0].text}</Link>
+                    ) : (
+                        <span>{solutions[0].text}</span>
+                    )}
+                </div>
+            </div>
+            <div className="flex flex-col gap-4 lg:ml-0 lg:flex-row sg-bg-gradient-venus p-8 border rounded-lg border-gray-300 p-5 md:p-8">
+                <div className="flex max-w-[50px] items-center justify-center self-start rounded bg-violet-100 p-1 text-center">
+                    <ChartLineVariantIcon size={40} className="p-1 text-violet-400" />
+                </div>
+                <div>
+                    <h4>Results</h4>
+                    {results.length > 1 ? (
+                        <ul className="mb-0 ml-0 pl-6">
+                            {results.map(result => (
+                                <ListItemType key={result.text} item={result} />
+                            ))}
+                        </ul>
+                    ) : results[0].href ? (
+                        <Link href={results[0].href}>{results[0].text}</Link>
+                    ) : (
+                        <span>{results[0].text}</span>
+                    )}
                 </div>
             </div>
         </div>

--- a/src/pages/case-studies/hashicorp-uses-sourcegraph-to-streamline-cross-repository-code-search.tsx
+++ b/src/pages/case-studies/hashicorp-uses-sourcegraph-to-streamline-cross-repository-code-search.tsx
@@ -67,7 +67,7 @@ export const CaseStudy: FunctionComponent = () => (
 
             <ContentSection>
                 <UseChallengeSolutionResults
-                    useCases={[{ text: 'Streamline code reuse', href: '/use-cases/code-reuse' }]}
+                    useCases={[{ text: 'Streamline code reuse.', href: '/use-cases/code-reuse' }]}
                     challenges={[
                         {
                             text: 'Excessive time and effort spent manually searching for code across multiple repositories',

--- a/src/pages/case-studies/neo-financial-improves-the-developer-experience-with-sourcegraph.tsx
+++ b/src/pages/case-studies/neo-financial-improves-the-developer-experience-with-sourcegraph.tsx
@@ -68,11 +68,7 @@ export const CaseStudy: FunctionComponent = () => (
 
             <ContentSection>
                 <UseChallengeSolutionResults
-                    useCases={[
-                        {
-                            text: 'Code Reuse',
-                        },
-                    ]}
+                    useCases={[{ text: 'Streamline code reuse.', href: '/use-cases/code-reuse' }]}
                     challenges={[
                         {
                             text: 'Unable to understand their codebase and efficiently find code to reuse with code host’s native search functionality.',


### PR DESCRIPTION
I was showing how awesome Sourcegraph is to some friends in industry when I ran into this:

<img width="1693" alt="Screenshot 2023-05-01 at 10 47 23 AM" src="https://user-images.githubusercontent.com/19855629/235470516-d755e3a0-57c9-481a-b624-f5d39ad2c252.png">

I decided to fix this accordingly:

<img width="1693" alt="Screenshot 2023-05-01 at 10 47 45 AM" src="https://user-images.githubusercontent.com/19855629/235470589-29110a16-0a7c-4759-890d-3c4950405d7f.png">
<img width="565" alt="Screenshot 2023-05-01 at 10 48 04 AM" src="https://user-images.githubusercontent.com/19855629/235470649-c69e65f1-8848-4634-b13b-11d81e450ced.png">

I imagine that you'll eventually want to phase this component out completely and write up a nice report for the last three pages that use it, but I think this should be a quick and easy solution for the time being :)
