### PR TITLE
Add v2 telemetry infrastructure to about repo

### DIFF
--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "@headlessui/react": "^1.7.11",
     "@heroicons/react": "^2.0.15",
     "@popperjs/core": "^2.11.7",
+    "@sourcegraph/telemetry": "^0.16.0",
     "@visx/axis": "^2.12.2",
     "@visx/curve": "^2.1.0",
     "@visx/glyph": "^2.10.0",
@@ -62,6 +63,7 @@
     "@visx/text": "^2.12.2",
     "@visx/xychart": "^2.9.0",
     "classnames": "^2.3.2",
+    "date-fns": "^3.3.1",
     "d3-format": "^3.1.0",
     "d3-scale": "^3.3.0",
     "d3-time-format": "^4.1.0",
@@ -86,7 +88,8 @@
     "sharp": "^0.31.3",
     "shikiji": "0.7.x",
     "ts-loader": "^9.2.8",
-    "ts-node": "^10.7.0"
+    "ts-node": "^10.7.0",
+    "uuid": "^8.3.0"
   },
   "devDependencies": {
     "@cypress/webpack-preprocessor": "^5.12.0",
@@ -106,6 +109,7 @@
     "@types/prismjs": "^1.26.0",
     "@types/react": "18.0.20",
     "@types/react-dom": "^18.0.6",
+    "@types/uuid": "8.0.1",
     "autoprefixer": "^10.4.8",
     "cypress": "13.2.0",
     "eslint": "^8.32.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,5 @@
 lockfileVersion: '6.0'
 
-settings:
-  autoInstallPeers: true
-  excludeLinksFromLockfile: false
-
 dependencies:
   '@dotlottie/react-player':
     specifier: ^1.6.15
@@ -17,6 +13,9 @@ dependencies:
   '@popperjs/core':
     specifier: ^2.11.7
     version: 2.11.7
+  '@sourcegraph/telemetry':
+    specifier: ^0.16.0
+    version: 0.16.0
   '@visx/axis':
     specifier: ^2.12.2
     version: 2.12.2(react@18.2.0)
@@ -56,6 +55,9 @@ dependencies:
   d3-time-format:
     specifier: ^4.1.0
     version: 4.1.0
+  date-fns:
+    specifier: ^3.3.1
+    version: 3.3.1
   feed:
     specifier: ^4.2.2
     version: 4.2.2
@@ -122,6 +124,9 @@ dependencies:
   ts-node:
     specifier: ^10.7.0
     version: 10.9.1(@types/node@18.7.18)(typescript@4.5.5)
+  uuid:
+    specifier: ^8.3.0
+    version: 8.3.2
 
 devDependencies:
   '@cypress/webpack-preprocessor':
@@ -175,6 +180,9 @@ devDependencies:
   '@types/react-dom':
     specifier: ^18.0.6
     version: 18.0.6
+  '@types/uuid':
+    specifier: 8.0.1
+    version: 8.0.1
   autoprefixer:
     specifier: ^10.4.8
     version: 10.4.11(postcss@8.4.16)
@@ -4435,6 +4443,12 @@ packages:
     resolution: {integrity: sha512-FQ1/Ued4I02R0JkrHHofDN163juVxUnPALzfxPZrDZUHv+c3jHjfZhmTHEz+Wd+g3b7MFk0fkj36nZSnvPyU8A==}
     dev: true
 
+  /@sourcegraph/telemetry@0.16.0:
+    resolution: {integrity: sha512-/LTbGWwscy/iNOYc0JS2Sl5Q21WOaiIhABlGynwJLMfPYy0YoJQfEtrCEGTSYWY735dSdUBW3wcTgCOCz8EEjA==}
+    dependencies:
+      rxjs: 7.8.1
+    dev: false
+
   /@svgr/babel-plugin-add-jsx-attribute@6.3.1(@babel/core@7.19.3):
     resolution: {integrity: sha512-jDBKArXYO1u0B1dmd2Nf8Oy6aTF5vLDfLoO9Oon/GLkqZ/NiggYWZA+a2HpUMH4ITwNqS3z43k8LWApB8S583w==}
     engines: {node: '>=10'}
@@ -4873,6 +4887,10 @@ packages:
   /@types/unist@3.0.2:
     resolution: {integrity: sha512-dqId9J8K/vGi5Zr7oo212BGii5m3q5Hxlkwy3WpYuKPklmBEvsbMYYyLxAQpSffdLl/gdW0XUpKWFvYmyoWCoQ==}
     dev: false
+
+  /@types/uuid@8.0.1:
+    resolution: {integrity: sha512-2kE8rEFgJpbBAPw5JghccEevQb0XVU0tewF/8h7wPQTeCtoJ6h8qmBIwuzUVm2MutmzC/cpCkwxudixoNYDp1A==}
+    dev: true
 
   /@types/yargs-parser@21.0.0:
     resolution: {integrity: sha512-iO9ZQHkZxHn4mSakYV0vFHAVDyEOIJQrV2uZ06HxEPcx+mt8swXoZHIbaaJ2crJYFfErySgktuTZ3BeLz+XmFA==}
@@ -6723,6 +6741,10 @@ packages:
     resolution: {integrity: sha512-dDCnyH2WnnKusqvZZ6+jA1O51Ibt8ZMRNkDZdyAyK4YfbDwa/cEmuztzG5pk6hqlp9aSBPYcjOlktquahGwGeA==}
     engines: {node: '>=0.11'}
     dev: true
+
+  /date-fns@3.3.1:
+    resolution: {integrity: sha512-y8e109LYGgoQDveiEBD3DYXKba1jWf5BA8YU1FL5Tvm0BTdEfy54WLCwnuYWZNnzzvALy/QQ4Hov+Q9RVRv+Zw==}
+    dev: false
 
   /dayjs@1.11.10:
     resolution: {integrity: sha512-vjAczensTgRcqDERK0SR2XMwsF/tSvnvlv6VcF2GIhg6Sx4yOIt/irsr1RDJsKiIyBzJDpCoXiWWq28MqH2cnQ==}
@@ -9108,7 +9130,7 @@ packages:
       log-update: 4.0.0
       p-map: 4.0.0
       rfdc: 1.3.0
-      rxjs: 7.5.6
+      rxjs: 7.8.1
       through: 2.3.8
       wrap-ansi: 7.0.0
     dev: true
@@ -12128,6 +12150,12 @@ packages:
     resolution: {integrity: sha512-dnyv2/YsXhnm461G+R/Pe5bWP41Nm6LBXEYWI6eiFP4fiwx6WRI/CD0zbdVAudd9xwLEF2IDcKXLHit0FYjUzw==}
     dependencies:
       tslib: 2.4.0
+    dev: false
+
+  /rxjs@7.8.1:
+    resolution: {integrity: sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==}
+    dependencies:
+      tslib: 2.6.2
 
   /sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
@@ -12815,7 +12843,7 @@ packages:
     engines: {node: ^14.18.0 || >=16.0.0}
     dependencies:
       '@pkgr/utils': 2.3.1
-      tslib: 2.4.0
+      tslib: 2.6.2
     dev: true
 
   /tailwindcss@3.1.8(postcss@8.4.16)(ts-node@10.9.1):
@@ -13448,7 +13476,6 @@ packages:
   /uuid@8.3.2:
     resolution: {integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==}
     hasBin: true
-    dev: true
 
   /uvu@0.5.6:
     resolution: {integrity: sha512-+g8ENReyr8YsOc6fv/NVJs2vFdHBnBNdfE49rshrTzDWOlUx4Gq7KOS2GD8eqhy2j+Ejq29+SbKH8yjkAqXqoA==}
@@ -13562,7 +13589,7 @@ packages:
       joi: 17.6.0
       lodash: 4.17.21
       minimist: 1.2.6
-      rxjs: 7.5.6
+      rxjs: 7.8.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -13899,3 +13926,7 @@ packages:
   /zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
     dev: false
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false

--- a/src/hooks/telemetry.ts
+++ b/src/hooks/telemetry.ts
@@ -1,0 +1,18 @@
+import { useEffect } from 'react';
+
+import { TelemetryRecorder } from '@sourcegraph/telemetry';
+
+export function useRecordPageViews(telemetryRecorder: TelemetryRecorder<'', ''>): void {
+    useEffect(() => {
+        const privateMetadata: { [key: string]: string | null} = {path: location.pathname}
+        const urlSearchParameters = new URLSearchParams(location.search)
+        const utmParameters: string[] = ['utm_source', 'utm_campaign', 'utm_medium', 'utm_term', 'utm_content']
+
+        for (const parameter of utmParameters) {
+            if (urlSearchParameters.has(parameter)) {
+                privateMetadata[parameter] = urlSearchParameters.get(parameter)
+            }
+        }
+        telemetryRecorder.recordEvent('aboutPage', 'view', {privateMetadata})
+    }, [])
+}

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -12,6 +12,8 @@ import { PostHogProvider } from 'posthog-js/react'
 import { AuthModalProvider } from '../context/AuthModalContext'
 import { useEventLogger, useLogAllLinkClicks } from '../hooks/eventLogger'
 import { useLandingSource } from '../hooks/landingSource'
+import { useRecordPageViews } from '../hooks/telemetry'
+import { TelemetryRecorderProvider, noOpTelemetryRecorder } from '../telemetry'
 import 'prism-themes/themes/prism-one-light.css'
 
 // Check that PostHog is client-side (used to handle Next.js SSR)
@@ -28,6 +30,13 @@ const App = ({ Component, pageProps }: AppProps): ReactNode => {
     useEventLogger()
     useLandingSource()
     useLogAllLinkClicks()
+
+    let telemetryRecorder = noOpTelemetryRecorder
+    if (typeof window !== 'undefined') {
+      const telemetryRecorderProvider = new TelemetryRecorderProvider()
+      telemetryRecorder = telemetryRecorderProvider.getRecorder()
+    }
+    useRecordPageViews(telemetryRecorder)
 
     const router = useRouter()
 

--- a/src/telemetry/cookies.ts
+++ b/src/telemetry/cookies.ts
@@ -1,0 +1,73 @@
+/**
+ * THE COOKIE SETTINGS IN THIS FILE ARE IDENTICAL TO THOSE USED ON SOURCEGRAPH.COM
+ * AND OTHER SOURCEGRAPH.COM SUBDOMAINS.
+ *
+ * It is essential to keep these in sync, to ensure that cross-platform user and
+ * session tracking cookies are re-used and not duplicated or different.
+ */
+
+import cookies, { type CookieAttributes } from 'js-cookie'
+
+/**
+ * Cookies is a simple interface over real cookies from 'js-cookie'.
+ */
+export interface Cookies {
+    /**
+     * Read cookie
+     */
+    get(name: string): string | undefined
+    /**
+     * Create a cookie
+     */
+    set(name: string, value: string, options?: CookieAttributes): string | undefined
+}
+
+/**
+ * Alias for 'js-cookie' default implementation, behind the Cookies interface.
+ */
+export function defaultCookies(): Cookies {
+    return cookies
+}
+
+let userCookieSettings: CookieAttributes
+let sessionCookieSettings: CookieAttributes
+
+export function getUserCookieSettings(): CookieAttributes {
+    if (userCookieSettings) { return userCookieSettings }
+    userCookieSettings = {
+        // 365 days expiry, but renewed on activity.
+        expires: 365,
+        // Enforce HTTPS
+        secure: true,
+        // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
+        // However, we do need it on page redirects when users sign up via OAuth, hence using the Lax policy.
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+        sameSite: 'Lax',
+        // Specify the Domain attribute to ensure subdomains (sourcegraph.com) can receive this cookie.
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        domain: window.location.hostname,
+    }
+    return userCookieSettings
+}
+
+export function getSessionCookieSettings(): CookieAttributes {
+    if (sessionCookieSettings) { return sessionCookieSettings }
+    sessionCookieSettings = {
+        // ~30 minutes expiry, but renewed on activity.
+        expires: 0.0208,
+        // Enforce HTTPS
+        secure: true,
+        // We only read the cookie with JS so we don't need to send it cross-site nor on initial page requests.
+        // However, we do need it on page redirects when users sign up via OAuth, hence using the Lax policy.
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Set-Cookie/SameSite
+        sameSite: 'Lax',
+        // Specify the Domain attribute to ensure subdomains (sourcegraph.com) can receive this cookie.
+        // https://developer.mozilla.org/en-US/docs/Web/HTTP/Cookies#define_where_cookies_are_sent
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore
+        domain: window.location.hostname,
+    }
+    return sessionCookieSettings
+}

--- a/src/telemetry/gqlTelemetryExporter.ts
+++ b/src/telemetry/gqlTelemetryExporter.ts
@@ -1,0 +1,40 @@
+import type { TelemetryEventInput, TelemetryExporter } from '@sourcegraph/telemetry'
+
+/**
+ * GraphQLTelemetryExporter exports events via the new Sourcegraph telemetry
+ * framework: https://sourcegraph.com/docs/dev/background-information/telemetry
+ */
+export class GraphQLTelemetryExporter implements TelemetryExporter {
+    private sourcegraphURL: string | undefined
+
+    constructor(
+        sourcegraphURL: string,
+    ) {
+        this.sourcegraphURL = sourcegraphURL
+    }
+
+    public async exportEvents(events: TelemetryEventInput[]): Promise<void> {
+        await fetch(`${this.sourcegraphURL}/.api/graphql?ExportTelemetryEventsFromAbout`, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                Accept: 'application/json',
+            },
+            body: JSON.stringify({
+                query: `
+                    mutation ExportTelemetryEventsFromAbout($events: [TelemetryEventInput!]!) {
+                        telemetry {
+                            recordEvents(events: $events) {
+                                alwaysNil
+                            }
+                        }
+                    }`,
+                variables: { events },
+            }),
+        }).catch(() => {
+            // Swallow errors. This should not be necessary for the Sourcegraph Cloud GraphQL API (that
+            // this file logs to), which should always be up to date, but end users should not be subjected
+            // to error messages.
+        })
+    }
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,69 @@
+import {
+    TelemetryRecorderProvider as BaseTelemetryRecorderProvider,
+    MarketingTrackingTelemetryProcessor,
+    NoOpTelemetryExporter,
+    type MarketingTrackingProvider,
+    type TelemetryEventMarketingTrackingInput,
+} from '@sourcegraph/telemetry'
+
+import { GraphQLTelemetryExporter } from './gqlTelemetryExporter'
+import { getSessionTracker } from './sessionTracker'
+import { getUserTracker } from './userTracker'
+
+function getTelemetrySourceClient(): string {
+    return 'about.web'
+}
+
+/**
+ * TelemetryRecorderProvider is the default provider implementation for the
+ * Sourcegraph web app.
+ */
+export class TelemetryRecorderProvider extends BaseTelemetryRecorderProvider<'', ''> {
+    constructor() {
+        super(
+            {
+                client: getTelemetrySourceClient(),
+            },
+            new GraphQLTelemetryExporter('https://sourcegraph.com'),
+            [new MarketingTrackingTelemetryProcessor(new TrackingMetadataProvider())],
+            {
+                /**
+                 * Use buffer time of 100ms - some existing buffering uses
+                 * 1000ms, but we use a more conservative value.
+                 */
+                bufferTimeMs: 100,
+                bufferMaxSize: 10,
+                errorHandler: error => {
+                    throw new Error(error)
+                },
+            }
+        )
+    }
+}
+
+class TrackingMetadataProvider implements MarketingTrackingProvider {
+    private user = getUserTracker()
+    private session = getSessionTracker()
+
+    public getMarketingTrackingMetadata(): TelemetryEventMarketingTrackingInput | null {
+        return {
+            cohortID: this.user.cohortID,
+            deviceSessionID: this.user.deviceSessionID,
+            firstSourceURL: this.session.getFirstSourceURL(),
+            lastSourceURL: this.session.getLastSourceURL(),
+            referrer: this.session.getReferrer(),
+            sessionFirstURL: this.session.getSessionFirstURL(),
+            sessionReferrer: this.session.getSessionReferrer(),
+            url: window.location.href,
+        }
+    }
+}
+
+export class NoOpTelemetryRecorderProvider extends BaseTelemetryRecorderProvider<'', ''> {
+    constructor() {
+        super({ client: '' }, new NoOpTelemetryExporter(), [])
+    }
+}
+
+export const noOptelemetryRecorderProvider = new NoOpTelemetryRecorderProvider()
+export const noOpTelemetryRecorder = noOptelemetryRecorderProvider.getRecorder()

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -31,6 +31,7 @@ export class TelemetryRecorderProvider extends BaseTelemetryRecorderProvider<'',
                  * Disable buffering for now
                  */
                 bufferTimeMs: 0,
+                bufferMaxSize: 1,
                 errorHandler: error => {
                     throw new Error(error)
                 },

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -28,11 +28,9 @@ export class TelemetryRecorderProvider extends BaseTelemetryRecorderProvider<'',
             [new MarketingTrackingTelemetryProcessor(new TrackingMetadataProvider())],
             {
                 /**
-                 * Use buffer time of 100ms - some existing buffering uses
-                 * 1000ms, but we use a more conservative value.
+                 * Disable buffering for now
                  */
-                bufferTimeMs: 100,
-                bufferMaxSize: 10,
+                bufferTimeMs: 0,
                 errorHandler: error => {
                     throw new Error(error)
                 },

--- a/src/telemetry/sessionTracker.ts
+++ b/src/telemetry/sessionTracker.ts
@@ -1,0 +1,81 @@
+import { type Cookies, defaultCookies } from './cookies'
+
+const FIRST_SOURCE_URL_KEY = 'sourcegraphSourceUrl'
+const LAST_SOURCE_URL_KEY = 'sourcegraphRecentSourceUrl'
+const ORIGINAL_REFERRER_KEY = 'originalReferrer'
+const SESSION_REFERRER_KEY = 'sessionReferrer'
+const SESSION_FIRST_URL_KEY = 'sessionFirstUrl'
+
+/**
+ * Session tracking is only done in Sourcegraph.com and subdomains, where cookie values are set in Google Tag Manager
+ * to ensure consistency across all public Sourcegraph-managed properties (e.g. marketing sites, blog, etc.)
+ *
+ * Prefer the global sessionTracker instance.
+ */
+export class SessionTracker {
+    private originalReferrer: string
+    private sessionReferrer: string
+    private sessionFirstURL: string
+    private firstSourceURL: string
+    private lastSourceURL: string
+
+    constructor(private cookies: Cookies = defaultCookies()) {
+        this.originalReferrer = this.getOriginalReferrer()
+        this.sessionReferrer = this.getSessionReferrer()
+        this.sessionFirstURL = this.getSessionFirstURL()
+        this.firstSourceURL = this.getFirstSourceURL()
+        this.lastSourceURL = this.getLastSourceURL()
+    }
+
+    public getOriginalReferrer(): string {
+        // This cookie is set in Google Tag manager.
+        this.originalReferrer = this.originalReferrer || this.cookies.get(ORIGINAL_REFERRER_KEY) || document.referrer
+
+        return this.originalReferrer
+    }
+
+    public getSessionReferrer(): string {
+        // This cookie is set in Google Tag manager.
+        this.sessionReferrer = this.sessionReferrer || this.cookies.get(SESSION_REFERRER_KEY) || document.referrer
+
+        return this.sessionReferrer
+    }
+
+    public getSessionFirstURL(): string {
+        // This cookie is set in Google Tag manager.
+        this.sessionFirstURL = this.sessionFirstURL || this.cookies.get(SESSION_FIRST_URL_KEY) || location.href
+
+        return this.sessionFirstURL
+    }
+
+    public getFirstSourceURL(): string {
+        // This cookie is set in Google Tag manager.
+        this.firstSourceURL = this.firstSourceURL || this.cookies.get(FIRST_SOURCE_URL_KEY) || location.href
+
+        return this.firstSourceURL
+    }
+
+    public getLastSourceURL(): string {
+        // This cookie is set in Google Tag manager.
+        this.lastSourceURL = this.lastSourceURL || this.cookies.get(LAST_SOURCE_URL_KEY) || location.href
+
+        return this.lastSourceURL
+    }
+
+    public getReferrer(): string {
+        return document.referrer
+    }
+}
+
+let sessionTracker: SessionTracker
+
+/**
+ * Configures and loads cookie properties for session tracking purposes.
+ */
+export function getSessionTracker(): SessionTracker {
+    if (sessionTracker) {
+        return sessionTracker
+    }
+    sessionTracker = new SessionTracker()
+    return sessionTracker
+}

--- a/src/telemetry/userTracker.ts
+++ b/src/telemetry/userTracker.ts
@@ -1,0 +1,109 @@
+import { formatISO, startOfWeek } from 'date-fns'
+import { v4 as uuidv4 } from 'uuid'
+
+import { type Cookies, defaultCookies, getUserCookieSettings, getSessionCookieSettings } from './cookies'
+
+const ANONYMOUS_USER_ID_KEY = 'sourcegraphAnonymousUid'
+const COHORT_ID_KEY = 'sourcegraphCohortId'
+const DEVICE_ID_KEY = 'sourcegraphDeviceId'
+const DEVICE_SESSION_ID_KEY = 'sourcegraphSessionId'
+
+/**
+ * Configures and loads cookie properties for user tracking purposes.
+ *
+ * All values are configured and initialized once on the constructor, as values
+ * are unlikely to change.
+ *
+ * Prefer the global userTracker instance.
+ */
+export class UserTracker {
+    /**
+     * The anonymous identifier for this user (used to allow site admins
+     * on a Sourcegraph instance to see a count of unique users on a daily,
+     * weekly, and monthly basis).
+     */
+    public readonly anonymousUserID: string
+    /**
+     * The cohort ID is generated when the anonymous user ID is generated.
+     * Users that have visited before the introduction of cohort IDs will not have one.
+     */
+    public readonly cohortID: string | undefined
+    /**
+     * Device ID is a require field for Amplitude events:  https://developers.amplitude.com/docs/http-api-v2
+     */
+    public readonly deviceID: string
+    /**
+     * Device session ID seems to be the same thing as anonymousUserID for the
+     * most part.
+     */
+    public readonly deviceSessionID: string
+
+    constructor(cookies: Cookies = defaultCookies()) {
+        /**
+         * Gets the anonymous user ID and cohort ID of the user from cookies.
+         * If user doesn't have an anonymous user ID yet, a new one is generated, along with
+         * a cohort ID of the week the user first visited.
+         *
+         * If the user already has an anonymous user ID before the introduction of cohort IDs,
+         * the user will not haved a cohort ID.
+         *
+         * If user had an anonymous user ID in localStorage, it will be migrated to cookies.
+         */
+        let anonymousUserID = cookies.get(ANONYMOUS_USER_ID_KEY) || localStorage.getItem(ANONYMOUS_USER_ID_KEY)
+        let cohortID = cookies.get(COHORT_ID_KEY)
+        if (!anonymousUserID) {
+            anonymousUserID = uuidv4()
+            cohortID = getPreviousMonday(new Date())
+        }
+
+        // Use cookies instead of localStorage so that the ID can be shared with subdomains (sourcegraph.com).
+        // Always set to renew expiry and migrate from localStorage
+        cookies.set(ANONYMOUS_USER_ID_KEY, anonymousUserID, getUserCookieSettings())
+        localStorage.removeItem(ANONYMOUS_USER_ID_KEY)
+
+        if (cohortID) {
+            cookies.set(COHORT_ID_KEY, cohortID, getUserCookieSettings())
+        }
+
+        let deviceID = cookies.get(DEVICE_ID_KEY)
+        if (!deviceID || deviceID === '') {
+            // If device ID does not exist, use the anonymous user ID value so these are consolidated.
+            deviceID = anonymousUserID
+        }
+        cookies.set(DEVICE_ID_KEY, deviceID, getUserCookieSettings())
+
+        let deviceSessionID = cookies.get(DEVICE_SESSION_ID_KEY)
+        if (!deviceSessionID || deviceSessionID === '') {
+            // If device ID does not exist, use the anonymous user ID value so these are consolidated.
+            deviceSessionID = anonymousUserID
+        }
+        cookies.set(DEVICE_SESSION_ID_KEY, deviceSessionID, getSessionCookieSettings)
+
+        this.anonymousUserID = anonymousUserID
+        this.cohortID = cohortID
+        this.deviceID = deviceID
+        this.deviceSessionID = deviceSessionID
+    }
+}
+
+/**
+ * Returns the Monday at or before the supplied date, in YYYY-MM-DD format.
+ * This is used to generate cohort IDs for users who
+ * started using the site on the same week.
+ */
+export function getPreviousMonday(date: Date): string {
+    return formatISO(startOfWeek(date, { weekStartsOn: 1 }), { representation: 'date' })
+}
+
+let userTracker: UserTracker
+
+/**
+ * Configures and loads cookie properties for user tracking purposes.
+ */
+export function getUserTracker(): UserTracker {
+    if (userTracker) {
+        return userTracker
+    }
+    userTracker = new UserTracker()
+    return userTracker
+}


### PR DESCRIPTION
Thanks for the guidance on this @bobheadxi at https://sourcegraph.slack.com/archives/C05BGNBEPKL/p1716573233789729

This PR adds a new frontend telemetry service at `src/telemetry/gqlTelemetryExporter.ts` and `src/telemetry/index.ts`. It also duplicates the existing user and session trackers and cookie helpers, adapted to the new service. It also adds a single hook that records telemetry events on every pageview (again, duplicating what the old v1 telemetry was doing). 

Instead of building a pre-rolled `TelemetryExporter` _or_ `TelemetryRecorderProvider`, I decided to just do this all in place to start and to determine, based on the level of overlap I see with other marketing-owned subdomains, whether to eventually pull all of that out into a separate package. I suspect I ultimately will.

I will go through the process of updating all event logging/recording sites to use v2 telemetry once this is merged.