### PR TITLE
Update self-serve Cody CTA copy

### DIFF
--- a/src/components/cta/CodyCta.tsx
+++ b/src/components/cta/CodyCta.tsx
@@ -31,7 +31,7 @@ export const CodyCta: FunctionComponent<CodyCtaProps> = ({ isCodyPage = false, s
                         '!leading-10 !tracking-[-1px]': isCodyPage,
                     })}
                 >
-                    Cody Free
+                    Get started with Cody
                 </Heading>
 
                 <Heading
@@ -49,7 +49,7 @@ export const CodyCta: FunctionComponent<CodyCtaProps> = ({ isCodyPage = false, s
                         className="btn btn-primary text-center"
                         type="button"
                     >
-                        Get Cody free
+                        Get Cody for free
                     </button>
                 </div>
             </div>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -305,7 +305,7 @@ const Home: FunctionComponent = () => {
                             <div className="cta-top-border absolute left-0 right-0 top-0 rounded-t-2xl" />
                             <div className=" px-14 py-16">
                                 <Heading className="mb-4 !-tracking-[1px] text-gray-700 md:leading-10" size="h2">
-                                    Cody Free
+                                    Get started with Cody
                                 </Heading>
                                 <p className="mb-0 text-lg text-gray-500">
                                     Use Cody for free in your IDE, no credit card required.


### PR DESCRIPTION
This PR updates the copy we use for the self-serve Cody CTA on 2 pages:
- sourcegraph.com/
- sourcegraph.com/cody

This makes the CTA more aligned to Cody self-serve and less aligned to Cody Free (the SKU).