### PR TITLE
Redirect /get-started to /enterprise-trial-offer

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -183,6 +183,10 @@
   to = "/contact/request-info"
 
 [[redirects]]
+  from = "/get-started"
+  to = "/enterprise-trial-offer"
+
+[[redirects]]
   from = "/contact/product-specialist"
   to = "/contact/request-info"
 


### PR DESCRIPTION
Redirects /get-started (outdated trial page) to /enterprise-trial-offer

Before you merge this PR, please review the following:

## Blog post
- [ ] Checked title case (This is correct. This Is Not Correct)
- [ ] Updated publishDate
- [ ] Updated authors
- [ ] Updated and checked slug
- [ ] Proofread for spelling and grammar errors
- [ ] Checked for consistent tone and voice throughout via Grammarly
- [ ] Ensured all links are working correctly
- [ ] Added relevant tags and categories
- [ ] Optimized meta description
- [ ] Included a new hero and social/OG image
- [ ] Uploaded images to Google Storage
- [ ] Formatted text for readability (headings, bullet points, etc.)
- [ ] Added image alt text
- [ ] Ran [Markdown linter](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)

## Other

- [ ] This is not a blog post