### PR TITLE
Fix the image stretch in /resources

### DIFF
--- a/src/pages/resources.tsx
+++ b/src/pages/resources.tsx
@@ -171,8 +171,8 @@ const Resources: FunctionComponent = () => {
             }
         >
             <ContentSection background="white" parentClassName="bg-gray-50 !py-0">
-                <div className="relative -top-[107px] -mb-[43px] -mt-[70px] flex max-w-[1280px] flex-col justify-between gap-x-[144px] rounded-md border border-gray-500 bg-white px-[23px] py-[31px] shadow-sm md:-top-[84px] md:-mb-[84px] lg:flex-row lg:px-[79px] lg:py-[63px]">
-                    <div className="flex flex-col items-center justify-center lg:items-start">
+                <div className="relative -top-[107px] -mb-[43px] -mt-[70px] flex max-w-[1280px] flex-col justify-between md:gap-x-[144px] rounded-md border border-gray-500 bg-white px-[23px] py-[31px] shadow-sm md:-top-[84px] md:-mb-[84px] lg:flex-row lg:px-[79px] lg:py-[63px]">
+                    <div className="flex flex-col items-center justify-center lg:items-start flex-shrink-0">
                         <p className="pb-1 text-center font-mono font-[500] capitalize lg:text-left">
                             {featuredResource.contentType}
                         </p>
@@ -185,7 +185,7 @@ const Resources: FunctionComponent = () => {
                         >{`Read the ${featuredResource.contentType}`}</Link>
                     </div>
                     <div className="flex justify-center lg:justify-end">
-                        <img className="max-h-[252px] w-full rounded-lg" src="/big-code.png" alt="Featured resource" />
+                        <img className="rounded-lg w-full md:max-w-[700px]" src="/big-code.png" alt="Featured resource" width="2400" height="1350" />
                     </div>
                     <Link
                         href={featuredResource.link}


### PR DESCRIPTION
Fixes the image stretch in /resources

| Before | After |
| - | - |
| <img width="890" alt="Screenshot 2023-10-05 at 2 38 55 pm" src="https://github.com/sourcegraph/about/assets/153/f4fee4e6-ad65-4a47-ba43-f89071b782a7"> | <img width="890" alt="Screenshot 2023-10-05 at 2 39 00 pm" src="https://github.com/sourcegraph/about/assets/153/e688dc35-6161-41ea-bd88-8449c6d153a6"> |
| <img width="1642" alt="Screenshot 2023-10-05 at 2 38 49 pm" src="https://github.com/sourcegraph/about/assets/153/38196a18-1378-41ab-ab12-b983f8080aac"> | <img width="1642" alt="Screenshot 2023-10-05 at 2 38 40 pm" src="https://github.com/sourcegraph/about/assets/153/01396abb-3669-4037-9d80-3a8edc11bfff"> |