### PR TITLE
Update PCS link in the navbar

### DIFF
--- a/src/components/Layout/Header/NavItems.tsx
+++ b/src/components/Layout/Header/NavItems.tsx
@@ -74,7 +74,7 @@ const NAV_ITEMS: NavItem[] = [
     },
     {
         name: 'Search public code',
-        href: 'https://sourcegraph.com',
+        href: 'https://sourcegraph.com/search',
     },
 ]
 


### PR DESCRIPTION
This PR fixes the link to public code search in the nav bar, which currently points to sourcegraph.com/ (but should point to /search).