### PR TITLE
Email redirect parameter should be returnTo, not redirect

### DIFF
--- a/src/components/cta/EmailAuth.tsx
+++ b/src/components/cta/EmailAuth.tsx
@@ -29,7 +29,7 @@ export const EmailAuth: React.FunctionComponent<EmailAuthProps> = ({
 
     return (
         <Link
-            href="https://sourcegraph.com/sign-up?showEmail=true&redirect=/get-cody"
+            href="https://sourcegraph.com/sign-up?showEmail=true&returnTo=/get-cody"
             className={classNames(
                 'btn hover:sg-bg-hover-signup-button flex w-full items-center justify-center',
                 className


### PR DESCRIPTION
Closes https://github.com/sourcegraph/sourcegraph/issues/54402

The email signup does not go through the oauth flow, so the redirect parameter should be `returnTo`, not `redirect`