### PR TITLE
remove OSS from terms

### DIFF
--- a/content/terms/index.md
+++ b/content/terms/index.md
@@ -13,8 +13,6 @@ Are you interested in terms for...
 
 - **[Sourcegraph Cloud](/terms/cloud)**: If you’d like to use Sourcegraph Cloud to search, navigate, and analyze code rather than a self-hosted instance, or if you’d like to use any products (e.g. browser or editor extensions) developed and distributed by us for use with Sourcegraph Cloud, please see our [Sourcegraph Cloud terms and conditions](/terms/cloud).
 
-- **[Sourcegraph OSS](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.apache)**: It is possible to run a version of Sourcegraph without some Enterprise features from our open source code available at https://github.com/sourcegraph/sourcegraph. If you want to follow the instructions there to build and run Sourcegraph OSS from source, please see the open source license (Apache 2.0) at https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.apache.
-
 - **Sourcegraph extensions**: If you’d like to use any extensions made available via our [extension registry](https://sourcegraph.com/extensions), please understand that extensions made available by third-parties are not provided by us and are generally governed by separate terms and conditions. Extensions that are developed and distributed by us are governed by the appropriate terms and conditions (for a self-hosted Sourcegraph instance, or for Sourcegraph Cloud) above.
 
 - **[Government](/terms/gov)**: Certain features of our software may have their own terms and conditions that you must agree to when you sign up for that particular feature. As an example, if you’re using our software as an employee or contractor of the U.S. Government, our [Supplemental Terms for U.S. Government Users](/terms/gov) apply. Those terms and conditions supplement these terms and conditions.


### PR DESCRIPTION
as of 5.1 Sourcegraph OSS has been removed, updating the terms to reflect that.