### PR TITLE
Link to past Cody for VS Code releases

### DIFF
--- a/content/blogposts/2023/cody-vscode-0-14-release.md
+++ b/content/blogposts/2023/cody-vscode-0-14-release.md
@@ -61,6 +61,6 @@ See the [changelog](https://github.com/sourcegraph/cody/blob/main/vscode/CHANGEL
 
 Cody is [open source](https://github.com/sourcegraph/cody), and wouldn’t be what it is without our amazing contributors 💖 A big thank you to everyone who contributed, filed issues, and sent us feedback.
 
-<hr style={{marginTop:"2rem",marginBottom:"2rem"}} />
+---
 
-To get started with Cody, [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+**To get started with Cody [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)**

--- a/content/blogposts/2023/cody-vscode-0-16-release.md
+++ b/content/blogposts/2023/cody-vscode-0-16-release.md
@@ -81,6 +81,11 @@ See the [changelog](https://github.com/sourcegraph/cody/releases/tag/vscode-v0.1
 
 Cody is [open source](https://github.com/sourcegraph/cody), and wouldn’t be what it is without our amazing contributors 💖 A big thank you to everyone who contributed, filed issues, and sent us feedback.
 
-<hr style={{marginTop:"2rem",marginBottom:"2rem"}} />
+---
 
-To get started with Cody, [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+**To get started with Cody [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)**
+
+
+---
+
+Previous release: [Cody for VS Code v0.14](/blog/cody-vscode-0-14-release)

--- a/content/blogposts/2023/cody-vscode-0-18-release.md
+++ b/content/blogposts/2023/cody-vscode-0-18-release.md
@@ -114,6 +114,11 @@ See the [changelog](https://github.com/sourcegraph/cody/releases/tag/vscode-v0.1
 
 Cody wouldn’t be what it is without our amazing contributors 💖 A big thank you to everyone who contributed, filed issues, and sent us feedback.
 
-<hr style={{marginTop:"2rem",marginBottom:"2rem"}} />
+---
 
-To get started with Cody, [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+**To get started with Cody [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)**
+
+
+---
+
+Previous release: [Cody for VS Code v0.16](/blog/cody-vscode-0-16-release)

--- a/content/blogposts/2024/cody-vscode-1-1-0-release.md
+++ b/content/blogposts/2024/cody-vscode-1-1-0-release.md
@@ -67,8 +67,13 @@ See the [changelog](https://github.com/sourcegraph/cody/compare/vscode-v1.0.5...
 
 Cody wouldn’t be what it is without our amazing contributors 💖 A big thank you to everyone who contributed, filed issues, and sent us feedback.
 
-As always, we value your feedback in [Discord](https://discord.com/servers/sourcegraph-969688426372825169) and [GitHub](https://github.com/sourcegraph/cody/discussions). Happy Codying!
+As always, we value your feedback in [Discord](https://discord.com/servers/sourcegraph-969688426372825169) and [GitHub](https://github.com/sourcegraph/cody/issues/new/choose). Happy Codying!
 
-<hr style={{marginTop:"2rem",marginBottom:"2rem"}} />
+---
 
-To get started with Cody, [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+**To get started with Cody [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)**
+
+
+---
+
+Previous release: [Cody for VS Code v0.18](/blog/cody-vscode-0-18-release)

--- a/content/blogposts/2024/cody-vscode-1-2-0-release.md
+++ b/content/blogposts/2024/cody-vscode-1-2-0-release.md
@@ -106,6 +106,11 @@ If you missed it above, we mentioned two individuals in this post, **Deepak and 
 💖 Also, a big thank you to everyone else who contributed, filed issues and sent us feedback. 
 
 
-<hr style={{marginTop:"2rem",marginBottom:"2rem"}} />
+---
 
-To get started with Cody, [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+**To get started with Cody [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)**
+
+
+---
+
+Previous release: [Cody for VS Code v1.1.0](/blog/cody-vscode-1.1.0-release)

--- a/content/blogposts/2024/cody-vscode-1-4-0-release.md
+++ b/content/blogposts/2024/cody-vscode-1-4-0-release.md
@@ -116,9 +116,14 @@ See the [changelog](https://github.com/sourcegraph/cody/releases/tag/vscode-v1.4
 
 Cody wouldn’t be what it is without our amazing contributors 💖 A big thank you to everyone who contributed, filed issues, and sent us feedback.
 
-As always, we value your feedback in [Discord](https://discord.com/servers/sourcegraph-969688426372825169) and [GitHub](https://github.com/sourcegraph/cody/discussions). Happy Codying!
+As always, we value your feedback in [Discord](https://discord.com/servers/sourcegraph-969688426372825169) and [GitHub](https://github.com/sourcegraph/cody/issues/new/choose). Happy Codying!
 
 
-<hr style={{marginTop:"2rem",marginBottom:"2rem"}} />
+---
 
-To get started with Cody, [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+**To get started with Cody [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)**
+
+
+---
+
+Previous release: [Cody for VS Code v1.2.0](/blog/cody-vscode-1-2-0-release)

--- a/content/blogposts/2024/cody-vscode-1-6-0-release.md
+++ b/content/blogposts/2024/cody-vscode-1-6-0-release.md
@@ -107,9 +107,14 @@ See the [changelog](https://github.com/sourcegraph/cody/releases/tag/vscode-v1.6
 
 Cody wouldn’t be what it is without our amazing contributors 💖 A big thank you to everyone who contributed, filed issues, and sent us feedback.
 
-As always, we value your feedback in [Discord](https://discord.com/servers/sourcegraph-969688426372825169) and [GitHub](https://github.com/sourcegraph/cody/discussions). Happy Codying!
+As always, we value your feedback in [Discord](https://discord.com/servers/sourcegraph-969688426372825169) and [GitHub](https://github.com/sourcegraph/cody/issues/new/choose). Happy Codying!
 
 
-<hr style={{marginTop:"2rem",marginBottom:"2rem"}} />
+---
 
-To get started with Cody, [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+**To get started with Cody [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)**
+
+
+---
+
+Previous release: [Cody for VS Code v1.4.0](/blog/cody-vscode-1-4-0-release)

--- a/content/blogposts/2024/cody-vscode-1-8-0-release.md
+++ b/content/blogposts/2024/cody-vscode-1-8-0-release.md
@@ -76,9 +76,14 @@ See the [changelog](https://github.com/sourcegraph/cody/releases/tag/vscode-v1.8
 
 Cody wouldn’t be what it is without our amazing contributors 💖 A big thank you to everyone who contributed, filed issues, and sent us feedback.
 
-As always, we value your feedback in [Discord](https://discord.com/servers/sourcegraph-969688426372825169) and [GitHub](https://github.com/sourcegraph/cody/discussions). Happy Codying!
+As always, we value your feedback in [Discord](https://discord.com/servers/sourcegraph-969688426372825169) and [GitHub](https://github.com/sourcegraph/cody/issues/new/choose). Happy Codying!
 
 
-<hr style={{marginTop:"2rem",marginBottom:"2rem"}} />
+---
 
-To get started with Cody, [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai).
+**To get started with Cody [install it from the VS Code Marketplace](https://marketplace.visualstudio.com/items?itemName=sourcegraph.cody-ai)**
+
+
+---
+
+Previous release: [Cody for VS Code v1.6.0](/blog/cody-vscode-1-6-0-release)


### PR DESCRIPTION
Adds a link to the bottom of the VS Code blog posts so people can navigate to previous releases, and see all the stuff they might have missed.