### PR TITLE
Revert the nav padding change from #6381

### DIFF
--- a/src/components/Layout/Layout.tsx
+++ b/src/components/Layout/Layout.tsx
@@ -109,7 +109,7 @@ export const Layout: FunctionComponent<LayoutProps> = ({ headerColorTheme, class
             </Head>
 
             {!props.hideHeader && (
-                <div className={classNames(props.heroAndHeaderClassName, 'pt-[147px] md:pt-[64px]')}>
+                <div className={classNames(props.heroAndHeaderClassName, 'pt-[147px] md:pt-[116px]')}>
                     <Header minimal={props.minimal} colorTheme={headerColorTheme || 'white'} navRef={navRef} />
 
                     {props.hero}


### PR DESCRIPTION
The top nav padding was changed in #6381 which caused some elements to be incorrectly positioned on desktop sized widths. This reverts it back to the original value, fixing the layout.

| Before | After |
| - | - |
| <img width="1439" alt="Screenshot 2023-10-05 at 11 58 43 am" src="https://github.com/sourcegraph/about/assets/153/782e7e70-f6c6-458a-beab-248fa1efcf55"> | <img width="1439" alt="Screenshot 2023-10-05 at 11 58 36 am" src="https://github.com/sourcegraph/about/assets/153/d8aa1bd2-5b11-47f5-9038-0cf3056361f3"> |
| <img width="1439" alt="Screenshot 2023-10-05 at 11 58 13 am" src="https://github.com/sourcegraph/about/assets/153/872841e3-83ee-4964-bac0-ffc8651d86a6"> | <img width="1439" alt="Screenshot 2023-10-05 at 11 58 05 am" src="https://github.com/sourcegraph/about/assets/153/d71e2bbc-eee7-4bc7-9d3a-37e7e235c718"> |
| <img width="1762" alt="Screenshot 2023-10-05 at 12 01 49 pm" src="https://github.com/sourcegraph/about/assets/153/35e919ac-9913-4cef-a856-3dff725521b0"> | <img width="1762" alt="Screenshot 2023-10-05 at 12 01 36 pm" src="https://github.com/sourcegraph/about/assets/153/99c65789-1f62-463d-86ad-9f7f01195769"> |
| <img width="1762" alt="Screenshot 2023-10-05 at 12 01 53 pm" src="https://github.com/sourcegraph/about/assets/153/380f0146-a68e-415e-886d-95eb17946d44"> | <img width="1762" alt="Screenshot 2023-10-05 at 12 01 40 pm" src="https://github.com/sourcegraph/about/assets/153/2c3aace5-62f9-41df-897c-f0975eb6c9d4"> |
|  <img width="1762" alt="Screenshot 2023-10-05 at 12 05 35 pm" src="https://github.com/sourcegraph/about/assets/153/9a1f3cb3-329c-461e-8976-8fc806744446"> | <img width="1762" alt="Screenshot 2023-10-05 at 12 05 39 pm" src="https://github.com/sourcegraph/about/assets/153/2a94b341-300a-427b-bdb0-8e51470e62dc"> |