### PR TITLE
SGM-6309 - Legal pages - Block Search indexing with noindex

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,10 @@
     X-Frame-Options = "DENY"
     X-Content-Type-Options = "nosniff"
 
+[[headers]]
+  for = "/terms/archives/*"
+  [headers.values]
+    X-Robots-Tag = "noindex, nofollow"
 
 # ========== SOURCEGRAPH REDIRECTS ==========
 [[redirects]]


### PR DESCRIPTION
## Description
Drop all old legal pages from Google (and other Search Engines) Search results.

## Ref
[SG Issue](https://github.com/sourcegraph/about/issues/6309)
[Gitstart Ticket](https://clients.gitstart.com/sourcegraph/1/tickets/SGM-6309)

### Demo