### PR TITLE
Reduce blog index data size

### DIFF
--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -19,10 +19,10 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
         return { notFound: true }
     }
     const postsIndexProps = publishedPosts.map(post => ({
-            frontmatter: post.frontmatter,
-            excerpt: post.excerpt,
-            slugPath: post.slugPath,
-            urlPat: post.urlPath
+        frontmatter: post.frontmatter,
+        excerpt: post.excerpt,
+        slugPath: post.slugPath,
+        urlPath: post.urlPath,
     }))
     return {
         props: {

--- a/src/pages/blog/index.tsx
+++ b/src/pages/blog/index.tsx
@@ -18,9 +18,15 @@ export const getStaticProps: GetStaticProps = async ({ preview = false }) => {
     if (!publishedPosts) {
         return { notFound: true }
     }
+    const postsIndexProps = publishedPosts.map(post => ({
+            frontmatter: post.frontmatter,
+            excerpt: post.excerpt,
+            slugPath: post.slugPath,
+            urlPat: post.urlPath
+    }))
     return {
         props: {
-            allPosts: publishedPosts,
+            allPosts: postsIndexProps,
             posts: publishedPosts.slice(0, 20),
             preview,
         },


### PR DESCRIPTION
Reduces the page data from 5.4MB to 744kB

Partially addresses the https://nextjs.org/docs/messages/large-page-data warning when loading the blog index.