### PR TITLE
Rename download app events to match the new Get Cody page

### DIFF
--- a/src/components/DownloadLink.tsx
+++ b/src/components/DownloadLink.tsx
@@ -16,7 +16,7 @@ export const DownloadLink: React.FunctionComponent<DownloadLinkProps> = props =>
     const handleOnClick = (): void => {
         const eventArguments = {
             downloadSource: 'about',
-            downloadName,
+            type: downloadName,
             downloadLinkUrl: href,
         }
         // eslint-disable-next-line @typescript-eslint/no-floating-promises

--- a/src/hooks/eventLogger.ts
+++ b/src/hooks/eventLogger.ts
@@ -63,7 +63,7 @@ export const useLogAllLinkClicks = (): void => {
 
 export const enum EventName {
     STATIC_VIDEO_PLAYED = 'StaticVideoPlayed',
-    DOWNLOAD_CLICK = 'DownloadClick',
+    DOWNLOAD_CLICK = 'DownloadApp',
     SIGNUP_INITIATED = 'SignupInitiated',
     CODE_SNIPPET_COPIED = 'CodeSnippetCopied',
     VIEW_STATIC_PAGE = 'ViewStaticPage',


### PR DESCRIPTION
Discussed here: https://sourcegraph.slack.com/archives/CN4FC7XT4/p1687967097146099

Between the two name options, I prefer `DownloadApp` as it's more descriptive of the action (whereas `DownloadClick` could refer to downloading a PDF or a browser extension or Cody editor extensions, etc.)