### PR TITLE
Add css for kbd element

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -36,7 +36,7 @@
         @apply font-mono text-base font-medium tracking-tightest break-words;
     }
     kbd {
-        @apply bg-gray-200 border border-gray-400 rounded shadow-sm text-gray-500 font-bold text-sm inline-block px-2 py-1
+        @apply bg-gray-200 border border-gray-400 rounded shadow-sm text-gray-500 text-sm inline-block px-2 py-1
     } 
     /* Inline Links */
     p a,

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -35,6 +35,9 @@
     code {
         @apply font-mono text-base font-medium tracking-tightest break-words;
     }
+    kbd {
+        @apply bg-gray-200 border border-gray-400 rounded shadow-sm text-gray-500 font-bold text-sm inline-block px-2 py-1
+    } 
     /* Inline Links */
     p a,
     li a {


### PR DESCRIPTION
These styles visually differentiate the keyboard input on the page, making it stand out from regular text while still blending in. 

## Example (Chrome)

![Screen Recording 2023-10-20 at 01 47 02 PM](https://github.com/sourcegraph/about/assets/398230/595a324a-cc0a-42b9-9bd8-3545aff6dc50)

## Test

https://deploy-preview-6552--sourcegraph.netlify.app/blog/power-users-guide-to-cody-ai-for-visual-studio-code#:~:text=You%20can%20hide,panel%20for%20it.

### Firefox
<img width="810" alt="Image 2023-10-20 at 2 13 44 PM png" src="https://github.com/sourcegraph/about/assets/398230/33f02bb3-c1ad-41ba-82b3-c17e5caf9640">

### Safari
<img width="830" alt="Image 2023-10-20 at 2 12 21 PM png" src="https://github.com/sourcegraph/about/assets/398230/fbf97e72-d8ef-4193-a598-4d107949e64e">

### Mobile
<img width="304" alt="Image 2023-10-20 at 2 11 02 PM png" src="https://github.com/sourcegraph/about/assets/398230/0d3c8901-a73a-4c33-b57d-37f962559263">

