### PR TITLE
Fix auth provider URL for GitLab

### DIFF
--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -118,7 +118,7 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
         </Link>
     ) : (
         <Link
-            href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3A262309265ae76179773477bd50c93c7022007a4810c344c69a7371da11949c48&redirect=/get-cody"
+            href="https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3Ab45ecb474e92c069567822400cf73db6e39917635bf682f062c57aca68a1e41c&redirect=/get-cody"
             className={classNames(
                 `btn hover:sg-bg-hover-external-auth-button flex items-center px-4 hover:text-black md:h-12 md:px-6 md:text-lg ${
                     dark ? 'sg-gitlab-bg-color hover:btn-primary text-white ' : 'btn-inverted-primary text-black'


### PR DESCRIPTION
Since we rotated secrets, this is probably out of date and needs to be rotated.

Let's see if that fixes the invalid auth provider error.