### PR TITLE
footer: fix enterprise link

### DIFF
--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -41,7 +41,7 @@ const FOOTER_LINK_SECTIONS: { name: string; items: LinkWithIcon[] }[] = [
         items: [
             {
                 name: 'Enterprise',
-                href: '/Enterprise',
+                href: '/enterprise',
             },
         ],
     },


### PR DESCRIPTION
The current link `/Enterprise` directs to the code search, and the correct link should be `/enterprise`.

<img width="112" alt="image" src="https://github.com/sourcegraph/about/assets/12731778/555ac5f6-0d34-4d46-9227-c0a3045a783f">
