### PR TITLE
Change "Get" CTA copy to "Download"

### DIFF
--- a/src/components/cody/dual-theme/CodyIntroDualTheme.tsx
+++ b/src/components/cody/dual-theme/CodyIntroDualTheme.tsx
@@ -60,7 +60,7 @@ export const CodyIntroDualTheme: FunctionComponent<CodyIntroDualThemeProps> = ({
                     onClick={() => handleOpenModal('top')}
                 >
                     <div className="flex items-center justify-center">
-                        <img src="/cody/cody-logo.svg" className="mr-2 h-[15px] w-[15px]" alt="Cody Logo" /> Get Cody
+                        <img src="/cody/cody-logo.svg" className="mr-2 h-[15px] w-[15px]" alt="Cody Logo" /> Download Cody
                         for your IDE
                     </div>
                 </button>

--- a/src/components/cta/CodyCta.tsx
+++ b/src/components/cta/CodyCta.tsx
@@ -63,8 +63,8 @@ export const CodyCta: FunctionComponent<CodyCtaProps> = ({
         >
             {isLight ? (
                 <>
-                    <span className="hidden md:block">Get Cody for free</span>
-                    <span className="block md:hidden">Get Cody free</span>
+                    <span className="hidden md:block">Download Cody for free</span>
+                    <span className="block md:hidden">Download Cody free</span>
                 </>
             ) : (
                 <span>{isVariantStyle ? 'Start free' : 'Get Cody for free'}</span>

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -305,7 +305,7 @@ const Home: FunctionComponent = () => {
                                         title="free cody"
                                         onClick={() => handleOpenModal('bottom')}
                                     >
-                                        Get Cody for free
+                                        Download Cody for free
                                     </button>
                                 </div>
                             </div>


### PR DESCRIPTION
Changes Cody page and bottom-of-page standard CTAs to use "Download" instead of "Get" copy