### PR TITLE
Add banner with the domain for public code search

### DIFF
--- a/src/components/Banner.tsx
+++ b/src/components/Banner.tsx
@@ -6,14 +6,14 @@ export const Banner: FunctionComponent<{}> = () => (
     <div className="sg-border-gradient-banner z-[1000] border-b-1 bg-black py-[13px]">
         <div className="mx-auto flex max-w-screen-xl flex-col items-center justify-center gap-y-[9px] gap-x-12 px-2 md:flex-row">
             <p className="mb-0 text-center font-semibold leading-[22px] text-white">
-                The latest Cody release improves autocomplete performance by up to 2x
+                Public code search has moved! You can find it at sourcegraph.com/search.
             </p>
             <Link
-                href="https://about.sourcegraph.com/blog/feature-release-october-2023"
-                title="RSVP to the livestream"
+                href="https://sourcegraph.com/search"
+                title="Public code search"
                 className="btn bg-transparent !px-0 !py-0 leading-[22px] text-violet-300"
             >
-                Read the release blog
+                Go to public code search
                 <ChevronRightIcon className="!mb-0 ml-[18px] inline" />
             </Link>
         </div>

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -8,6 +8,7 @@ import { useRouter } from 'next/router'
 
 import { useAuthModal } from '../../../context/AuthModalContext'
 import { buttonLocation } from '../../../data/tracking'
+import { Banner } from '../../Banner'
 import { MeetWithProductExpertButton } from '../../cta/MeetWithProductExpertButton'
 
 import { NavItems } from './NavItems'
@@ -54,7 +55,10 @@ export const Header: FunctionComponent<Props> = ({ minimal, colorTheme, navRef }
     return (
         <Disclosure as="nav" className={classNames('fixed top-0 left-0 right-0 z-[1030]')} ref={navRef}>
             {({ open }) => (
-                <HeaderContent colorTheme={colorTheme} minimal={minimal} open={open} sticky={sticky} source={source} />
+                <>
+                    <Banner />
+                    <HeaderContent colorTheme={colorTheme} minimal={minimal} open={open} sticky={sticky} source={source} />
+                </>
             )}
         </Disclosure>
     )


### PR DESCRIPTION
This adds a banner with a link to public code search, for when marketing moves to sourcegraph.com.