### PR TITLE
Remove Double CTA on homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -1,6 +1,5 @@
 import { FunctionComponent, ReactSVG, useState, useEffect } from 'react'
 
-import classNames from 'classnames'
 import ChevronRightIcon from 'mdi-react/ChevronRightIcon'
 import Link from 'next/link'
 import { posthog } from 'posthog-js'
@@ -353,57 +352,6 @@ const Home: FunctionComponent = () => {
 
                 {/* call to actions ------------------------------------------------------- */}
                 {/* ------------------------------------------------------------------------------- */}
-                <div className="mx-auto mt-10 max-w-6xl">
-                    <div className="mx-6 grid grid-cols-1 gap-6 py-16 md:mx-0 md:grid-cols-2 md:py-24">
-                        <div className="hover:cta-free-cody relative overflow-hidden rounded-2xl border-1 border-gray-200 bg-white">
-                            <div className="cta-top-border absolute left-0 right-0 top-0 rounded-t-2xl" />
-                            <div className=" px-14 py-16">
-                                <h2 className="mb-4 text-gray-700">Get started with Cody</h2>
-                                <p className="mb-0 text-lg text-gray-500">
-                                    Use Cody for free in your IDE, no credit card required.
-                                </p>
-                                <div className="mt-6 flex flex-wrap gap-2">
-                                    <button
-                                        type="button"
-                                        className={classNames('btn btn-primary w-full md:w-auto')}
-                                        title="free cody"
-                                        onClick={() => handleOpenModal('bottom')}
-                                    >
-                                        Download Cody for free
-                                    </button>
-                                </div>
-                            </div>
-                        </div>
-
-                        <div className="cta-home rounded-2xl px-14 py-16 text-white">
-                            <h2 className="mb-[10px]">Cody Enterprise</h2>
-                            <p className="mb-0 text-lg text-[#FFFFFFCC]">
-                                Cody Enterprise provides additional security, scalability, and control for your
-                                organization. Unlimited usage and context search for your entire codebase.
-                            </p>
-                            <div className="mt-8 flex flex-col items-center gap-4 md:flex-row">
-                                <Link
-                                    href="/contact/request-info"
-                                    title="Get Cody for Enterprise"
-                                    className="btn btn-secondary-dark w-full px-6 py-2 text-center md:w-auto"
-                                    onClick={() =>
-                                        captureCustomEventWithPageData('contact_sales_onpage_click', 'bottom')
-                                    }
-                                >
-                                    Book a demo
-                                </Link>
-                                <Link
-                                    href="/pricing"
-                                    title="See pricing"
-                                    className="btn btn-link-dark md:btn-link-icon w-full rounded-[5px] px-6 text-center md:w-auto"
-                                >
-                                    See pricing
-                                    <ChevronRightIcon className="link-icon hidden md:block" />
-                                </Link>
-                            </div>
-                        </div>
-                    </div>
-                </div>
             </div>
         </Layout>
     )

--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -352,6 +352,59 @@ const Home: FunctionComponent = () => {
 
                 {/* call to actions ------------------------------------------------------- */}
                 {/* ------------------------------------------------------------------------------- */}
+                {/* Remove Duplicate CTA, see HomepageCTA on line 329
+                <div className="mx-auto mt-10 max-w-6xl">
+                    <div className="mx-6 grid grid-cols-1 gap-6 py-16 md:mx-0 md:grid-cols-2 md:py-24">
+                        <div className="hover:cta-free-cody relative overflow-hidden rounded-2xl border-1 border-gray-200 bg-white">
+                            <div className="cta-top-border absolute left-0 right-0 top-0 rounded-t-2xl" />
+                            <div className=" px-14 py-16">
+                                <h2 className="mb-4 text-gray-700">Get started with Cody</h2>
+                                <p className="mb-0 text-lg text-gray-500">
+                                    Use Cody for free in your IDE, no credit card required.
+                                </p>
+                                <div className="mt-6 flex flex-wrap gap-2">
+                                    <button
+                                        type="button"
+                                        className={classNames('btn btn-primary w-full md:w-auto')}
+                                        title="free cody"
+                                        onClick={() => handleOpenModal('bottom')}
+                                    >
+                                        Download Cody for free
+                                    </button>
+                                </div>
+                            </div>
+                        </div>
+
+                        <div className="cta-home rounded-2xl px-14 py-16 text-white">
+                            <h2 className="mb-[10px]">Cody Enterprise</h2>
+                            <p className="mb-0 text-lg text-[#FFFFFFCC]">
+                                Cody Enterprise provides additional security, scalability, and control for your
+                                organization. Unlimited usage and context search for your entire codebase.
+                            </p>
+                            <div className="mt-8 flex flex-col items-center gap-4 md:flex-row">
+                                <Link
+                                    href="/contact/request-info"
+                                    title="Get Cody for Enterprise"
+                                    className="btn btn-secondary-dark w-full px-6 py-2 text-center md:w-auto"
+                                    onClick={() =>
+                                        captureCustomEventWithPageData('contact_sales_onpage_click', 'bottom')
+                                    }
+                                >
+                                    Book a demo
+                                </Link>
+                                <Link
+                                    href="/pricing"
+                                    title="See pricing"
+                                    className="btn btn-link-dark md:btn-link-icon w-full rounded-[5px] px-6 text-center md:w-auto"
+                                >
+                                    See pricing
+                                    <ChevronRightIcon className="link-icon hidden md:block" />
+                                </Link>
+                            </div>
+                        </div>
+                    </div>
+                </div>
+                */}
             </div>
         </Layout>
     )


### PR DESCRIPTION
Before you merge this PR, please review the following:

## Blog post
- [ ] Checked title case (This is correct. This Is Not Correct)
- [ ] Updated publishDate
- [ ] Updated authors
- [ ] Updated and checked slug
- [ ] Proofread for spelling and grammar errors
- [ ] Checked for consistent tone and voice throughout via Grammarly
- [ ] Ensured all links are working correctly
- [ ] Added relevant tags and categories
- [ ] Optimized meta description
- [ ] Included a new hero and social/OG image
- [ ] Uploaded images to Google Storage
- [ ] Formatted text for readability (headings, bullet points, etc.)
- [ ] Added image alt text
- [ ] Ran [Markdown linter](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)

## Other

- [ ] This is not a blog post