### PR TITLE
Remove SF mono from tailwind.config.js

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -112,7 +112,6 @@ module.exports = {
         'sans-serif',
       ],
       mono: [
-        'SF Mono',
         'ui-monospace',
         'Menlo',
         'Monaco',


### PR DESCRIPTION
This fixes a bug for those who use Chrome on macOS and have the SF Mono font installed. See video for more context.

It starting happening after https://github.com/sourcegraph/about/pull/6818

https://www.loom.com/share/7dcd9b6df7774ee19c38138e8ee25716