### PR TITLE
ExternalsAuth: update sign-in URLs to use SAMS

### DIFF
--- a/src/components/cta/ExternalsAuth.tsx
+++ b/src/components/cta/ExternalsAuth.tsx
@@ -129,8 +129,8 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
                 <Link
                     href={
                         plan === PLAN_PRO
-                            ? 'https://sourcegraph.com/.auth/github/login?pc=https://github.com/::e917b2b7fa9040e1edd4&redirect=/get-cody?pro=true'
-                            : 'https://sourcegraph.com/.auth/github/login?pc=https%3A%2F%2Fgithub.com%2F%3A%3Ae917b2b7fa9040e1edd4&redirect=/get-cody'
+                            ? 'https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=github&pc=sams&redirect=/get-cody?pro=true'
+                            : 'https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=github&pc=sams&&redirect=/get-cody'
                     }
                     className={classNames(
                         'hover:sg-bg-hover-external-auth-button flex items-center justify-center px-4 py-2 font-normal hover:text-black md:h-12 md:px-6 md:text-base',
@@ -151,8 +151,8 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
                 <Link
                     href={
                         plan === PLAN_PRO
-                            ? 'https://sourcegraph.com/.auth/gitlab/login?pc=https://gitlab.com/::b45ec[...]400cf73db6e39917635bf682f062c57aca68a1e41c&redirect=/get-cody?pro=true'
-                            : 'https://sourcegraph.com/.auth/gitlab/login?pc=https%3A%2F%2Fgitlab.com%2F%3A%3Ab45ecb474e92c069567822400cf73db6e39917635bf682f062c57aca68a1e41c&redirect=/get-cody'
+                            ? 'https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=/get-cody?pro=true'
+                            : 'https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=gitlab&pc=sams&redirect=/get-cody'
                     }
                     className={classNames(
                         'hover:sg-bg-hover-external-auth-button flex items-center justify-center px-4 py-2 font-normal hover:text-black md:h-12 md:px-6 md:text-base',
@@ -173,8 +173,8 @@ export const ExternalsAuth: React.FunctionComponent<ExternalsAuthProps> = ({
                 <Link
                     href={
                         plan === PLAN_PRO
-                            ? 'https://sourcegraph.com/.auth/openidconnect/login?pc=google&redirect=/get-cody?pro=true'
-                            : 'https://sourcegraph.com/.auth/openidconnect/login?pc=google&redirect=/get-cody'
+                            ? 'https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=/get-cody?pro=true'
+                            : 'https://sourcegraph.com/.auth/openidconnect/login?prompt_auth=google&pc=sams&redirect=/get-cody'
                     }
                     className={classNames(
                         'hover:sg-bg-hover-external-auth-button flex items-center justify-center px-4 py-2 font-normal font-normal hover:text-black md:h-12 md:px-6 md:text-base',


### PR DESCRIPTION
We are going to take down old sign-in URLs in favor of SAMS.

Side note: the Pro plan link for GitLab one never worked... 😂 

We have patched both Cody clients, e.g. https://github.com/sourcegraph/cody/pull/3037