### PR TITLE
Use CDN for image

### DIFF
--- a/src/components/cody/CodyAutocomplete.tsx
+++ b/src/components/cody/CodyAutocomplete.tsx
@@ -38,7 +38,7 @@ export const CodyAutocomplete: FunctionComponent<{ className?: string }> = ({ cl
             <div className="relative w-[670px] overflow-hidden">
                 <img
                     className="relative top-4 -right-4 w-[670px]"
-                    src="/cody/single-line-autocomplete_ty-arp242.svg"
+                    src="https://storage.googleapis.com/sourcegraph-assets/blog/single-line-autocomplete_ty-arp242.svg"
                     alt="Cody auto complete"
                 />
             </div>


### PR DESCRIPTION
For some reason `src="/cody/single-line-autocomplete_ty-arp242.svg"` was redirecting to /cody the web app. I guess there needs to be a route made?