### PR TITLE
Update VS Coded 1.20 blog about OpenCtx

### DIFF
--- a/content/blogposts/2024/cody-vscode-1-20-0-release.md
+++ b/content/blogposts/2024/cody-vscode-1-20-0-release.md
@@ -97,7 +97,7 @@ Today, we’re releasing experimental functionality to use OpenCtx context provi
 * [Google docs](https://openctx.org/docs/providers/google-docs)
 * [Sourcegraph code search](https://openctx.org/docs/providers/sourcegraph-search)
 
-To try it out, add context providers to your VS Code settings. For examples, to utilize the [DevDocs provider](https://openctx.org/docs/providers/devdocs), add the following to your `settings.json`:
+To try it out, add context providers to your VS Code settings. For example, to use the [DevDocs provider](https://openctx.org/docs/providers/devdocs), add the following to your `settings.json`:
 
 ```javascript
 "openctx.providers": {

--- a/content/blogposts/2024/cody-vscode-1-20-0-release.md
+++ b/content/blogposts/2024/cody-vscode-1-20-0-release.md
@@ -97,7 +97,7 @@ Today, we’re releasing experimental functionality to use OpenCtx context provi
 * [Google docs](https://openctx.org/docs/providers/google-docs)
 * [Sourcegraph code search](https://openctx.org/docs/providers/sourcegraph-search)
 
-To begin, please ensure that you uninstall OpenCtx from VS Code extensions. Then, configure your context providers in settings. For instance, to utilize the [DevDocs provider](https://openctx.org/docs/providers/devdocs), add the following to your `settings.json`:
+To try it out, add context providers to your VS Code settings. For examples, to utilize the [DevDocs provider](https://openctx.org/docs/providers/devdocs), add the following to your `settings.json`:
 
 ```javascript
 "openctx.providers": {
@@ -110,6 +110,8 @@ To begin, please ensure that you uninstall OpenCtx from VS Code extensions. Then
 <Badge text="EXPERIMENTAL" color="vermillion" size="large" />
 
 Note that this is early and experimental functionality. If you have any OpenCtx feedback or questions, please [visit our support forum](https://community.sourcegraph.com/c/openctx/10).
+
+This functionality is also _not_ dependent on the separate OpenCtx VS Code extension, which adds inline context from providers to your code. We recommend uninstalling the dedicated OpenCtx extension before trying this feature in Cody.
 
 <Video
   source={{

--- a/content/blogposts/2024/cody-vscode-1-20-0-release.md
+++ b/content/blogposts/2024/cody-vscode-1-20-0-release.md
@@ -111,7 +111,7 @@ To try it out, add context providers to your VS Code settings. For examples, to 
 
 Note that this is early and experimental functionality. If you have any OpenCtx feedback or questions, please [visit our support forum](https://community.sourcegraph.com/c/openctx/10).
 
-This functionality is also _not_ dependent on the separate OpenCtx VS Code extension, which adds inline context from providers to your code. We recommend uninstalling the dedicated OpenCtx extension before trying this feature in Cody.
+This functionality is also _not_ dependent on the separate OpenCtx VS Code extension, which adds inline context from providers to your code. We recommend uninstalling the OpenCtx extension before trying this feature in Cody.
 
 <Video
   source={{


### PR DESCRIPTION
Clarifies that you don't need the OpenCtx extension to use the feature in Cody.