### PR TITLE
fixing papercuts on homepage and menu

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -238,8 +238,8 @@ const HeaderContent: FunctionComponent<
         <>
             <div
                 className={classNames(
-                    'transition bg-gray-50',
-                    (sticky || open) && HEADER_CONTENT_THEME_CLASS[colorTheme].container
+                    'transition',
+                    HEADER_CONTENT_THEME_CLASS[colorTheme].container
                 )}
             >
                 <div className="mx-auto max-w-7xl px-2 md:px-6 xl:px-0">

--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -238,7 +238,7 @@ const HeaderContent: FunctionComponent<
         <>
             <div
                 className={classNames(
-                    'transition',
+                    'transition bg-gray-50',
                     (sticky || open) && HEADER_CONTENT_THEME_CLASS[colorTheme].container
                 )}
             >

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -105,7 +105,7 @@ const Home: FunctionComponent = () => {
                     <div className="relative mx-6 mb-8 flex h-auto gap-[19px] overflow-hidden rounded-2xl border-1 border-gray-200 bg-white md:mx-0 md:max-h-[500px] lg:h-[329px]">
                         <div className="text-pretty flex w-full flex-col py-16 pl-10">
                             <img
-                                className="h-[48px] w-[48px]"
+                                className="h-[40px] w-[40px]"
                                 src="/home/branded-icons/completions-brand-icon.svg"
                                 alt="Completions Brand Icon"
                             />
@@ -151,7 +151,7 @@ const Home: FunctionComponent = () => {
                         </div>
                         <div className="flex flex-col rounded-2xl border-1 border-gray-200 bg-white px-10 py-16">
                             <img
-                                className="h-[48px] w-[48px]"
+                                className="h-[40px] w-[40px]"
                                 src="/home/branded-icons/commands-brand-icon.svg"
                                 alt="Completions Brand Icon"
                             />
@@ -263,9 +263,9 @@ const Home: FunctionComponent = () => {
                         {isDesktop && <img src="/home/code-graph-home.svg" alt="Multiline Completion" />}
                     </div>
                     <div className="mx-6 mb-8 flex flex-col gap-8 md:mx-0 md:flex-row md:gap-6">
-                        <div className="flex w-full flex-col rounded-2xl border-1 border-gray-200 bg-white px-10 py-16 md:w-[566px]">
+                        <div className="flex w-full flex-col rounded-2xl border-1 border-gray-200 bg-white px-10 py-16">
                             <img
-                                className="h-[48px] w-[48px]"
+                                className="h-[40px] w-[40px]"
                                 src="/home/branded-icons/Code-insights-icon.svg"
                                 alt="Completions Brand Icon"
                             />
@@ -276,7 +276,7 @@ const Home: FunctionComponent = () => {
                         </div>
                         <div className="flex w-full flex-col rounded-2xl border-1 border-gray-200 bg-white px-10 py-16">
                             <img
-                                className="h-[48px] w-[48px]"
+                                className="h-[40px] w-[40px]"
                                 src="/home/branded-icons/batch-changes-icon.svg"
                                 alt="Completions Brand Icon"
                             />
@@ -383,7 +383,7 @@ const HomeHero: FunctionComponent<HomeHeroProps> = ({ onOpenModal }) => {
         >
             <div className="mx-auto flex flex-col items-center justify-center px-3 text-center md:px-0">
                 <div className="mx-auto flex max-w-[456px] flex-col items-center pb-8 pt-8 sm:max-w-full md:w-[680px] md:pb-[26px] md:pt-10">
-                    <h1 className="mb-8 w-full text-center text-5xl text-gray-100 sm:text-6xl">
+                    <h1 className="mb-8 mt-10 w-full text-center text-5xl text-gray-100 sm:text-6xl">
                         Understand and write code blazingly fast
                     </h1>
                     <p className="mb-10 text-2xl font-normal leading-[30px] -tracking-[0.25px] text-white opacity-60 md:mb-8">

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -378,7 +378,7 @@ const HomeHero: FunctionComponent<HomeHeroProps> = ({ onOpenModal }) => {
 
     return (
         <ContentSection
-            className="relative mt-[-82px] flex items-center justify-center rounded-2xl bg-violet-700 md:mt-[-53px]"
+            className="relative mt-[-72px] flex items-center justify-center rounded-2xl bg-violet-700 md:mt-[-43px]"
             parentClassName="!py-0 !pb-16 !bg-gray-50"
         >
             <div className="mx-auto flex flex-col items-center justify-center px-3 text-center md:px-0">


### PR DESCRIPTION
- Adding a little more padding above the H1
- Adjust size of icons so they're less chongo 
- Fixed wonky width on bentos in Code Search section
- Fixing flickering of the navmenu on scroll 