### PR TITLE
Remove two mentions of Sourcegraph OSS version

### DIFF
--- a/content/terms/archives/cloud/2023-07-11.md
+++ b/content/terms/archives/cloud/2023-07-11.md
@@ -5,7 +5,7 @@ title: Terms of Service for Sourcegraph Cloud
 
 Last modified: June 28, 2023
 
-See the [changes](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/about%24+file:%5Econtent/terms/cloud%5C.md%7C%5Edocs/terms-dotcom+type:diff&patternType=standard) since the [previous version](/terms/archives/cloud/2023-07-11/) or visit our [archives](https://github.com/sourcegraph/about/tree/main/content/terms/archives).
+See the [changes](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/about%24+file:%5Econtent/terms/cloud%5C.md%7C%5Edocs/terms-dotcom+type:diff&patternType=standard) since the [previous version](/terms/archives/cloud/2023-06-28/) or visit our [archives](https://github.com/sourcegraph/about/tree/main/content/terms/archives).
 
 Thank you for using Sourcegraph! This page lays out the basic terms and conditions that apply to your use of Sourcegraph Cloud.
 
@@ -21,6 +21,8 @@ Thank you for using Sourcegraph! This page lays out the basic terms and conditio
   - **Sourcegraph Cloud**: You're in the right place! Read on.
 
   - **[A self-hosted Sourcegraph instance](/terms/self-hosted)**: If you’d like to use a self-hosted Sourcegraph instance (e.g. one deployed via the `docker run` command in our [Quickstart](https://docs.sourcegraph.com)) to search, navigate, and analyze your code, rather than the Sourcegraph Cloud instance, or if you’d like to use any products (e.g. browser or editor extensions) developed and distributed by us for use with your self-hosted instance, please see our [terms and conditions](/terms/self-hosted).
+
+  - **[Sourcegraph OSS](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.apache)**: It is possible to run a version of Sourcegraph without some Enterprise features from our open source code available at https://github.com/sourcegraph/sourcegraph. If you want to follow the instructions there to build and run Sourcegraph OSS from source, please see the open source license (Apache 2.0) at https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.apache.
 
   - **[Government](/terms/gov)**: Certain features of our software may have their own terms and conditions that you must agree to when you sign up for that particular feature. As an example, if you’re using our software as an employee or contractor of the U.S. Government, our [Supplemental Terms for U.S. Government Users](/terms/gov) apply. Those terms and conditions supplement these terms and conditions.
 </div>

--- a/content/terms/cloud.md
+++ b/content/terms/cloud.md
@@ -22,8 +22,6 @@ Thank you for using Sourcegraph! This page lays out the basic terms and conditio
 
   - **[A self-hosted Sourcegraph instance](/terms/self-hosted)**: If you’d like to use a self-hosted Sourcegraph instance (e.g. one deployed via the `docker run` command in our [Quickstart](https://docs.sourcegraph.com)) to search, navigate, and analyze your code, rather than the Sourcegraph Cloud instance, or if you’d like to use any products (e.g. browser or editor extensions) developed and distributed by us for use with your self-hosted instance, please see our [terms and conditions](/terms/self-hosted).
 
-  - **[Sourcegraph OSS](https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.apache)**: It is possible to run a version of Sourcegraph without some Enterprise features from our open source code available at https://github.com/sourcegraph/sourcegraph. If you want to follow the instructions there to build and run Sourcegraph OSS from source, please see the open source license (Apache 2.0) at https://github.com/sourcegraph/sourcegraph/blob/main/LICENSE.apache.
-
   - **[Government](/terms/gov)**: Certain features of our software may have their own terms and conditions that you must agree to when you sign up for that particular feature. As an example, if you’re using our software as an employee or contractor of the U.S. Government, our [Supplemental Terms for U.S. Government Users](/terms/gov) apply. Those terms and conditions supplement these terms and conditions.
 </div>
 

--- a/content/terms/cloud.md
+++ b/content/terms/cloud.md
@@ -3,7 +3,7 @@ layout: markdown
 title: Terms of Service for Sourcegraph Cloud
 ---
 
-Last modified: June 28, 2023
+Last modified: July 11, 2023
 
 See the [changes](https://sourcegraph.com/search?q=context:global+repo:%5Egithub%5C.com/sourcegraph/about%24+file:%5Econtent/terms/cloud%5C.md%7C%5Edocs/terms-dotcom+type:diff&patternType=standard) since the [previous version](/terms/archives/cloud/2023-07-11/) or visit our [archives](https://github.com/sourcegraph/about/tree/main/content/terms/archives).
 

--- a/src/pages/security.tsx
+++ b/src/pages/security.tsx
@@ -288,9 +288,7 @@ const SecurityPage: FunctionComponent = () => (
                                             Software Bill of Materials and OSS usage
                                         </Heading>
                                         <p className="mt-4">
-                                            Sourcegraph is an OSS product licensed under Apache 2.0. We also make great
-                                            use of open source components and ship them as part of our application. Full
-                                            lists of tools and licenses can be found{' '}
+                                            A full list of tools and licenses can be found{' '}
                                             <Link
                                                 href="https://sourcegraph.com/github.com/sourcegraph/sourcegraph/-/tree/third-party-licenses"
                                                 title="here"


### PR DESCRIPTION
I noticed a few mentions of running Sourcegraph OSS version and removed them.