### PR TITLE
[SG-54465]: Simplify post signup flow

### DIFF
--- a/src/components/cta/EmailAuth.tsx
+++ b/src/components/cta/EmailAuth.tsx
@@ -29,7 +29,7 @@ export const EmailAuth: React.FunctionComponent<EmailAuthProps> = ({
 
     return (
         <Link
-            href="https://sourcegraph.com/sign-up?showEmail=true&returnTo=/get-cody"
+            href="https://sourcegraph.com/sign-up?showEmail=true&returnTo=/post-sign-up"
             className={classNames(
                 'btn hover:sg-bg-hover-signup-button flex w-full items-center justify-center',
                 className

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -70,7 +70,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
     }
     return authProvider === 'github' ? (
         <Link
-            href="https://sourcegraph.com/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F%3A%3Ae917b2b7fa9040e1edd4&redirect=/get-cody"
+            href="https://sourcegraph.com/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F%3A%3Ae917b2b7fa9040e1edd4&redirect=/post-sign-up"
             className={classNames(
                 `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg
                  ${dark ? 'hover:btn-primary bg-black text-white ' : 'btn-inverted-primary text-black'}`,
@@ -83,7 +83,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
         </Link>
     ) : (
         <Link
-            href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48&redirect=/get-cody"
+            href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48&redirect=/post-sign-up"
             className={classNames(
                 `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg ${
                     dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black'


### PR DESCRIPTION
### Descriptions
This is a follow-up PR from https://github.com/sourcegraph/sourcegraph/pull/54653, ensuring that the external auth flows on this app, redirects to the /post-sign-up page once signup is completed.

### Refs
[Sourcegraph issue](https://github.com/sourcegraph/sourcegraph/issues/54465)
[Gitstart Ticket](https://clients.gitstart.com/sourcegraph/1/tickets/SGM-54465)