### PR TITLE
Create October release blogs

### DIFF
--- a/content/blogposts/2023/feature-release-october-2023.md
+++ b/content/blogposts/2023/feature-release-october-2023.md
@@ -1,0 +1,195 @@
+---
+title: "Introducing enhancements to Code Search and Cody, including a 2x increase in autocomplete quality"
+authors:
+  - name:
+    url:
+publishDate: 2023-10-04T10:00-07:00
+description: "New versions of Cody and Code Search are now available, including Cody for Neovim and support for OpenAI LLMs in Cody."
+tags: [blog]
+slug: 'feature-release-october-2023'
+published: true
+heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/october-release-blog-hero.png
+socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/october-release-blog-hero.png
+---
+
+<YouTube
+  title="What's New in Cody + Code Search: October 2023" 
+  id="FKt3X0rVwQc"
+  showTitle={false}
+/>
+
+Today, we're announcing a major upgrade to Cody that achieves a best-in-class initial completion acceptance rate of 30%. Cody now supports using OpenAI and open source language models in addition to the models from Anthropic already supported, and Cody LLMs can now be hosted on Azure OpenAI and AWS Bedrock. Cody is also now available for Neovim, in addition to VS Code and JetBrains IDEs. We've also revamped the Cody onboarding experience, which no longer requires installing a separate app, greatly simplifying the installation process.
+
+Code Search version 5.2 also gets a number of usability upgrades, including better onboarding for admins. We’ve also shipped improved git debuggability to make troubleshooting gitserver faster for customers running large Sourcegraph instances.
+
+Read on to learn more about what’s new. And, if you’d like to learn more about how we view the evolution of the code AI landscape, check out our other post: [How we’re thinking about the levels of Code AI](https://about.sourcegraph.com/blog/levels-of-code-ai).
+
+## Cody
+
+<br/>
+
+### Speed & quality improvements across Cody IDE clients
+
+Completion Acceptance Rate (CAR) has become a de facto standard way to measure the combined latency and quality of autocompletions produced by AI coding assistants. If the response quality is high but it takes too long to appear, it will be rejected. Likewise, if it comes quickly but is of low quality, the response will also be rejected. A raising CAR measures our ability to hit the sweet spot between the two as we optimize for users accepting the suggestion Cody makes. 
+
+In June, Cody’s CAR was 15%, which frankly, we were not happy with. Now with this October release, and our continued improvement to context, we’re proud to say that the latest Cody achieves as high as 30% acceptance rate among users on average. Cody autocomplete is also now much quicker, with multiline latency improving from 3.4 seconds to 2.4 seconds and single-line latencies from 2.0 seconds to 1.1 seconds on average. And we’ve got plenty of headroom yet in these numbers, so stay tuned for further improvements in future releases.
+
+A major factor in Cody’s improved performance comes from incorporating open source LLMs into Cody. Cody now uses the [StarCoder](https://huggingface.co/bigcode/starcoder) model for the majority of its completions - specifically, StarCoder running on Fireworks, a new platform that provides fast inference for open source LLMs. Going forward, Cody Community users will make use of a combination of proprietary LLMs from Anthropic and open source models like StarCoder (the CAR we report comes from using Cody with StarCoder).
+
+Cody also now incorporates syntactic signals to inform when it triggers a completion, including recent user behavior and recently viewed files. In some cases, this means adding latency to Cody’s completions to yield a better experience. We’ve also shipped code graph context for a select number of users, making use of Tree-sitter to fetch related snippets of code that help eliminate type errors, a common mistake in hallucinated code generations.
+
+Behaviorally, Cody now uses [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) to determine when to trigger a completion and whether to generate a single-line or multi-line completion. Here's an example of where Cody opts for a one-shot multiline completion in contrast to other coding assistants that generate code line by line.
+
+_Cody:_
+<Video 
+  source={{
+    webm: 'blog/release-october-2023/cody_multilinereturn',
+    mp4: 'blog/release-october-2023/cody_multilinereturn'
+  }}
+  loop={true}
+  title="Cody multiline autocomplete"
+/>
+
+_Other coding assistant:_
+<Video 
+  source={{
+    webm: 'blog/release-october-2023/competitor_multilinereturn',
+    mp4: 'blog/release-october-2023/competitor_multilinereturn'
+  }}
+  loop={true}
+  title="Competitor multiline autocomplete"
+/>
+
+Cody itself remains open source, while integrating with Sourcegraph Code Search (source available) and proprietary LLMs. Sourcegraph remains committed to its philosophy of striving for open source for single player dev tools like Cody. We also believe freedom of choice in the fast-moving model landscape will be a competitive advantage and accelerator of progress for Cody that will compound over time. 
+
+### Cody for Neovim, now available as experimental
+
+Cody for Neovim is here! This new plugin brings both autocomplete and chat to Neovim, and it's available today for free.
+
+Once you've [installed and configured the plugin](https://docs.sourcegraph.com/cody/overview/install-neovim), Cody for Neovim will provide three major features:
+
+- **Autocomplete**: Cody makes inline suggestions as you type. Cody's suggestions will be marked with `[cody]` and appear above other LSP suggestions if both are configured.
+- **Chat**: Talk with Cody in the side panel. If you connect the plugin to your Sourcegraph instance to enable codebase awareness, Cody can find & explain code using context from your team's codebase.
+- **Inline chat & refactors**: Use the `CodyTask` command and Cody will refactor or adjust highlighted code snippets and replace them directly inline.
+
+<br/>
+
+<Video 
+  source={{
+    webm: 'blog/release-october-2023/neovim-blog',
+    mp4: 'blog/release-october-2023/neovim-blog'
+  }}
+  loop={true}
+  title="Cody in Neovim"
+/>
+
+Cody for Neovim is considered experimental as we're still tweaking and fine-tuning the UX based on community feedback. If you have feedback, let us know in [Discord](https://discord.gg/rDPqBejz93).
+
+[Download Cody for Neovim](https://docs.sourcegraph.com/cody/overview/install-neovim).
+
+### Quality, performance, and onboarding improvements for Cody in JetBrains IDEs, now available in beta
+
+The JetBrains plugin has been rewritten with a new architecture that significantly improves quality and performance for autocomplete and chat. Additionally, we have simplified onboarding so that users can start using the plugin with far fewer steps and closed some gaps in [feature parity](https://docs.sourcegraph.com/cody/feature-reference) with the VS Code extension.
+
+<Video 
+  source={{
+    webm: 'blog/release-october-2023/jetbrains-blog',
+    mp4: 'blog/release-october-2023/jetbrains-blog'
+  }}
+  loop={true}
+  title="Cody in JetBrains"
+/>
+
+[Download Cody for JetBrains](https://plugins.jetbrains.com/plugin/9682-sourcegraph-cody--code-search).
+
+### Performance improvements and command updates for Cody in VS Code
+
+The VS Code extension has received a similar upgrade as JetBrains, with under-the-hood changes that significantly improve quality and performance of all Cody features. Both chat and autocomplete are faster, and autocomplete offers higher quality suggestions with lower latency.
+
+The `/doc` and `/test` commands have also been updated:
+
+- `/doc` now adds docstrings directly to your code without you needing to copy & paste from the chat sidebar.
+- `/test` now better detects your testing framework, adds any dependency imports as needed, and includes the necessary stubs and test setup code.
+
+<br/>
+
+<Video 
+  source={{
+    webm: 'blog/release-october-2023/vscode-doc-blog',
+    mp4: 'blog/release-october-2023/vscode-doc-blog'
+  }}
+  loop={true}
+  title="Docs command in VS Code"
+/>
+
+[Download Cody for VS Code](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+
+## Choose between Anthropic and OpenAI models for Cody Enterprise
+
+The AI field is advancing at a breakneck pace, and that includes the development of new LLMs and models to support specific use cases. We see new LLMs emerge nearly every week, tuned for performance across a host of benchmarks. To provide the best possible code AI experience, we believe Cody needs to be universal, with support for plugging in the latest-and-greatest LLMs. 
+
+Cody now supports OpenAI models, and enterprise Cody users can choose from these models to power Cody’s chat and commands features:
+
+- OpenAI GPT-3.5 Turbo
+- OpenAI GPT-4 
+- Anthropic Claude 2
+
+<br/>
+
+<a href="https://docs.sourcegraph.com/cody/overview/enable-cody-enterprise#using-a-third-party-llm-provider" className="not-italic flex items-center mb-sm">Docs<OpenInNewIcon className="ml-xxs" size={18} /></a>
+
+## Cody Enterprise users can bring their own LLM provider with Azure OpenAI and AWS Bedrock
+
+Alongside support for OpenAI models, users now have more choice in how they run the LLM powering Cody. Cody now supports both Azure OpenAI and AWS Bedrock hosted LLM services. Users can run either service from within their company’s own secure cloud VPC and configure Cody to talk to the LLM service.
+
+By default, Cody accesses LLMs directly via Anthropic & OpenAI’s respective APIs (with 0 retention on both inputs and outputs). By configuring Cody to use Azure OpenAI or Bedrock instead, users can securely route requests from Cody to their own Azure & AWS accounts, plus control their own LLM costs directly.
+
+<a href="https://docs.sourcegraph.com/cody/overview/enable-cody-enterprise#anthropic-claude-through-aws-bedrock-span-style-margin-left-0-25rem-class-badge-badge-experimental-experimental-span" className="not-italic flex items-center mb-sm">Docs<OpenInNewIcon className="ml-xxs" size={18} /></a>
+
+## Code Search
+
+<br/>
+
+### Improved visibility into gitserver for faster debugging
+
+Maintaining and debugging [gitserver](https://docs.sourcegraph.com/dev/background-information/gitserver-api) can be a challenge, especially for large instances with thousands of repositories. SSHing into a gitserver instance, looking through the logs, and piecing together what may be causing an issue is time consuming for users.
+
+Sourcegraph admins can now enable the ability to see gitserver information and git history on a per-repository basis. From the Site Admin dashboard, users can now see:
+
+- Which git commands recently ran on a repository
+- When each repository was last re-cloned
+- Gitserver instances' total and available disk space
+
+<br/>
+
+<Video 
+  source={{
+    webm: 'blog/release-october-2023/debug-blog',
+    mp4: 'blog/release-october-2023/debug-blog'
+  }}
+  loop={true}
+  title="Debugging gitserver"
+/>
+
+<a href="https://docs.sourcegraph.com/admin/repo/recording" className="not-italic flex items-center mb-sm">Docs<OpenInNewIcon className="ml-xxs" size={18} /></a>
+
+### Improved instance setup instructions for admins
+
+The steps needed to fully configure a fresh new Sourcegraph installation were previously not clearly conveyed to instance admins, which often led to later confusion when features weren't working due to misconfigurations. We've introduced a new onboarding process, which prompts admins step-by-step as they set up a fresh instance. Admins are now walked through several critical setup steps including:
+
+- Adding a license key
+- Setting an external URL
+- Configuring code hosts
+- Setting user permissions
+
+<br/>
+
+This change makes the setup process far more straightforward for admins to get the best experience on their new instance.
+
+### Get started today
+
+You can download the latest versions of the Cody IDE clients now. Code Search 5.2 will be available later today for download, and for Sourcegraph Cloud customers, your instance of Code Search will be automatically updated to the latest version.
+
+If you're new to Sourcegraph, you can [download Cody for free](https://sourcegraph.com/get-cody) or [contact us for a trial of Code Search](https://about.sourcegraph.com/contact/request-info).
+
+And, if you'd like to learn more about Sourcegraph and today's release, [join us for our livestream at 12pm PT](https://www.youtube.com/watch?v=IywQJ47XPE0) where our Engineering and DevRel teams will talk about the latest new features.

--- a/content/blogposts/2023/feature-release-october-2023.md
+++ b/content/blogposts/2023/feature-release-october-2023.md
@@ -1,8 +1,8 @@
 ---
 title: "Introducing enhancements to Code Search and Cody, including a 2x increase in autocomplete quality"
 authors:
-  - name:
-    url:
+  - name: Alex Isken
+    url: https://handbook.sourcegraph.com/team/#alex-isken
 publishDate: 2023-10-04T10:00-07:00
 description: "New versions of Cody and Code Search are now available, including Cody for Neovim and support for OpenAI LLMs in Cody."
 tags: [blog]
@@ -18,7 +18,7 @@ socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-octo
   showTitle={false}
 />
 
-Today, we're announcing a major upgrade to Cody that achieves a best-in-class initial completion acceptance rate of 30%. Cody now supports using OpenAI and open source language models in addition to the models from Anthropic already supported, and Cody LLMs can now be hosted on Azure OpenAI and AWS Bedrock. Cody is also now available for Neovim, in addition to VS Code and JetBrains IDEs. We've also revamped the Cody onboarding experience, which no longer requires installing a separate app, greatly simplifying the installation process.
+Today, we're announcing a major upgrade to Cody that achieves a best-in-class initial completion acceptance rate of 30%. Cody now supports using OpenAI and open source language models in addition to the models from Anthropic already supported, and Cody LLMs can now be hosted on Azure OpenAI and AWS Bedrock. Cody is also now available for Neovim, in addition to VS Code and [JetBrains IDEs](https://docs.sourcegraph.com/cody/explanations/cody_clients#cody-ide-extensions). We've also revamped the Cody onboarding experience, which no longer requires installing a separate app, greatly simplifying the installation process.
 
 Code Search version 5.2 also gets a number of usability upgrades, including better onboarding for admins. We’ve also shipped improved git debuggability to make troubleshooting gitserver faster for customers running large Sourcegraph instances.
 
@@ -34,7 +34,7 @@ Completion Acceptance Rate (CAR) has become a de facto standard way to measure t
 
 In June, Cody’s CAR was 15%, which frankly, we were not happy with. Now with this October release, and our continued improvement to context, we’re proud to say that the latest Cody achieves as high as 30% acceptance rate among users on average. Cody autocomplete is also now much quicker, with multiline latency improving from 3.4 seconds to 2.4 seconds and single-line latencies from 2.0 seconds to 1.1 seconds on average. And we’ve got plenty of headroom yet in these numbers, so stay tuned for further improvements in future releases.
 
-A major factor in Cody’s improved performance comes from incorporating open source LLMs into Cody. Cody now uses the [StarCoder](https://huggingface.co/bigcode/starcoder) model for the majority of its completions - specifically, StarCoder running on Fireworks, a new platform that provides fast inference for open source LLMs. Going forward, Cody Community users will make use of a combination of proprietary LLMs from Anthropic and open source models like StarCoder (the CAR we report comes from using Cody with StarCoder).
+A major factor in Cody’s improved performance comes from incorporating open source LLMs into Cody. Cody for community now uses the [StarCoder](https://github.com/bigcode-project/starcoder) model for the majority of its completions - specifically, StarCoder running on Fireworks, a new platform that provides fast inference for open source LLMs. Going forward, Cody community users will make use of a combination of proprietary LLMs from Anthropic and open source models like StarCoder (the CAR we report comes from using Cody with StarCoder).
 
 Cody also now incorporates syntactic signals to inform when it triggers a completion, including recent user behavior and recently viewed files. In some cases, this means adding latency to Cody’s completions to yield a better experience. We’ve also shipped code graph context for a select number of users, making use of Tree-sitter to fetch related snippets of code that help eliminate type errors, a common mistake in hallucinated code generations.
 

--- a/content/blogposts/2023/feature-release-october-2023.md
+++ b/content/blogposts/2023/feature-release-october-2023.md
@@ -20,7 +20,7 @@ socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-octo
 
 Today, we're announcing a major upgrade to Cody that achieves a best-in-class initial completion acceptance rate of 30%. Cody now supports using OpenAI and open source language models in addition to the models from Anthropic already supported, and Cody LLMs can now be hosted on Azure OpenAI and AWS Bedrock. Cody is also now available for Neovim, in addition to VS Code and [JetBrains IDEs](https://docs.sourcegraph.com/cody/explanations/cody_clients#cody-ide-extensions). We've also revamped the Cody onboarding experience, which no longer requires installing a separate app, greatly simplifying the installation process.
 
-Code Search version 5.2 also gets a number of usability upgrades, including better onboarding for admins. We’ve also shipped improved git debuggability to make troubleshooting gitserver faster for customers running large Sourcegraph instances.
+Sourcegraph Code Search 5.2 features a number of admin usability improvements, including improved admin onboarding and troubleshooting features for repository syncing on very large codebases.
 
 Read on to learn more about what’s new. And, if you’d like to learn more about how we view the evolution of the code AI landscape, check out our other post: [How we’re thinking about the levels of Code AI](https://about.sourcegraph.com/blog/levels-of-code-ai).
 
@@ -30,15 +30,13 @@ Read on to learn more about what’s new. And, if you’d like to learn more abo
 
 ### Speed & quality improvements across Cody IDE clients
 
-Completion Acceptance Rate (CAR) has become a de facto standard way to measure the combined latency and quality of autocompletions produced by AI coding assistants. If the response quality is high but it takes too long to appear, it will be rejected. Likewise, if it comes quickly but is of low quality, the response will also be rejected. A raising CAR measures our ability to hit the sweet spot between the two as we optimize for users accepting the suggestion Cody makes. 
+Completion Acceptance Rate (CAR) has become a standard way to measure the quality of completions produced by AI coding assistants. Both response quality and latency affect CAR as high quality slow completions and low quality fast completions are more likely to be rejected.
 
-In June, Cody’s CAR was 15%, which frankly, we were not happy with. Now with this October release, and our continued improvement to context, we’re proud to say that the latest Cody achieves as high as 30% acceptance rate among users on average. Cody autocomplete is also now much quicker, with multiline latency improving from 3.4 seconds to 2.4 seconds and single-line latencies from 2.0 seconds to 1.1 seconds on average. And we’ve got plenty of headroom yet in these numbers, so stay tuned for further improvements in future releases.
+Cody's initial CAR in June was 15%. With the latest updates, Cody's daily CAR has reached as high as 30%. Cody autocomplete is also now much quicker, with average multiline latency improving from 3.4 seconds to 2.4 seconds and single-line latencies from 2.0 seconds to 1.1 seconds.
 
-A major factor in Cody’s improved performance comes from incorporating open source LLMs into Cody. Cody for community now uses the [StarCoder](https://github.com/bigcode-project/starcoder) model for the majority of its completions - specifically, StarCoder running on Fireworks, a new platform that provides fast inference for open source LLMs. Going forward, Cody community users will make use of a combination of proprietary LLMs from Anthropic and open source models like StarCoder (the CAR we report comes from using Cody with StarCoder).
+A major factor in Cody’s improved performance comes from incorporating open source LLMs into Cody. Cody now uses the [StarCoder model](https://github.com/bigcode-project/starcoder) for the majority of its completions in the community edition. Cody’s StarCoder runs on Fireworks, a new platform that provides very fast inference for open source LLMs. Going forward, Cody for community users will make use of a combination of proprietary LLMs from Anthropic and open source models like StarCoder (the CAR we report comes from using Cody with StarCoder).
 
-Cody also now incorporates syntactic signals to inform when it triggers a completion, including recent user behavior and recently viewed files. In some cases, this means adding latency to Cody’s completions to yield a better experience. We’ve also shipped code graph context for a select number of users, making use of Tree-sitter to fetch related snippets of code that help eliminate type errors, a common mistake in hallucinated code generations.
-
-Behaviorally, Cody now uses [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) to determine when to trigger a completion and whether to generate a single-line or multi-line completion. Here's an example of where Cody opts for a one-shot multiline completion in contrast to other coding assistants that generate code line by line.
+Another factor driving improved CAR is that Cody now uses the [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) to determine when to trigger a completion and whether to generate a single-line or multi-line completion. Here's an example of where Cody opts for a one-shot multiline completion in contrast to another coding assistant that generates code line by line.
 
 _Cody:_
 <Video 
@@ -60,7 +58,7 @@ _Other coding assistant:_
   title="Competitor multiline autocomplete"
 />
 
-Cody itself remains open source, while integrating with Sourcegraph Code Search (source available) and proprietary LLMs. Sourcegraph remains committed to its philosophy of striving for open source for single player dev tools like Cody. We also believe freedom of choice in the fast-moving model landscape will be a competitive advantage and accelerator of progress for Cody that will compound over time. 
+Cody itself remains open source. We also believe our ability to integrate the best open source and proprietary LLMs in the fast-moving model landscape will be a competitive advantage and accelerator of progress for Cody that will compound over time. 
 
 ### Cody for Neovim, now available as experimental
 

--- a/content/blogposts/2023/feature-release-october-2023.md
+++ b/content/blogposts/2023/feature-release-october-2023.md
@@ -38,7 +38,7 @@ A major factor in Cody’s improved performance comes from incorporating open so
 
 Another factor driving improved CAR is that Cody now uses the [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree) to determine when to trigger a completion and whether to generate a single-line or multi-line completion. Here's an example of where Cody opts for a one-shot multiline completion in contrast to another coding assistant that generates code line by line.
 
-_Cody:_
+#### Cody:
 <Video 
   source={{
     webm: 'blog/release-october-2023/cody_multilinereturn',
@@ -48,7 +48,7 @@ _Cody:_
   title="Cody multiline autocomplete"
 />
 
-_Other coding assistant:_
+#### Other coding assistant:
 <Video 
   source={{
     webm: 'blog/release-october-2023/competitor_multilinereturn',

--- a/content/blogposts/2023/feature-release-october-2023.md
+++ b/content/blogposts/2023/feature-release-october-2023.md
@@ -108,8 +108,8 @@ The VS Code extension has received a similar upgrade as JetBrains, with under-th
 
 The `/doc` and `/test` commands have also been updated:
 
-- `/doc` now adds docstrings directly to your code without you needing to copy & paste from the chat sidebar.
-- `/test` now better detects your testing framework, adds any dependency imports as needed, and includes the necessary stubs and test setup code.
+- `/doc` now adds docstrings directly to your code without you needing to copy & paste from the chat sidebar
+- `/test` now better detects your testing framework, adds any dependency imports as needed, and includes the necessary stubs and test setup code
 
 <br/>
 
@@ -184,7 +184,7 @@ The steps needed to fully configure a fresh new Sourcegraph installation were pr
 
 <br/>
 
-This change makes the setup process far more straightforward for admins to get the best experience on their new instance.
+This change makes the setup process more straightforward for admins to get the best experience on their new instance.
 
 ### Get started today
 

--- a/content/blogposts/2023/feature-release-october-2023.md
+++ b/content/blogposts/2023/feature-release-october-2023.md
@@ -98,6 +98,8 @@ The JetBrains plugin has been rewritten with a new architecture that significant
   title="Cody in JetBrains"
 />
 
+Cody for Neovim remains experimental as we continue to tweak the UX based on community feedback. If you have feedback, let us know in [Discord](https://discord.gg/rDPqBejz93).
+
 [Download Cody for JetBrains](https://plugins.jetbrains.com/plugin/9682-sourcegraph-cody--code-search).
 
 ### Performance improvements and command updates for Cody in VS Code

--- a/content/blogposts/2023/levels-of-code-ai.md
+++ b/content/blogposts/2023/levels-of-code-ai.md
@@ -1,0 +1,129 @@
+---
+title: "How we’re thinking about the levels of code AI"
+authors:
+  - name: Quinn Slack
+    url: https://handbook.sourcegraph.com/team/#quinn-slack
+publishDate: 2023-10-04T10:00-07:00
+description: "We've defined levels of code AI capabilities to provide clarity for developers on what's achievable now and coming next amidst the hype."
+tags: [blog]
+slug: 'levels-of-code-ai'
+published: true
+heroImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/levels-of-code-ai-blog-hero.png
+socialImage: https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/levels-of-code-ai-blog-hero.png
+---
+
+In the last year, code AI went from less than 1% of developers using it, to [around 92%](https://github.blog/2023-06-13-survey-reveals-ais-impact-on-the-developer-experience/) of developers using it. Code AI has changed how almost everybody codes, and its impact is only just beginning. But overall, there's too much hype about code AI, which has led some to dismiss code AI altogether.
+
+To avoid this, and to communicate code AI's current and future state clearly, we've found it helpful to think in terms of "levels of code AI" as we've been building [Cody](https://cody.dev). This has made it easier for our own team and our users to understand what code AI can actually do today and what it'll be capable of in the future.
+
+We've defined the levels to be sequential, so that achieving level N first requires achieving level N-1. For example, good AI code completion (level 1) is a prerequisite for AI creating larger code diffs (level 2). This helps us identify what capabilities and primitives to build first before we can conceivably tackle the harder problems. This property also makes it useful to consumers of code AI as a BS filter when evaluating exaggerated claims from vendors.
+
+![Levels of code AI](https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/levels-of-code-ai/levels-of-code-ai.png)
+
+We took inspiration from the Society of Automotive Engineers' (SAE) [levels of driving automation](https://www.sae.org/blog/sae-j3016-update), which have helped cut through hype in the autonomous vehicle market.
+
+![SAE levels of automation](https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/levels-of-code-ai/sae-levels.png)
+
+Source: [SAE International](https://www.sae.org/blog/sae-j3016-update)
+
+Let's go through each level of code AI.
+
+## Human-initiated code
+
+Today, virtually all code written is human-initiated, where a human writes, debugs, documents, tests, and ships code. The first three levels of code AI are where the human developer is in control and initiates each invocation of code AI to directly help with the human's coding task.
+
+### Level 0 - No AI assistance
+
+At this base level, the developer writes all code manually without any AI assistance. This reflects the traditional software development process that relies solely on human developers writing code. The developer is responsible for all aspects of programming, including writing, structuring, testing, debugging, and maintaining a codebase. AI does not generate or modify any part of the codebase. All logic, planning, and implementation comes from the human developer. This level serves as the starting point before introducing any AI assistance into the development workflow.
+
+In self-driving car terminology, this represents the SAE level 0 of driving automation, which is "No Automation." A vehicle operating at Level 0 is fully reliant on the human driver. The human driver performs all the tasks from acceleration to braking, steering, and everything in between.
+
+Level 0 does include plenty of non-AI assistance, such as symbol name completion, hovers, definitions, references, implementations, auto-formatting, etc.
+
+![Level 0](https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/levels-of-code-ai/level-0.gif)
+
+### Level 1 - Code completion
+
+At this level, the developer begins to use AI that can generate single lines or entire blocks of code based on the surrounding code. For example, a developer might write the signature of the function, and the AI will infer the context and generate the implementation details for that function. At level 1, the code AI assistant's input is its training set (10^9-10^12 tokens of code and other text) and some limited context, often taken from recently viewed files in the editor.
+
+Here's an example of Cody generating the implementation logic for a bubble sort algorithm in Javascript below. Based on the function name and the surrounding context around that function, Cody is able to infer that we wanted to implement a bubble sort algorithm for our `bubbleSort` function and provided us with the implementation details to do so. GitHub Copilot and other code AI assistants provide similar code completion functionality.
+
+![Level 1](https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/levels-of-code-ai/autocomplete-ghost-text.png)
+
+The AI understands enough context to turn simple instructions into usable code. However, the developer still designs the overall program logic and control flow. AI code generation is limited to small code blocks like singular functions at level 1.
+
+A level 1 code AI assistant speeds up common coding patterns but does not compose meaningful programs itself. The human developer still decides the structure and design of the program, writes substantial amounts of original and nuanced code, and validates that the code AI completions are accurate.
+
+This is like SAE Level 1 (Driver Assistance), which includes basic cruise control and lane centering. At this level, vehicles still require the full attention of the human driver but offer simple automation features to make driving easier.
+
+### Level 2 - Code creation 
+
+At level 2, the code AI is able to write longer blocks of code, design and implement APIs, and fix existing code--all of which go far beyond filling in a few lines here and there. This requires a superior understanding of the codebase and related context compared to level 1, so that the AI-created code is more likely to be accurate and idiomatic. Because level 2 involves writing more code at once than level 1, level 2 is strictly harder than level 1 to achieve.
+
+At level 2, the developer is still in control and is expected to review all of the code that the AI generates. The AI code creation operation is a single operation in response to human direction.
+
+Here's an example where Cody performs a more complex code creation task based on human direction:
+
+<Video 
+  source={{
+    mp4: 'blog/release-october-2023/levels-of-code-ai/cody-convert-string-to-object-id'
+  }}
+  loop={true}
+  title="Level 2"
+/>
+
+Beyond code creation, one way to evaluate a code AI's depth of understanding is by asking it to explain code. While the code explanation is not necessarily used directly for code creation, you can often use it to gauge the tool's general reasoning capabilities about code and its comprehension of specific aspects of your codebase. Here's an example of using Cody to `/explain` some code:
+
+<Video 
+  source={{
+    mp4: 'blog/release-october-2023/levels-of-code-ai/explain-cody'
+  }}
+  loop={true}
+  title="Cody explains code"
+/>
+
+This is like SAE Level 2 (Partial Automation), which includes features like traffic-aware cruise control (TACC) and automatic lane changes. The human driver is still in control and can override anything the car does at any time, but the car is performing more complex actions in response to human direction on its own.
+
+## AI-initiated coding
+
+Code AI levels 1 and 2 about human-initiated coding, where the AI coding assistant performs a single operation in response to human direction, and where the AI's output is (intended to be) reviewed by the human.
+
+The next two levels, levels 3 and 4 of code AI, are where the code AI performs multiple steps (operations) to accomplish a human's higher-level intent. The human does not review the output of each step.
+
+### Level 3 - Supervised automation
+
+We call level 3 "supervised automation", where the human gives a high-level objective and the code AI performs multiple steps to accomplish it, with some capability to validate its work so it can iterate toward a solution. The objective is on the order of what you could give to a software engineering intern or junior developer with unbounded time and patience, such as fixing many kinds of bugs, adding new features, and integrating with other systems.
+
+This is where the human starts to step back from writing code and instead focuses on higher-level design, specifications, and reviews. The code AI is responsible for determining which code (and docs) to add or update, writing the code and associated tests, and distilling it into an easily reviewable change. If needed, the code AI might ask the human for input along the way, such as to clarify the human's product requirements.
+
+The human is not expected to review the output of each step as the code AI iterates toward a solution, but the human still should perform a high-level review of the final code output. When the human reviews the final code output, the level 3 code AI is able to interact and adjust the code in response to the human feedback.
+
+Some coding objectives will probably be too complex to be accomplished by a level 3 code AI. We don't yet know how to specify the limits on task complexity in a useful way, but we think the 80-20 rule may apply here. That is to say, 80% of the issues in your issue tracker--the ones that are most straightforward, mechanical, or tedious--will be resolvable with level 3 code AI.
+
+An example of what a level 3 code AI could accomplish by itself is adding a new user profile field to an application. It's likely the code AI would need to ask the human for clarity on the product requirements as it starts to implement the solution. Another example is resolving a bug observed in the production logs. A level 3 code AI ought to be able to root-cause simple bugs, propose a solution, add the appropriate unit tests, and submit a PR for review by a human.
+
+This is like SAE Level 3 (Conditional Automation), where the vehicle itself takes on the primary role of driving, with the human driver being a fallback in case the vehicle cannot drive itself safely. The vehicle can perform most of the driving tasks including steering, acceleration, lane changes, and more, but it may encounter situations where it cannot adequately perform these tasks, so it gives control back to the human driver.
+
+### Level 4 - Full automation
+
+Level 4 is like level 3, except it can accomplish more complex tasks, and humans are no longer expected to review the final code output from the code AI. This is how a CEO or product manager would interact with a senior engineer, fully trusting them to produce a high-quality solution in code. It may also be useful for level 4 to include proactive monitoring of code to fix bugs and respond to user feedback.
+
+This is like SAE Level 4 (High Automation), which entails cars performing virtually all driving tasks under most conditions. For example, Waymo and Cruise operate a fleet of fully automated self-driving taxis in cities where they have high-quality mapping data and can provide a safe driving experience for passengers without human drivers. A customer simply hails a car using a mobile app, provides a destination, and is driven by the vehicle to their final destination without any additional human input.
+
+## Level 5: AI-led full autonomy
+
+Levels 1-4 of code AI involve achieving goals a human has directly defined. And level 4 certainly contains enough complexity to take up lifetimes of research and development. Through the power of composition and abstraction, level 4 could achieve indefinitely long and sophisticated chains of execution. However, a human will still need to articulate a definite goal, like "I need an application that does XYZ" and success will be measured by how closely the AI accomplishes this goal.
+
+But there is perhaps a level beyond this that involves AI setting its own goals to maximize a more fundamental reward function in a multi-agent, adversarial, and unbounded environment. Some analogues would be the way the human brain seeks dopamine or how companies seek profit---to revisit our self-driving analogy, the way transportation companies continually observe and refine their business, increasingly defined in code, to maximize the utility they deliver to their customers.
+
+Level 5 certainly feels distant to us given the current state of code AI, but on the other hand, the rapid progress we've seen in just the past few years presents the exciting possibility that we could achieve it within our lifetimes. There will be many challenges to overcome along the way, including ones of alignment (in the general sense of the word), but we are optimistic it is within reach.
+
+## Conclusion
+
+![Levels of Code AI](https://storage.googleapis.com/sourcegraph-assets/blog/release-october-2023/levels-of-code-ai/levels-of-code-ai.png)
+
+We expect to see code AI take on increasingly complex coding tasks with greater autonomy. Code AI's impact is real and growing, but there's also too much hype that causes confusion and loss of trust. Just as the autonomous driving industry came together to agree on a set of levels for self-driving cars to address that same problem, we've found it useful to define the levels of code AI as we've been building [Cody](https://cody.dev).
+
+We hope other people find these levels of code AI useful as a tool for thought in understanding, evaluating, and building code AI, and monitoring its impact.
+
+Tell us what you think about the code AI levels and help us improve them as a tool for thought!


### PR DESCRIPTION
This PR adds 2 new blogs to the website for the October 4 release: The release post and thought leadership on the levels of Code AI.