### PR TITLE
update banner to not show on mobile

### DIFF
--- a/src/components/Layout/Header/Header.tsx
+++ b/src/components/Layout/Header/Header.tsx
@@ -35,6 +35,8 @@ export const Header: FunctionComponent<Props> = ({ minimal, colorTheme, navRef }
      * useState(true) for on, useState(false) for off.
      */
     const [showBanner, setShowBanner] = useState(true)
+    const windowWidth = useWindowWidth()
+    const isMobile = windowWidth < breakpoints.md
 
     const source = pathname.slice(1) || 'about-home'
 
@@ -86,7 +88,7 @@ export const Header: FunctionComponent<Props> = ({ minimal, colorTheme, navRef }
         <Disclosure as="nav" className={classNames('fixed top-0 left-0 right-0 z-[1030]')} ref={navRef}>
             {({ open, close }) => (
                 <>
-                    {showBanner && <Banner />}
+                    {showBanner && !isMobile && <Banner />}
                     <HeaderContent
                         colorTheme={colorTheme}
                         minimal={minimal}


### PR DESCRIPTION
Updates the banner element to only show on wider viewports.

It was covering content on mobile view, causing a broken-looking page. This fixes that for now