### PR TITLE
Change tweet links from @Sourcegraph to actual customer testimonials

### DIFF
--- a/src/pages/cody.tsx
+++ b/src/pages/cody.tsx
@@ -85,10 +85,11 @@ const CodyPage: FunctionComponent = () => (
             </Heading>
 
             <div className="mt-6 grid w-full grid-cols-1 gap-6 md:mt-16 md:grid-cols-2">
-                <TwitterEmbed tweetId="1645903813302185984" className="flex max-w-[100%] justify-center" />
+                
+                <TwitterEmbed tweetId="1640734465294061571?s=20" className="flex max-w-[100%] justify-center " />
                 <div className="flex flex-col">
-                    <TwitterEmbed tweetId="1647765520673046529?s=20" className="flex max-w-[100%] justify-center" />
-                    <TwitterEmbed tweetId="1645490165857542145" className="flex max-w-[100%] justify-center " />
+                    <TwitterEmbed tweetId="1641845070453243904?s=20" className="flex max-w-[100%] justify-center" />
+                    <TwitterEmbed tweetId="1649289549988896773?s=20" className="flex max-w-[100%] justify-center" />
                 </div>
             </div>
         </ContentSection>


### PR DESCRIPTION
I think this is a more compelling bit of evidence about the product. If we have marketing videos, we should embed them directly rather than make people watch them from a tweet-embed.

<img width="1546" alt="Screenshot 2023-05-01 at 12 04 51 PM" src="https://user-images.githubusercontent.com/526432/235512334-95ce7e03-80c3-4be6-9f1d-83d0de80362d.png">
