### PR TITLE
Adding google sso into relevant places on about.sourcegraph.com

### DIFF
--- a/src/components/AuthenticateModalContent.tsx
+++ b/src/components/AuthenticateModalContent.tsx
@@ -25,6 +25,13 @@ export const AuthenticateModalContent: FunctionComponent<Props> = ({ source }) =
             className="mt-4"
             source={source}
         />
+        <ExternalsAuth
+            authProvider="google"
+            label="Continue With Google"
+            dark={true}
+            className="mt-4"
+            source={source}
+        />
         <p className="mt-5 text-sm text-gray-400">
             By registering, you agree to our{' '}
             <Link href="/terms" className="text-violet-400">

--- a/src/components/AuthenticateModalContent.tsx
+++ b/src/components/AuthenticateModalContent.tsx
@@ -20,7 +20,7 @@ export const AuthenticateModalContent: FunctionComponent<Props> = ({ source }) =
         />
         <ExternalsAuth
             authProvider="gitlab"
-            label="Continue With Gitlab"
+            label="Continue With GitLab"
             dark={true}
             className="mt-4"
             source={source}

--- a/src/components/cta/CallToActionWithCody.tsx
+++ b/src/components/cta/CallToActionWithCody.tsx
@@ -51,6 +51,12 @@ export const CallToActionWithCody: FunctionComponent<{ className?: string }> = (
                         label="GitLab"
                         source="about-home"
                     />
+                    <ExternalsAuth
+                        className="w-fit !font-normal"
+                        authProvider="google"
+                        label="Google"
+                        source="about-home"
+                    />
                 </div>
                 <p className="mt-4 mb-0 text-[14px] text-white opacity-70">
                     By registering, you agree to our{' '}

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -151,9 +151,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
                 {label}
             </Link>
         );
-    }
-
-    if (authProvider === 'google') {
+    } else if (authProvider === 'google') {
         link = (
             <Link
                 href="https://sourcegraph.com/.auth/openidconnect/login?pc=google"

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -81,7 +81,6 @@ const GoogleColorIcon: React.FunctionComponent<React.PropsWithChildren<{ classNa
     </svg>
 )
 
-
 export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
     label,
     authProvider = 'github',
@@ -135,6 +134,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
     }
 
     let link: React.ReactElement;
+    link =  <Link href="" />;
 
     if (authProvider === 'github') {
         link = (

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -152,22 +152,6 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
                 {label}
             </Link>
         );
-    } else if (authProvider === 'google') {
-        link = (
-            <Link
-                href="https://sourcegraph.com/.auth/openidconnect/login?pc=google"
-                className={classNames(
-                    `btn hover:sg-bg-hover-external-auth-button flex items-center pl-3 pr-3 hover:text-black md:h-12 md:text-lg 
-                    ${dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black' }`,
-                    className
-                )}
-                onClick={handleOnClick}
-                id="googleButton"
-            >   
-                <GoogleColorIcon className="pr-4" />
-                <span className="pr-2">{label}</span>
-            </Link>
-        );
     } else if (authProvider === 'gitlab') {
         link = (
             <Link
@@ -183,6 +167,22 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
             >
                 <GitlabColorIcon className="pr-2" />
                 {label}
+            </Link>
+        );
+    } else if (authProvider === 'google') {
+        link = (
+            <Link
+                href="https://sourcegraph.com/.auth/openidconnect/login?pc=google"
+                className={classNames(
+                    `btn hover:sg-bg-hover-external-auth-button flex items-center pl-3 pr-3 hover:text-black md:h-12 md:text-lg 
+                    ${dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black' }`,
+                    className
+                )}
+                onClick={handleOnClick}
+                id="googleButton"
+            >   
+                <GoogleColorIcon className="pr-4" />
+                <span className="pr-2">{label}</span>
             </Link>
         );
     }

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -58,6 +58,7 @@ const GoogleColorIcon: React.FunctionComponent<React.PropsWithChildren<{ classNa
       width="46"
       height="46"
       viewBox="0 0 46 46"
+      className={className}
     >
       <g fill="none" fillRule="evenodd" stroke="none" strokeWidth="1">
         <g transform="translate(-1 -1)">

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -167,9 +167,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
                 <span className="pr-2">{label}</span>
             </Link>
         );
-    }
-
-    if (authProvider === 'gitlab') {
+    } else if (authProvider === 'gitlab') {
         link = (
             <Link
                 href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48&redirect=/get-cody"

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -81,13 +81,15 @@ const GoogleColorIcon: React.FunctionComponent<React.PropsWithChildren<{ classNa
     </svg>
 )
 
+
 export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
     label,
     authProvider = 'github',
     source,
     dark,
     className,
-}) => {
+}: ExternalsAuthProps): React.ReactElement | null => {
+
     useEffect(() => {
         const { buttonId, conversionId } = getAuthButtonsTracker(authProvider)
         const script = document.createElement('script')
@@ -132,8 +134,10 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
         })
     }
 
