### PR TITLE
blog styles + larger typography

### DIFF
--- a/src/components/Blog/BlogHeader.tsx
+++ b/src/components/Blog/BlogHeader.tsx
@@ -29,9 +29,9 @@ export const BlogHeader: FunctionComponent<Props> = ({ title, belowTitle, baseUr
         <nav className={classNames(className, 'my-6')}>
             <Link
                 href={baseUrl}
-                className="!font-grotesk inline-flex items-center bg-violet-100 py-1 pl-2 pr-3 text-violet-600  hover:underline"
+                className="!font-grotesk group inline-flex items-center text-sm text-gray-300 hover:text-gray-600"
             >
-                <ArrowLeftIcon className="inline h-5" /> {title}
+                <ArrowLeftIcon className="inline h-3 transition-transform group-hover:-translate-x-1" /> {title}
             </Link>
         </nav>
     )

--- a/src/components/Blog/BylineAndDate.tsx
+++ b/src/components/Blog/BylineAndDate.tsx
@@ -11,9 +11,9 @@ export const BylineAndDate: React.FunctionComponent<{
         {authors?.length && (
             <span className="mr-1">
                 {authors.map((a, index) => (
-                    <span key={a.name} className="font-semibold text-gray-600">
+                    <span key={a.name} className="font-semibold text-gray-500">
                         {a.url ? (
-                            <Link href={a.url} className="font-semibold text-gray-600">
+                            <Link href={a.url} className="font-semibold text-gray-500">
                                 {a.name}
                             </Link>
                         ) : (
@@ -24,6 +24,7 @@ export const BylineAndDate: React.FunctionComponent<{
                 ))}
             </span>
         )}
+
         {publishDate && <PublishDate date={publishDate} />}
     </p>
 )

--- a/src/components/Blog/PostLayout.module.css
+++ b/src/components/Blog/PostLayout.module.css
@@ -1,8 +1,8 @@
 .content img,
-			.content object,
-			/* Gif-like videos */
-			.content video[autoplay][loop][muted]:not([controls]) {
-    width: 100%;
+.content object,
+/* Gif-like videos */
+.content video[autoplay][loop][muted]:not([controls]) {
+    /* width: 100%; */
     /* margin: 3rem auto 2rem auto; */
     display: block;
     border-style: none;
@@ -74,7 +74,7 @@
 
 .content ul,
 .content ol {
-    line-height: 1.8;
+    line-height: 1.6;
     padding-left: 0;
 }
 .content li {

--- a/src/components/Blog/PostLayout.tsx
+++ b/src/components/Blog/PostLayout.tsx
@@ -26,12 +26,12 @@ export const PostLayout: FunctionComponent<PostComponentProps> = ({
     contentClassName = '',
 }) => (
     <Tag className={className}>
-        <div className="mt-12">
-            <h2 className="!font-display">{frontmatter.title}</h2>
+        <div>
+            <h2 className="!font-display text-4xl xl:text-6xl">{frontmatter.title}</h2>
         </div>
 
         {(frontmatter.authors?.length || frontmatter.publishDate) && (
-            <div className="mt-4">
+            <div className="mt-3">
                 <BylineAndDate authors={frontmatter.authors} publishDate={frontmatter.publishDate} />
             </div>
         )}
@@ -39,11 +39,14 @@ export const PostLayout: FunctionComponent<PostComponentProps> = ({
         {content && (
             <div
                 className={classNames(
-                    'mt-12',
+                    'mt-8',
                     'min-h-[60vh]',
                     styles.content,
                     contentClassName,
                     'prose',
+                    'xl:prose-lg',
+                    'leading-relaxed',
+                    'xl:leading-relaxed',
                     'prose-headings:font-semibold',
                     'prose-headings:mb-2.5',
                     'prose-a:text-violet-500',

--- a/src/pages/blog/[...slug].tsx
+++ b/src/pages/blog/[...slug].tsx
@@ -47,7 +47,7 @@ const BlogPage: NextPage<PageProps> = ({ post, content }) => {
                 <BlogHeader {...blogInfo} title="Back to Blog" variant="post" />
             </header>
 
-            <div className="mx-auto flex max-w-7xl flex-col gap-x-20 px-8 lg:flex-row lg:px-10 2xl:px-0">
+            <div className="mx-auto flex max-w-7xl flex-col gap-x-14 px-8 lg:flex-row lg:px-10 2xl:px-0">
                 <article className="flex-1">
                     <PostTemplate post={post} content={content} />
                 </article>

--- a/src/pages/blog/[...slug].tsx
+++ b/src/pages/blog/[...slug].tsx
@@ -43,22 +43,27 @@ const BlogPage: NextPage<PageProps> = ({ post, content }) => {
 
     return (
         <Layout meta={meta}>
-            <div className="mx-auto mt-10 mb-12 flex max-w-screen-xl flex-col gap-x-5 px-8 lg:flex-row lg:px-10 2xl:px-0">
+            <header className="mx-auto max-w-7xl px-8 lg:px-10 2xl:px-0">
+                <BlogHeader {...blogInfo} title="Back to Blog" variant="post" />
+            </header>
+
+            <div className="mx-auto flex max-w-7xl flex-col gap-x-20 px-8 lg:flex-row lg:px-10 2xl:px-0">
                 <article className="flex-1">
-                    <BlogHeader {...blogInfo} variant="post" />
                     <PostTemplate post={post} content={content} />
                 </article>
-                <aside className="hidden md:block md:w-[350px]">
+
+                <aside className="mt-36 hidden md:block md:w-[350px]">
                     <div className="sticky top-36">
                         <div
                             className={classNames(
                                 styles.blogForm,
-                                'flex flex-col items-start rounded-2xl bg-gray-100 p-6'
+                                'flex flex-col items-start rounded-xl border border-gray-200 p-6'
                             )}
                         >
-                            <h1 className="text-blog-h3 mb-4 normal-case">
+                            <h3 className="mb-4 text-xl normal-case">
                                 Subscribe for the latest code AI news and product updates
-                            </h1>
+                            </h3>
+
                             <HubSpotForm
                                 formId="ab908b80-d1ed-44fd-968c-505c85ed72ac"
                                 inlineMessage="Thanks, you are now subscribed!"


### PR DESCRIPTION
Updating the blog styles to increase the font for header and text.

- increase text font from 16px to 18px on larger screens
- increase header font to 30px to 48px

BEFORE:
![CleanShot 2024-08-07 at 14 51 06@2x](https://github.com/user-attachments/assets/1221a739-363b-460f-becf-bb47c1c1ca0c)

AFTER:
![CleanShot 2024-08-07 at 14 51 15@2x](https://github.com/user-attachments/assets/ba29ebe9-3514-4747-9cb8-3cc574a62909)
