### PR TITLE
remove "version 5.1" from Cody blog post

### DIFF
--- a/content/blogposts/2023/whats-new-with-cody-5.1.md
+++ b/content/blogposts/2023/whats-new-with-cody-5.1.md
@@ -1,9 +1,9 @@
 ---
-title: "Cody June 2023 (version 5.1): Better codegen, more recipes, more context, more editors"
+title: "Cody June 2023 release: Better codegen, more recipes, more context, more editors"
 authors:
   - name: Ryan Phillips
 publishDate: 2023-06-28T10:00-07:00
-description: 'The June 2023 release of Cody (version 5.1) makes it more powerful and accurate with better autocomplete, new and improved recipes, multi-repository context, inline chat, support for JetBrains IDEs, and a new Cody desktop app. Cody is free forever for devs on both public and private code.'
+description: 'The June 2023 release of Cody makes it more powerful and accurate with better autocomplete, new and improved recipes, multi-repository context, inline chat, support for JetBrains IDEs, and a new Cody desktop app. Cody is free forever for devs on both public and private code.'
 tags: [blog]
 slug: 'cody-in-sourcegraph-5-1'
 published: true
@@ -17,7 +17,7 @@ socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/5.1/whats-ne
   showTitle={false}
 />
 
-The June 2023 release of Cody (version 5.1) brings even more powerful and accurate code AI to devs. Not only can Cody suggest AI-generated autocompletions in your editor like GitHub Copilot, it can also write entire files, fix bugs, refactor code, and answer questions about your entire codebase. Cody’s power and accuracy comes from supplying the LLM with better context about your codebase--also known as “cheating” from Steve Yegge’s [Cheating Is All You Need](https://about.sourcegraph.com/blog/cheating-is-all-you-need) post--which builds on our work at Sourcegraph creating the leading code search engine.
+The June 2023 release of Cody brings even more powerful and accurate code AI to devs. Not only can Cody suggest AI-generated autocompletions in your editor like GitHub Copilot, it can also write entire files, fix bugs, refactor code, and answer questions about your entire codebase. Cody’s power and accuracy comes from supplying the LLM with better context about your codebase--also known as “cheating” from Steve Yegge’s [Cheating Is All You Need](https://about.sourcegraph.com/blog/cheating-is-all-you-need) post--which builds on our work at Sourcegraph creating the leading code search engine.
 
 Highlights:
 


### PR DESCRIPTION
It makes Cody sound less new/cool than it is, perhaps less beta than it actually is, etc.