+    let link: React.ReactElement;
+
     if (authProvider === 'github') {
-        return (
+        link = (
             <Link
                 href="https://sourcegraph.com/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F%3A%3Ae917b2b7fa9040e1edd4&redirect=/get-cody"
                 className={classNames(
@@ -151,7 +155,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
     }
 
     if (authProvider === 'google') {
-        return (
+        link = (
             <Link
                 href="https://sourcegraph.com/.auth/openidconnect/login?pc=google"
                 className={classNames(
@@ -169,7 +173,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
     }
 
     if (authProvider === 'gitlab') {
-        return (
+        link = (
             <Link
                 href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48&redirect=/get-cody"
                 className={classNames(
@@ -186,4 +190,6 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
             </Link>
         );
     }
+
+    return link;
 }

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -3,7 +3,6 @@ import { useEffect } from 'react'
 import classNames from 'classnames'
 import Cookies from 'js-cookie'
 import GithubIcon from 'mdi-react/GithubIcon'
-import GoogleColorIcon from './GoogleColorIcon'
 import Link from 'next/link'
 
 import { EventName, getEventLogger } from '../../hooks/eventLogger'
@@ -53,7 +52,33 @@ const GitlabColorIcon: React.FunctionComponent<React.PropsWithChildren<{ classNa
 )
 
 const GoogleColorIcon: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({ className }) => (
-    // need to fill this in
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      xmlnsXlink="http://www.w3.org/1999/xlink"
+      width="46"
+      height="46"
+      viewBox="0 0 46 46"
+    >
+      <g fill="none" fillRule="evenodd" stroke="none" strokeWidth="1">
+        <g transform="translate(-1 -1)">
+          <g filter="url(#filter-1)" transform="translate(4 4)">
+            <g>
+              <use fill="#FFF" xlinkHref="#path-2" />
+              <use xlinkHref="#path-2" />
+              <use xlinkHref="#path-2" />
+              <use xlinkHref="#path-2" />
+            </g>
+          </g>
+          <g transform="translate(15 15)">
+            <path fill="#4285F4" d="M17.64 9.205c0-.639-.057-1.252-.164-1.841H9v3.481h4.844a4.14 4.14 0 01-1.796 2.716v2.259h2.908c1.702-1.567 2.684-3.875 2.684-6.615z" />
+            <path fill="#34A853" d="M9 18c2.43 0 4.467-.806 5.956-2.18l-2.908-2.259c-.806.54-1.837.86-3.048.86-2.344 0-4.328-1.584-5.036-3.711H.957v2.332A8.997 8.997 0 009 18z"/>
+            <path fill="#FBBC05" d="M3.964 10.71A5.41 5.41 0 013.682 9c0-.593.102-1.17.282-1.71V4.958H.957A8.996 8.996 0 000 9c0 1.452.348 2.827.957 4.042l3.007-2.332z" />
+            <path fill="#EA4335" d="M9 3.58c1.321 0 2.508.454 3.44 1.345l2.582-2.58C13.463.891 11.426 0 9 0A8.997 8.997 0 00.957 4.958L3.964 7.29C4.672 5.163 6.656 3.58 9 3.58z" />
+            <path d="M0 0h18v18H0V0z" />
+          </g>
+        </g>
+      </g>
+    </svg>
 )
 
 export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
@@ -123,23 +148,27 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
                 {label}
             </Link>
         );
-    } else if (authProvider === 'google') {
+    }
+
+    if (authProvider === 'google') {
         return (
             <Link
                 href="https://sourcegraph.com/.auth/openidconnect/login?pc=google"
                 className={classNames(
-                    `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg 
+                    `btn hover:sg-bg-hover-external-auth-button flex items-center pl-3 pr-3 hover:text-black md:h-12 md:text-lg 
                     ${dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black' }`,
                     className
                 )}
                 onClick={handleOnClick}
                 id="googleButton"
-            >
-                <GoogleColorIcon className="pr-2" />
-                {label}
+            >   
+                <GoogleColorIcon className="pr-4" />
+                <span className="pr-2">{label}</span>
             </Link>
         );
-    } else {
+    }
+
+    if (authProvider === 'gitlab') {
         return (
             <Link
                 href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48&redirect=/get-cody"
@@ -157,3 +186,4 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
             </Link>
         );
     }
+}

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -9,7 +9,7 @@ import { EventName, getEventLogger } from '../../hooks/eventLogger'
 import { getAuthButtonsTracker } from '../../lib/utils'
 
 export interface AuthProvider {
-    serviceType: 'github' | 'gitlab'
+    serviceType: 'github' | 'gitlab' | 'google'
 }
 
 interface ExternalsAuthProps {

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -3,6 +3,7 @@ import { useEffect } from 'react'
 import classNames from 'classnames'
 import Cookies from 'js-cookie'
 import GithubIcon from 'mdi-react/GithubIcon'
+import GoogleColorIcon from './GoogleColorIcon'
 import Link from 'next/link'
 
 import { EventName, getEventLogger } from '../../hooks/eventLogger'
@@ -49,6 +50,10 @@ const GitlabColorIcon: React.FunctionComponent<React.PropsWithChildren<{ classNa
         <path d="M9.99902 19.2023L13.6835 7.8689H18.8444L9.99902 19.2023Z" fill="#FC6D26" />
         <path d="M9.99907 19.2023L1.15918 7.8689H6.31995L9.99907 19.2023Z" fill="#FC6D26" />
     </svg>
+)
+
+const GoogleColorIcon: React.FunctionComponent<React.PropsWithChildren<{ className?: string }>> = ({ className }) => (
+    // need to fill this in
 )
 
 export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
@@ -102,34 +107,53 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
         })
     }
 
-    return authProvider === 'github' ? (
-        <Link
-            href="https://sourcegraph.com/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F%3A%3Ae917b2b7fa9040e1edd4&redirect=/get-cody"
-            className={classNames(
-                `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg
+    if (authProvider === 'github') {
+        return (
+            <Link
+                href="https://sourcegraph.com/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F%3A%3Ae917b2b7fa9040e1edd4&redirect=/get-cody"
+                className={classNames(
+                    `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg
                  ${dark ? 'hover:btn-primary bg-black text-white ' : 'btn-inverted-primary text-black'}`,
-                className
-            )}
-            onClick={handleOnClick}
-            id="githubButton"
-        >
-            <GithubIcon className="pr-2" />
-            {label}
-        </Link>
-    ) : (
-        <Link
-            href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48&redirect=/get-cody"
-            className={classNames(
-                `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg ${
-                    dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black'
-                }`,
-                className
-            )}
-            onClick={handleOnClick}
-            id="gitlabButton"
-        >
-            <GitlabColorIcon className="pr-2" />
-            {label}
-        </Link>
-    )
-}
+                    className
+                )}
+                onClick={handleOnClick}
+                id="githubButton"
+            >
+                <GithubIcon className="pr-2" />
+                {label}
+            </Link>
+        );
+    } else if (authProvider === 'google') {
+        return (
+            <Link
+                href="https://sourcegraph.com/.auth/openidconnect/login?pc=google"
+                className={classNames(
+                    `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg 
+                    ${dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black' }`,
+                    className
+                )}
+                onClick={handleOnClick}
+                id="googleButton"
+            >
+                <GoogleColorIcon className="pr-2" />
+                {label}
+            </Link>
+        );
+    } else {
+        return (
+            <Link
+                href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48&redirect=/get-cody"
+                className={classNames(
+                    `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg 
+                    ${dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black'
+                    }`,
+                    className
+                )}
+                onClick={handleOnClick}
+                id="gitlabButton"
+            >
+                <GitlabColorIcon className="pr-2" />
+                {label}
+            </Link>
+        );
+    }

--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -133,8 +133,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
         })
     }
 
-    let link: React.ReactElement;
-    link =  <Link href="" />;
+    let link: React.ReactElement = <Link href="" />;
 
     if (authProvider === 'github') {
         link = (

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -99,14 +99,19 @@ interface ButtonTrackerData {
     conversionId: string
 }
 
-export const getAuthButtonsTracker = (provider: 'github' | 'gitlab'): ButtonTrackerData => {
+export const getAuthButtonsTracker = (provider: 'github' | 'gitlab' | 'google'): ButtonTrackerData => {
     if (provider === 'github') {
         return {
             buttonId: 'githubButton',
             conversionId: 'IE36JRZchpg6WWkoBm1cNN',
         }
     }
-
+    else if (provider === 'google') {
+        return {
+            buttonId: 'googleButton',
+            conversionId: 'someID',
+        }
+    }
     return {
         buttonId: 'gitlabButton',
         conversionId: 'sL3CVtxUlXaAvWjHZb7PTW',

--- a/src/pages/cody.tsx
+++ b/src/pages/cody.tsx
@@ -106,6 +106,12 @@ const CodyPage: FunctionComponent<CodyProps> = ({ tweets }) => {
                             label="GitLab"
                             source="about-cody"
                         />
+                        <ExternalsAuth
+                            className="w-fit justify-center !font-normal"
+                            authProvider="google"
+                            label="Google"
+                            source="about-cody"
+                        />
                     </div>
                     <p className="mt-4 text-[14px] text-violet-300 opacity-70">
                         By registering, you agree to our{' '}
@@ -213,6 +219,12 @@ const CodyPage: FunctionComponent<CodyProps> = ({ tweets }) => {
                             className="w-fit justify-center !font-normal"
                             authProvider="gitlab"
                             label="GitLab"
+                            source="cody"
+                        />
+                        <ExternalsAuth
+                            className="w-fit justify-center !font-normal"
+                            authProvider="google"
+                            label="Google"
                             source="cody"
                         />
                     </div>

--- a/src/pages/demo/cody.tsx
+++ b/src/pages/demo/cody.tsx
@@ -157,6 +157,12 @@ const DemoCodyPage: FunctionComponent<CodyProps> = ({ tweets }) => {
                             label="GitLab"
                             source="cody"
                         />
+                        <ExternalsAuth
+                            className="w-fit justify-center !font-normal"
+                            authProvider="google"
+                            label="Google"
+                            source="cody"
+                        />
                     </div>
                     <p className="mt-4 mb-0 text-[14px] text-violet-300 opacity-70">
                         By registering, you agree to our{' '}

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -217,6 +217,12 @@ const HomeHero: FunctionComponent = () => {
                                         label="GitLab"
                                         source="about-home"
                                     />
+                                    <ExternalsAuth
+                                        className="col-span-1 mt-1 w-full justify-center !font-normal"
+                                        authProvider="google"
+                                        label="Google"
+                                        source="about-home"
+                                    />
                                 </div>
                             </div>
                             <p className="mt-4 text-sm text-violet-300 opacity-70">


### PR DESCRIPTION
Goal: To add the ability for users to login with Google SSO, alongside places where we allow Gitlab and Github SSO login/signup on about.