### PR TITLE
fix: remove invalid link to repo

### DIFF
--- a/content/blogposts/2020/going-beyond-regular-expressions-with-structural-code-search.md
+++ b/content/blogposts/2020/going-beyond-regular-expressions-with-structural-code-search.md
@@ -304,4 +304,3 @@ For a complete overview, refer to [comby.dev](https://comby.dev).
 ## Feedback
 
 - Have a usage question or suggestion about structural search? [Send us a tweet](https://twitter.com/sourcegraph) or e-mail us at feedback@sourcegraph.com
-- Run into a bug? [Create an issue on GitHub](https://github.com/sourcegraph/sourcegraph/issues/new?assignees=&labels=&template=bug_report.md&title=)


### PR DESCRIPTION
Just removing some text that points to our (not public anymore) repo.

---

Before you merge this PR, please review the following:

## Blog post
- [ ] Checked title case (This is correct. This Is Not Correct)
- [ ] Updated publishDate
- [ ] Updated authors
- [ ] Updated and checked slug
- [ ] Proofread for spelling and grammar errors
- [ ] Checked for consistent tone and voice throughout via Grammarly
- [ ] Ensured all links are working correctly
- [ ] Added relevant tags and categories
- [ ] Optimized meta description
- [ ] Included a new hero and social/OG image
- [ ] Uploaded images to Google Storage
- [ ] Formatted text for readability (headings, bullet points, etc.)
- [ ] Added image alt text
- [ ] Ran [Markdown linter](https://marketplace.visualstudio.com/items?itemName=DavidAnson.vscode-markdownlint)

## Other

- [x] This is not a blog post