### PR TITLE
Nine case study updates.

### DIFF
--- a/src/pages/case-studies/how-sourcegraph-transformed-nine-development-workflow.tsx
+++ b/src/pages/case-studies/how-sourcegraph-transformed-nine-development-workflow.tsx
@@ -415,8 +415,8 @@ const SidebarContent: FunctionComponent<{
     content: string | ReactNode
     title: string
 }> = ({ content, title }) => (
-    <div className="mb-16  md:w-[378px]">
-        <Heading size="h1" className="mb-4 !text-[52px] text-violet-500">
+    <div className="mb-8  md:w-[378px]">
+        <Heading size="h2" className="mb-2 !text-[30px] text-violet-500">
             {title}
         </Heading>
         {typeof content === 'string' ? <p className="text-[18px]">{content}</p> : content}


### PR DESCRIPTION
- Decrease font size of the headers
- Change headers from h1 to h2 for SEO
- remove excessive margin so that the Sourcegraph CTA is more visible.