### PR TITLE
Update /app page

### DIFF
--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -67,7 +67,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
         <Link
             href="https://sourcegraph.com/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F%3A%3Ae917b2b7fa9040e1edd4"
             className={classNames(
-                `btn flex md:h-12 items-center px-4 md:px-6 md:text-lg ${
+                `btn flex items-center px-4 md:h-12 md:px-6 md:text-lg ${
                     dark ? 'hover:btn-primary bg-black text-white ' : 'btn-inverted-primary text-black'
                 }`,
                 className
@@ -81,7 +81,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
         <Link
             href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48"
             className={classNames(
-                `btn flex md:h-12 items-center px-4 md:px-6 md:text-lg ${
+                `btn flex items-center px-4 md:h-12 md:px-6 md:text-lg ${
                     dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black'
                 }`,
                 className

--- a/src/data/downloads.ts
+++ b/src/data/downloads.ts
@@ -1,10 +1,7 @@
-const appVersionString = '2023.03.23+209542.7216ba'
+const appVersionString = 'v2023.6.2%2Bdebug.6705220765/Sourcegraph_2023.6.2+debug.6705220765_aarch64.dmg'
 
-const appDownloadPrefix = 'https://storage.googleapis.com/sourcegraph-app-releases'
+const appDownloadPrefix = 'https://github.com/sourcegraph/sourcegraph/releases/download/app-'
 
 export const appDownloads = {
-    'app-download-mac-dmg': `${appDownloadPrefix}/latest/Sourcegraph%20App.dmg`,
-    'app-download-mac-zip': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_darwin_all.zip`,
-    'app-download-linux-deb': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_linux_amd64.deb`,
-    'app-download-linux-zip': `${appDownloadPrefix}/${appVersionString}/sourcegraph_${appVersionString}_linux_amd64.zip`,
+    'app-download-mac-dmg': `${appDownloadPrefix}${appVersionString}`,
 } as const

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -1,67 +1,73 @@
 import { FunctionComponent } from 'react'
 
-import AppleIcon from 'mdi-react/AppleIcon'
-import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
-import LinuxIcon from 'mdi-react/LinuxIcon'
-import RocketLaunchIcon from 'mdi-react/RocketLaunchIcon'
-import SendIcon from 'mdi-react/SendIcon'
-import SourceBranchIcon from 'mdi-react/SourceBranchIcon'
 import Link from 'next/link'
 
-import { Layout, Heading, Tabs, Badge, ThreeUpText } from '../components'
-import { DemoVideo } from '../components/AppVideo'
-import { CodeSnippet } from '../components/CodeSnippet'
+import { Layout, Heading, Badge } from '../components'
 import { DownloadLink } from '../components/DownloadLink'
 
-const AppPage: FunctionComponent = () => {
-    return (
-        <Layout
-            meta={{
-                title: 'Introducing the Cody app',
-                description:
+const AppPage: FunctionComponent = () => (
+    <Layout
+        meta={{
+            title: 'Introducing the Cody app',
+            description:
                 'The app is a free, lightweight, native desktop version of Sourcegraph that connects your local code to our AI coding assistant, Cody.',
-                image: 'https://about.sourcegraph.com/app/app-og.png',
-            }}
-            headerColorTheme="purple"
-            childrenClassName="sg-bg-gradient-app-large text-white px-sm"
-            displayChildrenUnderNav={true}
-        >
-            <div className="mx-auto flex max-w-[637px] flex-col items-center justify-center pt-lg text-center">
-                <div className="flex gap-x-2">
-                    <Heading as="h1" size="h6">
-                        CODY APP
-                    </Heading>
-                    <Badge size="small" text="Experimental" color="dark-blue" />
-                </div>
-
-                <Heading as="h2" size="h1" className="mt-2 md:text-8xl">
-                    <p>
-                        Introducing
-                    </p> 
-                    <p>
-                        the Cody app
-                    </p>
+            image: 'https://about.sourcegraph.com/app/app-og.png',
+        }}
+        headerColorTheme="purple"
+        childrenClassName="sg-bg-gradient-app-large text-white px-sm"
+        displayChildrenUnderNav={true}
+    >
+        <div className="mx-auto flex max-w-[637px] flex-col items-center justify-center pt-lg text-center">
+            <div className="flex gap-x-2">
+                <Heading as="h1" size="h6">
+                    CODY APP
                 </Heading>
-
-                <p className="mt-6 mb-0 text-lg text-gray-200">
-                    The app is a free, lightweight, native desktop version of Sourcegraph that connects your local code to our AI coding assistant, Cody. 
-                </p>
-
-                <div className="mt-10">
-                    <DownloadSection />
-                </div>
+                <Badge size="small" text="Experimental" color="dark-blue" />
             </div>
 
-            <div className="mb-8 flex flex-col items-center text-center">
-                <p className="my-8 max-w-screen-md text-lg text-gray-200">
-                    This is an early version of the Cody app, and we’ll be cutting new releases regularly over the next few weeks. Visit our <Link href="https://docs.sourcegraph.com/app" title="docs" className="text-gray-300 underline">
-                docs</Link> for details on what to expect and share your feedback with us on <Link href="https://github.com/sourcegraph/app/issues" title="Github issues" className="text-gray-300 underline">GitHub</Link> or in <Link href="https://discord.gg/sourcegraph-969688426372825169" title="Discord" className="text-gray-300 underline">Discord</Link>. 
-                </p>
-            </div>
+            <Heading as="h2" size="h1" className="mt-2 md:text-8xl">
+                <p>Introducing</p>
+                <p>the Cody app</p>
+            </Heading>
 
-        </Layout>
-    )
-}
+            <p className="mt-6 mb-0 text-lg text-gray-200">
+                The app is a free, lightweight, native desktop version of Sourcegraph that connects your local code to
+                our AI coding assistant, Cody.
+            </p>
+
+            <div className="mt-10">
+                <DownloadSection />
+            </div>
+        </div>
+
+        <div className="mb-8 flex flex-col items-center text-center">
+            <p className="my-8 max-w-screen-md text-lg text-gray-200">
+                This is an early version of the Cody app, and we’ll be cutting new releases regularly over the next few
+                weeks. Visit our{' '}
+                <Link href="https://docs.sourcegraph.com/app" title="docs" className="text-gray-300 underline">
+                    docs
+                </Link>{' '}
+                for details on what to expect and share your feedback with us on{' '}
+                <Link
+                    href="https://github.com/sourcegraph/app/issues"
+                    title="Github issues"
+                    className="text-gray-300 underline"
+                >
+                    GitHub
+                </Link>{' '}
+                or in{' '}
+                <Link
+                    href="https://discord.gg/sourcegraph-969688426372825169"
+                    title="Discord"
+                    className="text-gray-300 underline"
+                >
+                    Discord
+                </Link>
+                .
+            </p>
+        </div>
+    </Layout>
+)
 
 const DownloadSection: FunctionComponent = () => (
     <>

--- a/src/pages/app.tsx
+++ b/src/pages/app.tsx
@@ -14,45 +14,12 @@ import { CodeSnippet } from '../components/CodeSnippet'
 import { DownloadLink } from '../components/DownloadLink'
 
 const AppPage: FunctionComponent = () => {
-    const threeUpTextItems = [
-        {
-            icon: <SourceBranchIcon className="mx-0 mb-6 rounded bg-violet-200 p-2 text-violet-400" size={35} />,
-            subtitle: <span className="flex text-left !text-4xl text-white">Connected</span>,
-            description: (
-                <p className="text-left text-lg text-gray-200">
-                    Search all your code, all in one place. Connect to your local and remote Git-based repositories, so
-                    you don't have to jump between your IDE and code host for search.
-                </p>
-            ),
-        },
-        {
-            icon: <RocketLaunchIcon className="mx-0 mb-6 rounded bg-violet-200 p-2 text-violet-400" size={35} />,
-            subtitle: <span className="flex text-left !text-4xl text-white">Fast</span>,
-            description: (
-                <p className="text-left text-lg text-gray-200">
-                    Navigate thousands of repositories in seconds. Find code while staying in flow, so you can focus
-                    less on finding things and more on writing code.
-                </p>
-            ),
-        },
-        {
-            icon: <SendIcon className="mx-0 mb-6 rounded bg-violet-200 p-2 text-violet-400" size={35} />,
-            subtitle: <span className="flex text-left !text-4xl text-white">Lightweight</span>,
-            description: (
-                <p className="text-left text-lg text-gray-200">
-                    Install in minutes. The app is a lightweight, single-binary version of Sourcegraph tailored for
-                    developers to use on their local machine.
-                </p>
-            ),
-        },
-    ]
-
     return (
         <Layout
             meta={{
-                title: 'Find, fix, and flow in minutes',
+                title: 'Introducing the Cody app',
                 description:
-                    'The app is a lightweight, single-binary version of Sourcegraph, designed for developers to experience the power of Sourcegraph for free on their local machine.',
+                'The app is a free, lightweight, native desktop version of Sourcegraph that connects your local code to our AI coding assistant, Cody.',
                 image: 'https://about.sourcegraph.com/app/app-og.png',
             }}
             headerColorTheme="purple"
@@ -62,18 +29,22 @@ const AppPage: FunctionComponent = () => {
             <div className="mx-auto flex max-w-[637px] flex-col items-center justify-center pt-lg text-center">
                 <div className="flex gap-x-2">
                     <Heading as="h1" size="h6">
-                        SOURCEGRAPH APP
+                        CODY APP
                     </Heading>
-                    <Badge size="small" text="Beta" color="dark-blue" />
+                    <Badge size="small" text="Experimental" color="dark-blue" />
                 </div>
 
                 <Heading as="h2" size="h1" className="mt-2 md:text-8xl">
-                    Find, fix, and flow in minutes
+                    <p>
+                        Introducing
+                    </p> 
+                    <p>
+                        the Cody app
+                    </p>
                 </Heading>
 
                 <p className="mt-6 mb-0 text-lg text-gray-200">
-                    The app is a lightweight, single-binary version of Sourcegraph, designed for developers to
-                    experience the power of Sourcegraph for free on their local machine.
+                    The app is a free, lightweight, native desktop version of Sourcegraph that connects your local code to our AI coding assistant, Cody. 
                 </p>
 
                 <div className="mt-10">
@@ -81,159 +52,16 @@ const AppPage: FunctionComponent = () => {
                 </div>
             </div>
 
-            <ThreeUpText items={threeUpTextItems} className="mx-auto mt-20 mb-28 max-w-screen-xl md:px-sm" />
-
             <div className="mb-8 flex flex-col items-center text-center">
-                <Heading size="h2">Run Sourcegraph for free across all your code</Heading>
                 <p className="my-8 max-w-screen-md text-lg text-gray-200">
-                    The app is the easiest way to run Sourcegraph on your local machine for free, complete with code
-                    search and navigation to complement your IDE and local environment. Sync to your GitHub or GitLab
-                    account to search and navigate all your code — local and remote — from a single, unified interface.
+                    This is an early version of the Cody app, and we’ll be cutting new releases regularly over the next few weeks. Visit our <Link href="https://docs.sourcegraph.com/app" title="docs" className="text-gray-300 underline">
+                docs</Link> for details on what to expect and share your feedback with us on <Link href="https://github.com/sourcegraph/app/issues" title="Github issues" className="text-gray-300 underline">GitHub</Link> or in <Link href="https://discord.gg/sourcegraph-969688426372825169" title="Discord" className="text-gray-300 underline">Discord</Link>. 
                 </p>
-
-                <DemoVideo
-                    video="app-demo-202304"
-                    splash={true}
-                    className="mt-8 w-full max-w-[804px] rounded-lg bg-violet-750 drop-shadow-2xl"
-                    splashClassName="rounded-lg"
-                />
             </div>
 
-            <div className="m-auto mt-40 flex max-w-screen-xl flex-col items-center gap-y-20 md:flex-row">
-                <Heading className="flex-1 text-center md:text-left" size="h2">
-                    Run Batch Changes and Code Insights for your personal code
-                </Heading>
-
-                <img src="/app/batch-changes.svg" alt="Batch changes" className="md:max-w-[50%]" />
-            </div>
-
-            <div className="mt-[115px] mb-[112px] flex flex-col items-center gap-y-4 text-center">
-                <Heading size="h2">Try Sourcegraph on your code</Heading>
-                <p className="mb-0 text-lg font-normal text-gray-200">
-                    Experience the power of Sourcegraph for free on your local machine.
-                </p>
-                <div className="mt-8">
-                    <DownloadSection />
-                </div>
-            </div>
         </Layout>
     )
 }
-
-const PlatformsInstallSnippet: FunctionComponent = () => (
-    <div className="mt-12 w-full rounded-lg bg-white text-gray-500 drop-shadow-xl sm:max-w-[453px]" id="install-script">
-        <Tabs
-            navClassName="md:flex justify-between text-center"
-            contentClassName="pt-4 pb-4"
-            tabBarExtraContent={
-                <Link
-                    href="https://docs.sourcegraph.com/app"
-                    target="_blank"
-                    title="Sourcegraph App"
-                    className="flex cursor-pointer flex-row-reverse items-center justify-center px-4 py-2 text-center text-sm leading-7 text-gray-500"
-                >
-                    <ChevronRightIcon />
-                    Other download options
-                </Link>
-            }
-            tabs={[
-                {
-                    key: 'macos',
-                    title: (
-                        <div className="flex items-center justify-center gap-x-2.5 text-sm font-normal leading-7">
-                            <AppleIcon /> MacOS
-                        </div>
-                    ),
-                    content: (
-                        <div className="mx-0.5 flex flex-col px-4">
-                            <ol className="m-0 text-left">
-                                <li className="ml-2.5 text-sm leading-7">
-                                    <div className="self-start text-sm leading-7">
-                                        Install via{' '}
-                                        <Link
-                                            href="https://brew.sh"
-                                            title="Homebrew"
-                                            className="text-gray-500 underline"
-                                            target="_blank"
-                                        >
-                                            Homebrew
-                                        </Link>
-                                        :
-                                    </div>
-
-                                    <CodeSnippet
-                                        snippetName="app-brew-install"
-                                        code="brew install sourcegraph/sourcegraph-app/sourcegraph"
-                                        className="-ml-2.5"
-                                    />
-                                </li>
-                                <li className="ml-2.5 text-sm leading-7">
-                                    Run{' '}
-                                    <code className="rounded-md bg-gray-200 p-1 text-xs text-gray-700">
-                                        sourcegraph
-                                    </code>{' '}
-                                    in your local directory.
-                                </li>
-                                <li className="ml-2.5 text-sm leading-7">
-                                    The app will detect code in the directory you run it in.
-                                </li>
-                                <li className="ml-2.5 text-sm leading-7">
-                                    Your browser will automatically open localhost:3080.
-                                </li>
-                            </ol>
-                        </div>
-                    ),
-                },
-                {
-                    key: 'linux',
-                    title: (
-                        <div className="flex items-center justify-center gap-x-2.5 text-sm font-normal leading-7">
-                            <LinuxIcon /> Linux
-                        </div>
-                    ),
-                    content: (
-                        <div className="mx-0.5 flex flex-col px-4">
-                            <ol className="m-0 text-left">
-                                <li className="ml-2.5 text-sm leading-7">
-                                    <div className="self-start text-sm leading-7">
-                                        Download the{' '}
-                                        <DownloadLink
-                                            downloadName="app-download-linux-deb"
-                                            title="Sourcegaph App Debian package"
-                                            className="text-gray-500 underline"
-                                        >
-                                            debian package
-                                        </DownloadLink>{' '}
-                                        and install it:
-                                    </div>
-
-                                    <CodeSnippet
-                                        snippetName="app-deb-install"
-                                        code="dpkg -i <file.deb>"
-                                        className="-ml-2.5"
-                                    />
-                                </li>
-                                <li className="ml-2.5 text-sm leading-7">
-                                    Run{' '}
-                                    <code className="rounded-md bg-gray-200 p-1 text-xs text-gray-700">
-                                        sourcegraph
-                                    </code>{' '}
-                                    in your local directory.
-                                </li>
-                                <li className="ml-2.5 text-sm leading-7">
-                                    The app will detect code in the directory you run it in.
-                                </li>
-                                <li className="ml-2.5 text-sm leading-7">
-                                    Your browser will automatically open localhost:3080.
-                                </li>
-                            </ol>
-                        </div>
-                    ),
-                },
-            ]}
-        />
-    </div>
-)
 
 const DownloadSection: FunctionComponent = () => (
     <>
@@ -243,28 +71,9 @@ const DownloadSection: FunctionComponent = () => (
             downloadName="app-download-mac-dmg"
         >
             Download for Mac
-            <Badge className="ml-2" size="small" text="Beta" color="blurple" />
+            <Badge className="ml-2" size="small" text="Experimental" color="blurple" />
         </DownloadLink>
-        <p className="mt-3 text-sm text-gray-300">
-            MacOS 13+ required.{' '}
-            <DownloadLink
-                title="Older versions"
-                downloadName="app-download-mac-zip"
-                className="text-sm leading-[21px] text-gray-300 underline"
-                target="_blank"
-            >
-                Older versions
-            </DownloadLink>
-            .
-        </p>
         <div className="mt-3 flex flex-row justify-center">
-            <Link
-                href="/get-started"
-                title="Linux"
-                className="border-r-1 border-r-gray-300 pr-2 text-sm leading-[21px] text-gray-300 underline"
-            >
-                Linux
-            </Link>
             <Link
                 href="https://docs.sourcegraph.com/app"
                 title="Other platforms"

--- a/src/pages/cody.tsx
+++ b/src/pages/cody.tsx
@@ -190,17 +190,11 @@ const CodyPage: FunctionComponent = () => {
                         </Heading>
                     </div>
                     <div className="flex flex-col gap-6 md:flex-row">
-                        <Heading
-                            size='h4'
-                            className="w-full border border-dashed border-white/[.15] py-6 text-white"
-                        >
+                        <Heading size="h4" className="w-full border border-dashed border-white/[.15] py-6 text-white">
                             Sourcegraph app
                             <Badge className="ml-2" size="small" text="Coming soon!" color="light-gray" />
                         </Heading>
-                        <Heading
-                            size='h4'
-                            className="w-full border border-dashed border-white/[.15] py-6 text-white"
-                        >
+                        <Heading size="h4" className="w-full border border-dashed border-white/[.15] py-6 text-white">
                             IntelliJ extension
                             <Badge className="ml-2" size="small" text="Coming soon!" color="light-gray" />
                         </Heading>

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -48,9 +48,9 @@ const GetStartedPage: FunctionComponent = () => {
     return (
         <Layout
             meta={{
-                title: 'Install the Sourcegraph app',
+                title: 'Install the Cody app',
                 description:
-                    'Install the app to get started with Sourcegraph quickly and easily. Use it to find, fix, and flow through all the code you care about, for free.',
+                    'Connect your code with Cody in minutes.',
             }}
             headerColorTheme="white"
         >
@@ -68,7 +68,7 @@ const GetStartedPage: FunctionComponent = () => {
                                     <div className="hidden items-center md:flex">
                                         <div className="flex-col gap-y-2">
                                             <Heading size="h4">
-                                                Install the app <Badge text="Beta" size="small" color="blurple" />
+                                                Install the app <Badge text="Experimental" size="small" color="blurple" />
                                             </Heading>
                                             <p
                                                 className={classNames(
@@ -76,7 +76,7 @@ const GetStartedPage: FunctionComponent = () => {
                                                     activeTab === 'app' && '!text-gray-200'
                                                 )}
                                             >
-                                                Get started navigating your local and remote code in minutes.
+                                                Connect your code with Cody in minutes.
                                             </p>
                                         </div>
                                         <CheckCircleIcon
@@ -88,7 +88,7 @@ const GetStartedPage: FunctionComponent = () => {
                                     </div>
 
                                     <div className="mb-2 flex gap-x-2 font-normal md:hidden">
-                                        Sourcegraph App <Badge text="Beta" size="small" color="blurple" className="" />
+                                        Cody App <Badge text="Beta" size="small" color="blurple" className="" />
                                     </div>
                                 </>
                             ),
@@ -151,12 +151,11 @@ const GetStartedPage: FunctionComponent = () => {
 const InterstitialAppContent: FunctionComponent = () => (
     <div className="mt-8 md:mt-0">
         <Heading size="h1" className="text-4xl text-gray-700 md:text-[56px]">
-            Install the Sourcegraph app
+            Install the Cody app
         </Heading>
         <div className="mt-4 flex flex-col justify-between gap-x-4 gap-y-[10px] md:flex-row md:items-end">
             <p className="mb-0 max-w-[590px] text-lg text-gray-500">
-                Install the app to get started with Sourcegraph quickly and easily. Use it to find, fix, and flow
-                through all the code you care about, for free.
+                Install the app to connect your code with Cody quickly and easily. Cody answers code questions and writes code for you by reading your entire codebase and the code graph. 
             </p>
             <Link
                 href="/app"
@@ -180,50 +179,10 @@ const InterstitialAppContent: FunctionComponent = () => (
                 title="Download for Mac"
                 downloadName="app-download-mac-dmg"
             >
-                Download for Mac
+                Download for Mac <Badge text="Experimental" size="small" color="blurple" />
             </DownloadLink>
 
-            <p className="mb-0 mt-2.5 flex text-gray-500">
-                MacOS 13+ required.
-                <DownloadLink
-                    className="ml-1 font-normal text-gray-500 underline"
-                    title="Old versions"
-                    target="_blank"
-                    downloadName="app-download-mac-zip"
-                >
-                    Old Versions
-                </DownloadLink>
-                .
-            </p>
-
-            {/* Linux */}
-            <div className="mt-12 flex flex-row gap-x-3">
-                <img src="/linux-icon.svg" alt="Linux icon" />
-                <Heading size="h4">Linux</Heading>
-            </div>
-
-            <div className="mt-4 flex flex-row gap-x-4">
-                <DownloadLink
-                    className="btn btn-primary w-fit px-4 font-normal"
-                    title="Download .deb"
-                    downloadName="app-download-linux-deb"
-                >
-                    Download .deb
-                </DownloadLink>
-                <DownloadLink
-                    className="btn btn-primary w-fit px-4 font-normal"
-                    title="Download .zip"
-                    downloadName="app-download-linux-zip"
-                >
-                    Download .zip
-                </DownloadLink>
-            </div>
-
-            <div className="mt-4 flex flex-row gap-x-2">
-                <p className="mb-0 text-base text-gray-500">After installing or unzipping, run</p>
-                <Badge text="sourcegraph" size="small" />
-            </div>
-
+        
             {/* Windows */}
             <div className="mt-12 flex flex-row items-center gap-x-3">
                 <MicrosoftWindowsIcon />

--- a/src/pages/get-started.tsx
+++ b/src/pages/get-started.tsx
@@ -49,8 +49,7 @@ const GetStartedPage: FunctionComponent = () => {
         <Layout
             meta={{
                 title: 'Install the Cody app',
-                description:
-                    'Connect your code with Cody in minutes.',
+                description: 'Connect your code with Cody in minutes.',
             }}
             headerColorTheme="white"
         >
@@ -68,7 +67,8 @@ const GetStartedPage: FunctionComponent = () => {
                                     <div className="hidden items-center md:flex">
                                         <div className="flex-col gap-y-2">
                                             <Heading size="h4">
-                                                Install the app <Badge text="Experimental" size="small" color="blurple" />
+                                                Install the app{' '}
+                                                <Badge text="Experimental" size="small" color="blurple" />
                                             </Heading>
                                             <p
                                                 className={classNames(
@@ -155,7 +155,8 @@ const InterstitialAppContent: FunctionComponent = () => (
         </Heading>
         <div className="mt-4 flex flex-col justify-between gap-x-4 gap-y-[10px] md:flex-row md:items-end">
             <p className="mb-0 max-w-[590px] text-lg text-gray-500">
-                Install the app to connect your code with Cody quickly and easily. Cody answers code questions and writes code for you by reading your entire codebase and the code graph. 
+                Install the app to connect your code with Cody quickly and easily. Cody answers code questions and
+                writes code for you by reading your entire codebase and the code graph.
             </p>
             <Link
                 href="/app"
@@ -182,7 +183,6 @@ const InterstitialAppContent: FunctionComponent = () => (
                 Download for Mac <Badge text="Experimental" size="small" color="blurple" />
             </DownloadLink>
 
-        
             {/* Windows */}
             <div className="mt-12 flex flex-row items-center gap-x-3">
                 <MicrosoftWindowsIcon />

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -363,45 +363,6 @@ const HomeHero: FunctionComponent = () => (
                 ))}
             </div>
         </ContentSection>
-
-        <ContentSection className="md:pb-4" parentClassName="!py-0 px-0 md:px-sm">
-            <div className="sg-home-cta mt-[88px] mb-0 flex flex-col overflow-hidden md:mt-6 md:mb-24 md:flex-row">
-                <div className="flex flex-col justify-center p-4 text-center md:text-start lg:p-8 xl:p-12">
-                    <div className="flex w-fit items-center gap-x-2 rounded-[5px] bg-blue-400 py-1 px-[7px]">
-                        <img src="/home/cody-icon.svg" alt="Cody Icon" className="h-[17px] w-[17px]" />
-                        <p className="text-blue-600 mb-0 text-[12px] font-semibold leading-[21px]">
-                            Cody is coming to the app June 2023
-                        </p>
-                    </div>
-                    <Heading className="my-4 !text-4xl text-white" size="h2">
-                        Download the Sourcegraph app
-                    </Heading>
-                    <p className="mb-4 text-lg text-gray-200 md:max-w-[614px]">
-                        Find, fix, & navigate code with the free Sourcegraph app. The app includes code search and
-                        navigation, plus Code Insights and Batch Changes for your local code.
-                    </p>
-                    <div className="flex flex-col items-center gap-4 md:flex-row">
-                        <Link href="/get-started" title="Download the app" className="btn btn-inverted-primary mt-1">
-                            Download the app
-                        </Link>
-                        <Link
-                            href="/get-started?t=enterprise"
-                            title="Sourcegraph for enterprise"
-                            className="btn flex bg-transparent p-0 text-white"
-                        >
-                            Sourcegraph for enterprise <ChevronRightIcon className="!mb-0 inline" />
-                        </Link>
-                    </div>
-                </div>
-                <div aria-hidden={true} className="flex justify-center">
-                    <img
-                        className="relative -right-[50px] sm:right-0"
-                        src="/home/app-illustration.png"
-                        alt="App Illustration"
-                    />
-                </div>
-            </div>
-        </ContentSection>
     </>
 )
 


### PR DESCRIPTION
Though we want to wait until June 28 to do the big marketing push for the Cody app, we're now at a point where the new Tauri version is substantially better than the version we launched at Starship. Anyone who stumbles upon the app on our marketing site should download the new version instead of the old one. 

This is a quick fix to update the download options and is *not* meant to reflect our ideal marketing positioning, which is in flight but shouldn't block this change. I'll follow up with a quick demo video to add to `/app`. 

This PR: 
- Removes the "download the app" CTA from about.sourcegraph.com homepage
- Updates about.sourcegraph.com/app to include the new download link, reorient copy around the Cody app, and remove the marketing material that was oriented around the old Sourcegraph app
- Updates about.sourcegraph.com/get-started to include the new download link and Cody-specific copy

# OLD
<img width="1354" alt="Screenshot 2023-06-05 at 12 36 51 PM" src="https://github.com/sourcegraph/about/assets/43555476/bf422422-31f5-425a-8fb4-b3cff38c381f">
<img width="1350" alt="Screenshot 2023-06-05 at 12 37 51 PM" src="https://github.com/sourcegraph/about/assets/43555476/088784de-2768-44aa-a71a-1410b17c4b55">
<img width="1350" alt="Screenshot 2023-06-05 at 12 38 39 PM" src="https://github.com/sourcegraph/about/assets/43555476/15549634-7b0b-4513-94fa-9a8e26f43881">

# NEW
<img width="1352" alt="Screenshot 2023-06-05 at 12 40 45 PM" src="https://github.com/sourcegraph/about/assets/43555476/175e96b1-1825-4c5b-85ba-72df51314022">
<img width="1350" alt="Screenshot 2023-06-05 at 12 40 59 PM" src="https://github.com/sourcegraph/about/assets/43555476/f8787cf9-f090-48a4-a34d-bd6f8ee6c76c">

