### PR TITLE
removing stripe

### DIFF
--- a/src/components/cody/CodyPartners.tsx
+++ b/src/components/cody/CodyPartners.tsx
@@ -104,10 +104,10 @@ const lightThemeIcons = [
         src: '/assets/icons/dropbox-logo.svg',
         className: 'h-[48px] w-[163px] order-4 md:order-4 mx-6',
     },
-    {
-        src: '/assets/icons/stripe-violet.svg',
-        className: 'w-[85px] order-4 md:order-4 mx-6',
-    },
+    // {
+    //     src: '/assets/icons/stripe-violet.svg',
+    //     className: 'w-[85px] order-4 md:order-4 mx-6',
+    // },
     {
         src: '/home/carousel/palo-alto-logo.svg',
         className: 'h-[48px] w-[166px] order-5 md:order-5 mx-6',


### PR DESCRIPTION
remove stripe from the /cody page

stripe still exists on the home page

we have also removed stripe from the following pages since this component is also used on those pages:

- /cody
- /code-insights
- /code-search
- /demo/cody-enterprise
- /demo/cody-enterprise
- /guides/code-ai-buyers-guide
- /solutions/build-unit-tests
- /solutions/gitlab
- /whitepapers/code-ai-buyers-guide